### PR TITLE
Restore onFocus and onBlur event handlers

### DIFF
--- a/src/components/text-field/text-field.tsx
+++ b/src/components/text-field/text-field.tsx
@@ -269,10 +269,10 @@ const TextFieldInput = forwardRef<TextInputType, TextFieldInputProps>(
           selectionHandleColor={
             props.colors?.focusBackground || themeColorMuted
           }
-          onFocus={handleFocus}
-          onBlur={handleBlur}
           textAlignVertical={restProps.multiline ? 'top' : 'center'}
           {...restProps}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
         />
         {endContent}
       </Animated.View>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Because rest props is not being being restructured - if I supply a custom onFocus or onBlue prop to the text field the internal logic within the text field that controls the border on focus style etc does not get called since the prop gets overridden. So just change the order of the props to let this pass. 

## ⛳️ Current behavior (updates)

Border style breaks when passing custom onFocus and onBlur props 

## 🚀 New behavior

Border style is fixed

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
