### PR TITLE
Refactor/radio group

### DIFF
--- a/example/src/app/(home)/components/radio-group.tsx
+++ b/example/src/app/(home)/components/radio-group.tsx
@@ -73,6 +73,7 @@ const StartIndicatorAlignmentContent = () => {
         value={shippingSpeed}
         onValueChange={setShippingSpeed}
         className="gap-4"
+        isOnSurface
       >
         <RadioGroup.Item value="standard">
           {({ isSelected }) => (
@@ -82,7 +83,9 @@ const StartIndicatorAlignmentContent = () => {
                 isSelected && 'bg-surface'
               )}
             >
-              <RadioGroup.Indicator />
+              <RadioGroup.Indicator
+                className={cn(!isSelected && 'border border-muted/10')}
+              />
               <View className="flex-1">
                 <RadioGroup.Label>Standard Shipping</RadioGroup.Label>
                 <RadioGroup.Description>
@@ -109,7 +112,9 @@ const StartIndicatorAlignmentContent = () => {
                 isSelected && 'bg-surface'
               )}
             >
-              <RadioGroup.Indicator />
+              <RadioGroup.Indicator
+                className={cn(!isSelected && 'border border-muted/10')}
+              />
               <View className="flex-1">
                 <RadioGroup.Label>Express Shipping</RadioGroup.Label>
                 <RadioGroup.Description>
@@ -136,7 +141,9 @@ const StartIndicatorAlignmentContent = () => {
                 isSelected && 'bg-surface'
               )}
             >
-              <RadioGroup.Indicator />
+              <RadioGroup.Indicator
+                className={cn(!isSelected && 'border border-muted/10')}
+              />
               <View className="flex-1">
                 <RadioGroup.Label>Overnight Shipping</RadioGroup.Label>
                 <RadioGroup.Description>
@@ -284,58 +291,70 @@ const CustomIndicatorBackgroundContent = () => {
         </View>
         <RadioGroup value={priority} onValueChange={setPriority}>
           <RadioGroup.Item value="high">
-            <View className="flex-1">
-              <RadioGroup.Label>High Priority</RadioGroup.Label>
-              <RadioGroup.Description>
-                Urgent - requires immediate attention
-              </RadioGroup.Description>
-            </View>
-            <RadioGroup.Indicator
-              className={cn(
-                'size-8',
-                priority === 'high' && 'bg-red-500 border-red-600'
-              )}
-            >
-              <RadioGroup.IndicatorThumb className="size-3.5 bg-red-100" />
-            </RadioGroup.Indicator>
+            {({ isSelected }) => (
+              <>
+                <View className="flex-1">
+                  <RadioGroup.Label>High Priority</RadioGroup.Label>
+                  <RadioGroup.Description>
+                    Urgent - requires immediate attention
+                  </RadioGroup.Description>
+                </View>
+                <RadioGroup.Indicator
+                  className={cn(
+                    'size-8',
+                    isSelected && 'bg-red-500 border-red-400'
+                  )}
+                >
+                  <RadioGroup.IndicatorThumb className="size-3.5 bg-red-100" />
+                </RadioGroup.Indicator>
+              </>
+            )}
           </RadioGroup.Item>
 
           <Divider />
 
           <RadioGroup.Item value="medium">
-            <View className="flex-1">
-              <RadioGroup.Label>Medium Priority</RadioGroup.Label>
-              <RadioGroup.Description>
-                Important - complete within this week
-              </RadioGroup.Description>
-            </View>
-            <RadioGroup.Indicator
-              className={cn(
-                'size-8',
-                priority === 'medium' && 'bg-amber-500 border-amber-600'
-              )}
-            >
-              <RadioGroup.IndicatorThumb className="size-3.5 bg-amber-100" />
-            </RadioGroup.Indicator>
+            {({ isSelected }) => (
+              <>
+                <View className="flex-1">
+                  <RadioGroup.Label>Medium Priority</RadioGroup.Label>
+                  <RadioGroup.Description>
+                    Important - complete within this week
+                  </RadioGroup.Description>
+                </View>
+                <RadioGroup.Indicator
+                  className={cn(
+                    'size-8',
+                    isSelected && 'bg-amber-500 border-amber-400'
+                  )}
+                >
+                  <RadioGroup.IndicatorThumb className="size-3.5 bg-amber-100" />
+                </RadioGroup.Indicator>
+              </>
+            )}
           </RadioGroup.Item>
 
           <Divider />
 
           <RadioGroup.Item value="low">
-            <View className="flex-1">
-              <RadioGroup.Label>Low Priority</RadioGroup.Label>
-              <RadioGroup.Description>
-                Standard - complete when possible
-              </RadioGroup.Description>
-            </View>
-            <RadioGroup.Indicator
-              className={cn(
-                'size-8',
-                priority === 'low' && 'bg-emerald-500 border-emerald-600'
-              )}
-            >
-              <RadioGroup.IndicatorThumb className="size-3.5 bg-emerald-100" />
-            </RadioGroup.Indicator>
+            {({ isSelected }) => (
+              <>
+                <View className="flex-1">
+                  <RadioGroup.Label>Low Priority</RadioGroup.Label>
+                  <RadioGroup.Description>
+                    Standard - complete when possible
+                  </RadioGroup.Description>
+                </View>
+                <RadioGroup.Indicator
+                  className={cn(
+                    'size-8',
+                    isSelected && 'bg-emerald-500 border-emerald-400'
+                  )}
+                >
+                  <RadioGroup.IndicatorThumb className="size-3.5 bg-emerald-100" />
+                </RadioGroup.Indicator>
+              </>
+            )}
           </RadioGroup.Item>
         </RadioGroup>
       </Surface>
@@ -361,65 +380,77 @@ const CustomIndicatorThumbContent = () => {
         </View>
         <RadioGroup value={notification} onValueChange={setNotification}>
           <RadioGroup.Item value="email">
-            <RadioGroup.Indicator>
-              {notification === 'email' && (
-                <AnimatedView entering={FadeIn.duration(200)}>
-                  <StyledFontAwesome
-                    name="check"
-                    size={12}
-                    className="text-accent-foreground"
-                  />
-                </AnimatedView>
-              )}
-            </RadioGroup.Indicator>
-            <View className="flex-1">
-              <RadioGroup.Label>Email Notifications</RadioGroup.Label>
-              <RadioGroup.Description>
-                Get updates via email
-              </RadioGroup.Description>
-            </View>
+            {({ isSelected }) => (
+              <>
+                <RadioGroup.Indicator>
+                  {isSelected && (
+                    <AnimatedView entering={FadeIn.duration(200)}>
+                      <StyledFontAwesome
+                        name="check"
+                        size={12}
+                        className="text-accent-foreground"
+                      />
+                    </AnimatedView>
+                  )}
+                </RadioGroup.Indicator>
+                <View className="flex-1">
+                  <RadioGroup.Label>Email Notifications</RadioGroup.Label>
+                  <RadioGroup.Description>
+                    Get updates via email
+                  </RadioGroup.Description>
+                </View>
+              </>
+            )}
           </RadioGroup.Item>
 
           <Divider />
 
           <RadioGroup.Item value="push">
-            <RadioGroup.Indicator>
-              {notification === 'push' && (
-                <AnimatedView entering={FadeIn.duration(200)}>
-                  <StyledIonicons
-                    name="flash"
-                    size={12}
-                    className="text-background"
-                  />
-                </AnimatedView>
-              )}
-            </RadioGroup.Indicator>
-            <View className="flex-1">
-              <RadioGroup.Label>Push Notifications</RadioGroup.Label>
-              <RadioGroup.Description>
-                Get instant push alerts
-              </RadioGroup.Description>
-            </View>
+            {({ isSelected }) => (
+              <>
+                <RadioGroup.Indicator>
+                  {isSelected && (
+                    <AnimatedView entering={FadeIn.duration(200)}>
+                      <StyledIonicons
+                        name="flash"
+                        size={12}
+                        className="text-background"
+                      />
+                    </AnimatedView>
+                  )}
+                </RadioGroup.Indicator>
+                <View className="flex-1">
+                  <RadioGroup.Label>Push Notifications</RadioGroup.Label>
+                  <RadioGroup.Description>
+                    Get instant push alerts
+                  </RadioGroup.Description>
+                </View>
+              </>
+            )}
           </RadioGroup.Item>
 
           <Divider />
 
           <RadioGroup.Item value="none">
-            <RadioGroup.Indicator>
-              {notification === 'none' && (
-                <AnimatedView
-                  key="none"
-                  entering={ZoomIn.springify()}
-                  className="h-2.5 w-2.5 bg-accent-foreground"
-                />
-              )}
-            </RadioGroup.Indicator>
-            <View className="flex-1">
-              <RadioGroup.Label>No Notifications</RadioGroup.Label>
-              <RadioGroup.Description>
-                Only check updates manually
-              </RadioGroup.Description>
-            </View>
+            {({ isSelected }) => (
+              <>
+                <RadioGroup.Indicator>
+                  {isSelected && (
+                    <AnimatedView
+                      key="none"
+                      entering={ZoomIn.springify()}
+                      className="h-2.5 w-2.5 bg-accent-foreground"
+                    />
+                  )}
+                </RadioGroup.Indicator>
+                <View className="flex-1">
+                  <RadioGroup.Label>No Notifications</RadioGroup.Label>
+                  <RadioGroup.Description>
+                    Only check updates manually
+                  </RadioGroup.Description>
+                </View>
+              </>
+            )}
           </RadioGroup.Item>
         </RadioGroup>
       </Surface>

--- a/example/src/components/showcases/paywall/styled-radio.tsx
+++ b/example/src/components/showcases/paywall/styled-radio.tsx
@@ -35,7 +35,9 @@ export const StyledRadio: FC<Props> = ({
     >
       <BlurContainer>
         <RadioGroup.Item value={value} className="flex-1 px-6">
-          <RadioGroup.Indicator className="border-white/25" />
+          <RadioGroup.Indicator
+            className={cn('border-white/25', isSelected && 'bg-white')}
+          />
           <View className="flex-1 flex-row items-center justify-between gap-3">
             <View>
               <RadioGroup.Label className={className.title}>

--- a/src/components/radio-group/radio-group.md
+++ b/src/components/radio-group/radio-group.md
@@ -193,6 +193,7 @@ export default function PaymentMethodExample() {
 | `onValueChange` | `(val: string) => void` | `undefined` | Callback fired when the selected value changes     |
 | `isDisabled`    | `boolean`               | `false`     | Whether the entire radio group is disabled         |
 | `isInvalid`     | `boolean`               | `false`     | Whether the radio group is invalid                 |
+| `isOnSurface`   | `boolean`               | `undefined` | Whether the radio group is on surface              |
 | `className`     | `string`                | `undefined` | Custom class name                                  |
 | `...ViewProps`  | `ViewProps`             | -           | All standard React Native View props are supported |
 
@@ -220,6 +221,7 @@ export default function PaymentMethodExample() {
 | prop                    | type                       | default     | description                                      |
 | ----------------------- | -------------------------- | ----------- | ------------------------------------------------ |
 | `children`              | `React.ReactNode`          | `undefined` | Indicator content                                |
+| `isOnSurface`           | `boolean`                  | `undefined` | Whether the indicator is on surface              |
 | `className`             | `string`                   | `undefined` | Custom class name                                |
 | `...Animated.ViewProps` | `AnimatedProps<ViewProps>` | -           | All Reanimated Animated.View props are supported |
 

--- a/src/components/radio-group/radio-group.styles.ts
+++ b/src/components/radio-group/radio-group.styles.ts
@@ -21,9 +21,13 @@ const item = tv({
 const itemIndicator = tv({
   base: 'size-6 rounded-full border border-field-border items-center justify-center overflow-hidden',
   variants: {
+    isOnSurface: {
+      true: 'bg-on-surface',
+      false: 'bg-field',
+    },
     isSelected: {
       true: 'bg-accent',
-      false: 'bg-field',
+      false: '',
     },
     isInvalid: {
       true: 'bg-transparent border-danger',

--- a/src/components/radio-group/radio-group.tsx
+++ b/src/components/radio-group/radio-group.tsx
@@ -3,6 +3,7 @@ import { forwardRef, useMemo } from 'react';
 import { View } from 'react-native';
 import Animated from 'react-native-reanimated';
 
+import { useIsOnSurface } from '../../helpers/theme';
 import type { TextRef, ViewRef } from '../../helpers/types';
 import { childrenToString, createContext } from '../../helpers/utils';
 import * as RadioGroupPrimitives from '../../primitives/radio-group';
@@ -136,13 +137,26 @@ const RadioGroupItem = forwardRef<
 
 const RadioGroupIndicator = forwardRef<Animated.View, RadioGroupIndicatorProps>(
   (props, ref) => {
-    const { children, className, style, ...restProps } = props;
+    const {
+      children,
+      className,
+      style,
+      isOnSurface: isOnSurfaceProp,
+      ...restProps
+    } = props;
 
+    const { isOnSurface: isOnSurfaceGroup } = useRadioGroup();
     const { isSelected, isInvalid } = useRadioGroupItem();
+
+    const isOnSurfaceAutoDetected = useIsOnSurface();
+
+    const isOnSurface =
+      isOnSurfaceProp ?? isOnSurfaceGroup ?? isOnSurfaceAutoDetected;
 
     const tvStyles = radioGroupStyles.itemIndicator({
       isSelected,
       isInvalid,
+      isOnSurface,
       className,
     });
 

--- a/src/components/radio-group/radio-group.types.ts
+++ b/src/components/radio-group/radio-group.types.ts
@@ -59,6 +59,8 @@ export interface RadioGroupItemProps extends Omit<ItemProps, 'children'> {
  * Props for RadioGroup.Indicator component
  */
 export interface RadioGroupIndicatorProps extends AnimatedProps<ViewProps> {
+  /** Whether the indicator is on surface */
+  isOnSurface?: boolean;
   /** Indicator content */
   children?: React.ReactNode;
   /** Custom class name */

--- a/src/components/surface/index.ts
+++ b/src/components/surface/index.ts
@@ -1,2 +1,2 @@
-export { default as Surface } from './surface';
+export { default as Surface, useSurface } from './surface';
 export type { SurfaceRootProps, SurfaceVariant } from './surface.types';

--- a/src/components/surface/surface.tsx
+++ b/src/components/surface/surface.tsx
@@ -1,23 +1,33 @@
-import { forwardRef } from 'react';
+import { forwardRef, useMemo } from 'react';
 import { View } from 'react-native';
 import type { ViewRef } from '../../helpers/types/primitives';
+import { createContext } from '../../helpers/utils';
 import { DISPLAY_NAME } from './surface.constants';
 import surfaceStyles, { styleSheet } from './surface.styles';
-import type { SurfaceRootProps } from './surface.types';
+import type { SurfaceContextValue, SurfaceRootProps } from './surface.types';
+
+const [SurfaceProvider, useSurface] = createContext<SurfaceContextValue>({
+  name: 'SurfaceContext',
+  strict: false,
+});
 
 const Surface = forwardRef<ViewRef, SurfaceRootProps>(
-  ({ children, variant, className, style, ...props }, ref) => {
+  ({ children, variant = 'default', className, style, ...props }, ref) => {
     const tvStyles = surfaceStyles({ variant, className });
 
+    const contextValue = useMemo(() => ({ variant }), [variant]);
+
     return (
-      <View
-        ref={ref}
-        className={tvStyles}
-        style={[styleSheet.root, style]}
-        {...props}
-      >
-        {children}
-      </View>
+      <SurfaceProvider value={contextValue}>
+        <View
+          ref={ref}
+          className={tvStyles}
+          style={[styleSheet.root, style]}
+          {...props}
+        >
+          {children}
+        </View>
+      </SurfaceProvider>
     );
   }
 );
@@ -34,3 +44,5 @@ Surface.displayName = DISPLAY_NAME.ROOT;
  * @see Full documentation: https://heroui.com/components/surface
  */
 export default Surface;
+
+export { useSurface };

--- a/src/components/surface/surface.types.ts
+++ b/src/components/surface/surface.types.ts
@@ -28,3 +28,13 @@ export interface SurfaceRootProps extends ViewProps {
    */
   className?: string;
 }
+
+/**
+ * Context value for the Surface component
+ */
+export interface SurfaceContextValue {
+  /**
+   * Visual variant of the surface
+   */
+  variant: SurfaceVariant;
+}

--- a/src/helpers/theme/hooks/use-is-on-surface.ts
+++ b/src/helpers/theme/hooks/use-is-on-surface.ts
@@ -1,0 +1,8 @@
+import { useSurface } from '../../../components/surface';
+
+export const useIsOnSurface = () => {
+  const surfaceContext = useSurface();
+  return surfaceContext?.variant && surfaceContext.variant !== 'transparent'
+    ? true
+    : false;
+};

--- a/src/helpers/theme/index.ts
+++ b/src/helpers/theme/index.ts
@@ -1,3 +1,4 @@
 export { default as colorKit } from './color-kit';
+export { useIsOnSurface } from './hooks/use-is-on-surface';
 export { useThemeColor } from './hooks/use-theme-color';
 export { cn } from './utils/cn';

--- a/src/primitives/radio-group/radio-group.tsx
+++ b/src/primitives/radio-group/radio-group.tsx
@@ -20,6 +20,7 @@ const Root = forwardRef<RootRef, RootProps>(
       onValueChange,
       isDisabled = false,
       isInvalid = false,
+      isOnSurface,
       ...viewProps
     },
     ref
@@ -33,6 +34,7 @@ const Root = forwardRef<RootRef, RootProps>(
           isDisabled,
           onValueChange,
           isInvalid,
+          isOnSurface,
         }}
       >
         <Component ref={ref} role="radiogroup" {...viewProps} />

--- a/src/primitives/radio-group/radio-group.types.ts
+++ b/src/primitives/radio-group/radio-group.types.ts
@@ -20,6 +20,8 @@ type RootProps = Omit<SlottableViewProps, 'disabled'> & {
   isDisabled?: boolean;
   /** Whether the radio group is invalid @default false */
   isInvalid?: boolean;
+  /** Whether the radio group is on surface */
+  isOnSurface?: boolean;
 };
 
 /**


### PR DESCRIPTION
## 📝 Description

This PR refactors the radio-group component to add render function support for item children and improve surface detection for indicator styling. The Surface component now exposes a context hook for better component integration.

## ⛳️ Current behavior (updates)

RadioGroup.Item only accepts React nodes as children, requiring manual state management for custom styling. RadioGroup.Indicator uses fixed background colors without surface awareness.

## 🚀 New behavior

- Added render function support to RadioGroup.Item children, providing `isSelected`, `isInvalid`, and `isDisabled` props
- Added `isOnSurface` prop to RadioGroup root and Indicator components for automatic surface detection
- Implemented `useIsOnSurface` hook that detects Surface context to determine appropriate indicator styling
- Updated indicator styles to use `bg-field` or `bg-on-surface` based on surface context
- Exported `useSurface` hook from Surface component for context access
- Updated example app to demonstrate render function usage for custom indicators

## 💣 Is this a breaking change (Yes/No):

**No** - All changes are backward compatible. Existing RadioGroup.Item usage with React nodes continues to work. Render functions are optional additions.

## 📝 Additional Information

The render function pattern enables more flexible customization of radio items while maintaining type safety. Surface detection improves visual consistency when radio groups are used within Surface components. Example app demonstrates both patterns.