### PR TITLE
Toast > Insets Container Overlay Issue

### DIFF
--- a/src/providers/toast/provider.tsx
+++ b/src/providers/toast/provider.tsx
@@ -368,22 +368,24 @@ export function ToastProvider({
     <ToastConfigContext.Provider value={globalConfig}>
       <ToasterContext.Provider value={contextValue}>
         {children}
-        <InsetsContainer insets={insets} contentWrapper={contentWrapper}>
-          <View className="flex-1">
-            {toasts.map((toastItem, index) => (
-              <ToastItemRenderer
-                key={toastItem.id}
-                toastItem={toastItem}
-                show={show}
-                hide={hide}
-                index={index}
-                total={total}
-                heights={heights}
-                maxVisibleToasts={maxVisibleToasts}
-              />
-            ))}
-          </View>
-        </InsetsContainer>
+        {toasts.length > 0 && (
+          <InsetsContainer insets={insets} contentWrapper={contentWrapper}>
+            <View className="flex-1">
+              {toasts.map((toastItem, index) => (
+                <ToastItemRenderer
+                  key={toastItem.id}
+                  toastItem={toastItem}
+                  show={show}
+                  hide={hide}
+                  index={index}
+                  total={total}
+                  heights={heights}
+                  maxVisibleToasts={maxVisibleToasts}
+                />
+              ))}
+            </View>
+          </InsetsContainer>
+        )}
       </ToasterContext.Provider>
     </ToastConfigContext.Provider>
   );


### PR DESCRIPTION
Closes #128 

## 📝 Description

Fixes UI inspection blocking issue by conditionally rendering the toast overlay container only when toasts are visible. Previously, the `InsetsContainer` (which uses `FullWindowOverlay` on iOS) was always rendered, preventing React Native's inspector from working even when no toasts were displayed.

## ⛳️ Current behavior (updates)

The `InsetsContainer` component is always rendered in the toast provider, creating a full-screen overlay layer that blocks UI inspection tools even when no toasts are visible.

## 🚀 New behavior

- `InsetsContainer` only renders when `toasts.length > 0`
- UI inspection works normally when no toasts are displayed
- Toast functionality remains unchanged when toasts are visible

## 💣 Is this a breaking change (Yes/No):

**No** - This is a bug fix that improves developer experience without changing toast API or behavior.

## 📝 Additional Information

The fix ensures the overlay layer is only present when needed, allowing React Native's inspector to function properly during development. No testing changes required as toast display behavior remains identical.