### PR TITLE
refactor(scroll-shadow): add LinearGradientComponent prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ npm install heroui-native
 ### 2. Install Mandatory Peer Dependencies
 
 ```bash
-npm install react-native-reanimated@~3.17.4 react-native-safe-area-context@5.4.0 react-native-svg@^15.12.1 tailwind-variants@^3.1.0 tailwind-merge@^3.3.1 expo-linear-gradient@^14.1.5
+npm install react-native-reanimated@~3.17.4 react-native-safe-area-context@5.4.0 react-native-svg@^15.12.1 tailwind-variants@^3.1.0 tailwind-merge@^3.3.1
 ```
 
 > **Important:** It's recommended to use the exact versions specified above to avoid compatibility issues. Version mismatches may cause unexpected bugs.

--- a/example/src/app/(home)/components/scroll-shadow.tsx
+++ b/example/src/app/(home)/components/scroll-shadow.tsx
@@ -1,4 +1,5 @@
 import { useHeaderHeight } from '@react-navigation/elements';
+import { LinearGradient } from 'expo-linear-gradient';
 import { ScrollShadow, Surface } from 'heroui-native';
 import { FlatList, Platform, ScrollView, Text, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -25,7 +26,7 @@ export default function ScrollShadowScreen() {
       }}
     >
       <SectionTitle title="Horizontal" />
-      <ScrollShadow>
+      <ScrollShadow LinearGradientComponent={LinearGradient}>
         <FlatList
           data={HORIZONTAL_ITEMS}
           horizontal
@@ -36,7 +37,11 @@ export default function ScrollShadowScreen() {
         />
       </ScrollShadow>
       <SectionTitle title="Vertical" />
-      <ScrollShadow size={100} className="flex-1">
+      <ScrollShadow
+        size={100}
+        className="flex-1"
+        LinearGradientComponent={LinearGradient}
+      >
         <ScrollView
           contentContainerClassName="px-5 py-8"
           showsVerticalScrollIndicator={false}

--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "eslint": "^9.22.0",
     "eslint-config-prettier": "^10.1.1",
     "eslint-plugin-prettier": "^5.2.3",
-    "expo-linear-gradient": "^14.1.5",
     "jest": "^29.7.0",
     "nativewind": "^4.1.23",
     "prettier": "^3.0.3",
@@ -107,7 +106,6 @@
     "typescript": "^5.8.3"
   },
   "peerDependencies": {
-    "expo-linear-gradient": "^14.1.5",
     "nativewind": "^4.1.23",
     "react": "*",
     "react-native": "*",

--- a/src/components/scroll-shadow/scroll-shadow.md
+++ b/src/components/scroll-shadow/scroll-shadow.md
@@ -17,7 +17,7 @@ import { ScrollShadow } from 'heroui-native';
 Wrap any scrollable component to automatically add edge shadows.
 
 ```tsx
-<ScrollShadow>
+<ScrollShadow LinearGradientComponent={LinearGradient}>
   <ScrollView>...</ScrollView>
 </ScrollShadow>
 ```
@@ -27,7 +27,7 @@ Wrap any scrollable component to automatically add edge shadows.
 The component auto-detects horizontal scrolling from the child's `horizontal` prop.
 
 ```tsx
-<ScrollShadow>
+<ScrollShadow LinearGradientComponent={LinearGradient}>
   <FlatList horizontal data={data} renderItem={...} />
 </ScrollShadow>
 ```
@@ -37,7 +37,7 @@ The component auto-detects horizontal scrolling from the child's `horizontal` pr
 Control the gradient shadow height/width with the `size` prop.
 
 ```tsx
-<ScrollShadow size={100}>
+<ScrollShadow size={100} LinearGradientComponent={LinearGradient}>
   <ScrollView>...</ScrollView>
 </ScrollShadow>
 ```
@@ -47,15 +47,15 @@ Control the gradient shadow height/width with the `size` prop.
 Specify which shadows to display using the `visibility` prop.
 
 ```tsx
-<ScrollShadow visibility="top">
+<ScrollShadow visibility="top" LinearGradientComponent={LinearGradient}>
   <ScrollView>...</ScrollView>
 </ScrollShadow>
 
-<ScrollShadow visibility="bottom">
+<ScrollShadow visibility="bottom" LinearGradientComponent={LinearGradient}>
   <ScrollView>...</ScrollView>
 </ScrollShadow>
 
-<ScrollShadow visibility="none">
+<ScrollShadow visibility="none" LinearGradientComponent={LinearGradient}>
   <ScrollView>...</ScrollView>
 </ScrollShadow>
 ```
@@ -65,7 +65,7 @@ Specify which shadows to display using the `visibility` prop.
 Override the default shadow color which uses the theme's background.
 
 ```tsx
-<ScrollShadow color="#ffffff">
+<ScrollShadow color="#ffffff" LinearGradientComponent={LinearGradient}>
   <ScrollView>...</ScrollView>
 </ScrollShadow>
 ```
@@ -75,6 +75,7 @@ Override the default shadow color which uses the theme's background.
 **Important:** ScrollShadow internally converts the child to a Reanimated animated component. If you need to use the `onScroll` prop, you must use `useAnimatedScrollHandler` from react-native-reanimated.
 
 ```tsx
+import { LinearGradient } from 'expo-linear-gradient';
 import Animated, { useAnimatedScrollHandler } from 'react-native-reanimated';
 
 const scrollHandler = useAnimatedScrollHandler({
@@ -83,7 +84,7 @@ const scrollHandler = useAnimatedScrollHandler({
   },
 });
 
-<ScrollShadow>
+<ScrollShadow LinearGradientComponent={LinearGradient}>
   <Animated.ScrollView onScroll={scrollHandler}>...</Animated.ScrollView>
 </ScrollShadow>;
 ```
@@ -92,6 +93,7 @@ const scrollHandler = useAnimatedScrollHandler({
 
 ```tsx
 import { ScrollShadow, Surface } from 'heroui-native';
+import { LinearGradient } from 'expo-linear-gradient';
 import { FlatList, ScrollView, Text, View } from 'react-native';
 
 export default function ScrollShadowExample() {
@@ -103,7 +105,7 @@ export default function ScrollShadowExample() {
   return (
     <View className="flex-1 bg-background">
       <Text className="px-5 py-3 text-lg font-semibold">Horizontal List</Text>
-      <ScrollShadow>
+      <ScrollShadow LinearGradientComponent={LinearGradient}>
         <FlatList
           data={horizontalData}
           horizontal
@@ -118,7 +120,11 @@ export default function ScrollShadowExample() {
       </ScrollShadow>
 
       <Text className="px-5 py-3 text-lg font-semibold">Vertical Content</Text>
-      <ScrollShadow size={80} className="h-48">
+      <ScrollShadow
+        size={80}
+        className="h-48"
+        LinearGradientComponent={LinearGradient}
+      >
         <ScrollView
           contentContainerClassName="p-5"
           showsVerticalScrollIndicator={false}
@@ -148,6 +154,7 @@ export default function ScrollShadowExample() {
 | prop           | type                                                                   | default     | description                                                                                                   |
 | -------------- | ---------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------- |
 | `children`     | `React.ReactElement`                                                   | -           | The scrollable component to enhance with shadows. Must be a single React element (ScrollView, FlatList, etc.) |
+| `LinearGradientComponent` | `ComponentType<LinearGradientProps>`                           | **required** | LinearGradient component from any compatible library (expo-linear-gradient, react-native-linear-gradient, etc.) |
 | `size`         | `number`                                                               | `50`        | Size (height/width) of the gradient shadow in pixels                                                          |
 | `orientation`  | `'horizontal' \| 'vertical'`                                           | auto-detect | Orientation of the scroll shadow. If not provided, will auto-detect from child's `horizontal` prop            |
 | `visibility`   | `'auto' \| 'top' \| 'bottom' \| 'left' \| 'right' \| 'both' \| 'none'` | `'auto'`    | Visibility mode for the shadows. 'auto' shows shadows based on scroll position and content overflow           |
@@ -155,3 +162,15 @@ export default function ScrollShadowExample() {
 | `isEnabled`    | `boolean`                                                              | `true`      | Whether the shadow effect is enabled                                                                          |
 | `className`    | `string`                                                               | -           | Additional CSS classes to apply to the container                                                              |
 | `...ViewProps` | `ViewProps`                                                            | -           | All standard React Native View props are supported                                                            |
+
+### LinearGradientProps
+
+The `LinearGradientComponent` prop expects a component that accepts these props:
+
+| prop           | type                              | description                                                                |
+| -------------- | --------------------------------- | -------------------------------------------------------------------------- |
+| `colors`       | `any`                             | Array of colors for the gradient                                          |
+| `locations`    | `any` (optional)                  | Array of numbers defining the location of each gradient color stop        |
+| `start`        | `any` (optional)                  | Start point of the gradient (e.g., `{ x: 0, y: 0 }`)                    |
+| `end`          | `any` (optional)                  | End point of the gradient (e.g., `{ x: 1, y: 0 }`)                      |
+| `style`        | `StyleProp<ViewStyle>` (optional) | Style to apply to the gradient view                                      |

--- a/src/components/scroll-shadow/scroll-shadow.tsx
+++ b/src/components/scroll-shadow/scroll-shadow.tsx
@@ -1,4 +1,3 @@
-import { LinearGradient } from 'expo-linear-gradient';
 import { cloneElement, createElement, forwardRef, isValidElement } from 'react';
 import { StyleSheet, View, type LayoutChangeEvent } from 'react-native';
 import Animated, {
@@ -32,6 +31,7 @@ const ScrollShadowRoot = forwardRef<View, ScrollShadowProps>((props, ref) => {
     isEnabled = true,
     className,
     style,
+    LinearGradientComponent,
     ...restProps
   } = props;
 
@@ -184,7 +184,7 @@ const ScrollShadowRoot = forwardRef<View, ScrollShadowProps>((props, ref) => {
         <Animated.View
           style={[nativeStyles.topShadow, { height: size }, topShadowStyle]}
         >
-          <LinearGradient
+          <LinearGradientComponent
             colors={topLeftColors}
             locations={topLeftLocations}
             style={StyleSheet.absoluteFill}
@@ -194,7 +194,7 @@ const ScrollShadowRoot = forwardRef<View, ScrollShadowProps>((props, ref) => {
         <Animated.View
           style={[nativeStyles.leftShadow, { width: size }, topShadowStyle]}
         >
-          <LinearGradient
+          <LinearGradientComponent
             colors={topLeftColors}
             locations={topLeftLocations}
             start={{ x: 0, y: 0 }}
@@ -213,7 +213,7 @@ const ScrollShadowRoot = forwardRef<View, ScrollShadowProps>((props, ref) => {
             bottomShadowStyle,
           ]}
         >
-          <LinearGradient
+          <LinearGradientComponent
             colors={bottomRightColors}
             locations={bottomRightLocations}
             style={StyleSheet.absoluteFill}
@@ -223,7 +223,7 @@ const ScrollShadowRoot = forwardRef<View, ScrollShadowProps>((props, ref) => {
         <Animated.View
           style={[nativeStyles.rightShadow, { width: size }, bottomShadowStyle]}
         >
-          <LinearGradient
+          <LinearGradientComponent
             colors={bottomRightColors}
             locations={bottomRightLocations}
             start={{ x: 0, y: 0 }}

--- a/src/components/scroll-shadow/scroll-shadow.types.ts
+++ b/src/components/scroll-shadow/scroll-shadow.types.ts
@@ -1,4 +1,5 @@
-import type { ViewProps } from 'react-native';
+import type { ComponentType } from 'react';
+import type { StyleProp, ViewProps, ViewStyle } from 'react-native';
 
 /**
  * Orientation of the scroll shadow
@@ -25,6 +26,16 @@ export type ScrollShadowVisibility =
   | 'right'
   | 'both'
   | 'none';
+
+export interface LinearGradientProps {
+  colors: any;
+  locations?: any;
+  start?: any;
+  end?: any;
+  style?: StyleProp<ViewStyle>;
+}
+
+export type LinearGradientComponent = ComponentType<LinearGradientProps>;
 
 /**
  * Props for the ScrollShadow component
@@ -71,4 +82,11 @@ export interface ScrollShadowProps extends ViewProps {
    * Additional CSS classes to apply to the container
    */
   className?: string;
+
+  /**
+   * LinearGradient component to use for rendering shadows
+   * Compatible with expo-linear-gradient, react-native-linear-gradient, etc.
+   * Required for the component to render shadows
+   */
+  LinearGradientComponent: LinearGradientComponent;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6975,7 +6975,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-linear-gradient@npm:^14.1.5, expo-linear-gradient@npm:~14.1.5":
+"expo-linear-gradient@npm:~14.1.5":
   version: 14.1.5
   resolution: "expo-linear-gradient@npm:14.1.5"
   peerDependencies:
@@ -8070,7 +8070,6 @@ __metadata:
     eslint: ^9.22.0
     eslint-config-prettier: ^10.1.1
     eslint-plugin-prettier: ^5.2.3
-    expo-linear-gradient: ^14.1.5
     jest: ^29.7.0
     nativewind: ^4.1.23
     prettier: ^3.0.3
@@ -8086,7 +8085,6 @@ __metadata:
     tailwindcss: ^3.4.17
     typescript: ^5.8.3
   peerDependencies:
-    expo-linear-gradient: ^14.1.5
     nativewind: ^4.1.23
     react: "*"
     react-native: "*"


### PR DESCRIPTION
📝 Description

  This pull request refactors the ScrollShadow component to remove the hard dependency on expo-linear-gradient, making it library-agnostic. The
  component now accepts a LinearGradientComponent prop, allowing users to provide their own gradient implementation from any compatible library
  (expo-linear-gradient, react-native-linear-gradient, etc.).

  ⛳️ Current behavior (updates)

  The ScrollShadow component previously had a direct dependency on expo-linear-gradient, forcing all users to install this specific library even if
   they preferred or already had a different gradient implementation in their project. The component imported and used LinearGradient directly from
   expo-linear-gradient, limiting flexibility and increasing the bundle size for users who might not need this specific implementation.

  🚀 New behavior

  The ScrollShadow component now requires a LinearGradientComponent prop that users must provide when using the component. This approach:
  - Removes expo-linear-gradient as a peer dependency from the main library
  - Allows users to choose their preferred gradient library (expo-linear-gradient, react-native-linear-gradient, or any compatible implementation)
  - Reduces the number of mandatory dependencies for the library
  - Provides better flexibility for different React Native environments (bare React Native, Expo, etc.)
  - Updates all documentation and examples to reflect the new usage pattern with the LinearGradientComponent prop

  💣 Is this a breaking change (Yes/No):

  Yes - This is a breaking change that requires all users of the ScrollShadow component to update their implementation.

  Migration instructions for HeroUI users:
  1. Install your preferred gradient library if not already installed (e.g., npm install expo-linear-gradient or npm install 
  react-native-linear-gradient)
  2. Import the LinearGradient component from your chosen library
  3. Pass it to ScrollShadow via the LinearGradientComponent prop

  📝 Additional Information

  - The LinearGradientComponent prop accepts any component that implements the standard gradient interface with colors, locations, start, end, and
  style props
  - This change reduces the mandatory peer dependencies from 6 to 5, simplifying the installation process
  - All examples in the documentation have been updated to show the new usage pattern
  - The example app continues to use expo-linear-gradient for demonstration purposes, but users are free to choose any compatible implementation
  - Type definitions have been added to clearly document the expected LinearGradientProps interface