### PR TITLE
Update theme documentation to match uniwind usage

### DIFF
--- a/src/styles/theme.md
+++ b/src/styles/theme.md
@@ -253,12 +253,10 @@ module.exports = withUniwindConfig(wrapWithReanimatedMetroConfig(config), {
 Apply themes in your app:
 
 ```tsx
-import { useColorScheme } from 'uniwind';
+import { Uniwind } from 'uniwind';
 
 function App() {
-  const { setColorScheme } = useColorScheme();
-
-  return <Button onPress={() => setColorScheme('ocean')}>Ocean Theme</Button>;
+  return <Button onPress={() => Uniwind.setTheme('ocean')}>Ocean Theme</Button>;
 }
 ```
 
@@ -376,16 +374,16 @@ cn('bg-background p-4', 'bg-accent');
 HeroUI Native automatically supports dark mode through Uniwind. The theme switches between light and dark variants based on the system or manual selection:
 
 ```tsx
-import { useColorScheme } from 'uniwind';
+import { Uniwind, useUniwind } from 'uniwind';
 
 function ThemeToggle() {
-  const { colorScheme, setColorScheme } = useColorScheme();
+  const { theme } = useUniwind();
 
   return (
     <Button
-      onPress={() => setColorScheme(colorScheme === 'light' ? 'dark' : 'light')}
+      onPress={() => Uniwind.setTheme(theme === 'light' ? 'dark' : 'light')}
     >
-      Toggle {colorScheme === 'light' ? 'Dark' : 'Light'} Mode
+      Toggle {theme === 'light' ? 'Dark' : 'Light'} Mode
     </Button>
   );
 }


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

This PR updates the theming documentation to reflect the correct usage of the `uniwind` library

## ⛳️ Current behavior (updates)

The docs currently suggests using `useColorScheme` from `uniwind`. Following the guide results in the following TypeScript error because the member is not exported:

```
Module '"uniwind"' has no exported member 'useColorScheme'.ts(2305)
```

## 🚀 New behavior

Updated the documentation to use `useUniwind` and `Uniwind.setTheme` instead of `useColorScheme`