### PR TITLE
fix(stack): apply theme background color in Stack screenOptions

### DIFF
--- a/example/src/app/(home)/_layout.tsx
+++ b/example/src/app/(home)/_layout.tsx
@@ -48,6 +48,9 @@ export default function Layout() {
         gestureEnabled: true,
         gestureDirection: 'horizontal',
         fullScreenGestureEnabled: true,
+        contentStyle: {
+          backgroundColor: colors.background,
+        },
       }}
     >
       <Stack.Screen

--- a/example/src/app/(home)/components/_layout.tsx
+++ b/example/src/app/(home)/components/_layout.tsx
@@ -44,6 +44,9 @@ export default function Layout() {
         gestureEnabled: true,
         gestureDirection: 'horizontal',
         fullScreenGestureEnabled: true,
+        contentStyle: {
+          backgroundColor: colors.background,
+        }
       }}
     >
       <Stack.Screen

--- a/example/src/app/(home)/showcases/_layout.tsx
+++ b/example/src/app/(home)/showcases/_layout.tsx
@@ -1,6 +1,9 @@
 import { Stack } from 'expo-router';
+import { useTheme } from 'heroui-native';
 
 export default function Layout() {
+  const { colors } = useTheme();
+
   return (
     <Stack
       screenOptions={{
@@ -9,6 +12,9 @@ export default function Layout() {
         gestureDirection: 'horizontal',
         fullScreenGestureEnabled: true,
         animation: 'none',
+        contentStyle: {
+          backgroundColor: colors.background,
+        }
       }}
     />
   );


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description
Applied the theme background color to Stack screenOptions.contentStyle.
By default, the background during stack transitions was showing as white, ignoring the active theme. This caused a visible flash when navigating between screens in dark mode. Updating the contentStyle.backgroundColor ensures the stack uses the current theme background color consistently across transitions.

<!--- Add a brief description -->

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->


https://github.com/user-attachments/assets/3e655310-da4d-4a7d-b6bc-3ea8aa03c0f9


## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->

https://github.com/user-attachments/assets/7cfaa364-d242-4cd1-a8c3-23dd009b4255



## 💣 Is this a breaking change (Yes/No): No

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->

## 📝 Additional Information
