### PR TITLE
fix(avatar): same source loading cycle issue

### DIFF
--- a/src/primitives/avatar/avatar.tsx
+++ b/src/primitives/avatar/avatar.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { createContext, forwardRef, useEffect, useMemo, useState } from 'react';
 import {
   type ImageErrorEventData,
-  type ImageLoadEventData,
+  type ImageLoadEvent,
   type NativeSyntheticEvent,
   Image as RNImage,
   View,
@@ -17,7 +17,7 @@ import type {
   RootProps,
   RootRef,
 } from './avatar.types';
-import { isValidSource } from './avatar.utils';
+import { isSameSource, isValidSource } from './avatar.utils';
 
 interface IRootContext extends RootProps {
   status: AvatarStatus;
@@ -78,18 +78,40 @@ const Image = forwardRef<ImageRef, ImageProps>(
   ) => {
     const { alt, setStatus, status } = useRootContext();
 
+    // Use ref to track the previous source value for comparison
+    const previousSourceRef = React.useRef<ImageProps['source'] | undefined>(
+      undefined
+    );
+
     useEffect(() => {
-      if (isValidSource(props?.source)) {
-        setStatus('loading');
+      const currentSource = props?.source;
+      const previousSource = previousSourceRef.current;
+
+      // Only reset status if the source actually changed (not just reference)
+      const sourceChanged = !isSameSource(currentSource, previousSource);
+
+      if (sourceChanged) {
+        // Update the ref to track the new source
+        previousSourceRef.current = currentSource;
+
+        if (isValidSource(currentSource)) {
+          setStatus('loading');
+        } else {
+          setStatus('error');
+        }
       }
 
+      // Cleanup: only reset to error if component unmounts or source becomes invalid
       return () => {
-        setStatus('error');
+        // Only reset if source is no longer valid or component is unmounting
+        if (!isValidSource(currentSource)) {
+          setStatus('error');
+        }
       };
     }, [props?.source, setStatus]);
 
     const onLoad = React.useCallback(
-      (e: NativeSyntheticEvent<ImageLoadEventData>) => {
+      (e: ImageLoadEvent) => {
         setStatus('loaded');
         onLoadingStatusChange?.('loaded');
         onLoadProps?.(e);

--- a/src/primitives/avatar/avatar.utils.ts
+++ b/src/primitives/avatar/avatar.utils.ts
@@ -35,3 +35,68 @@ export function isValidSource(source?: ImageSourcePropType) {
 
   return !!source.uri;
 }
+
+/**
+ * Compares two image sources to determine if they represent the same image.
+ * Performs deep comparison of source values, not just reference equality.
+ *
+ * @param source1 - First image source to compare
+ * @param source2 - Second image source to compare
+ * @returns `true` if both sources represent the same image, `false` otherwise
+ *
+ * @example
+ * ```ts
+ * // Same sources (different object references)
+ * isSameSource({ uri: 'https://example.com/img.jpg' }, { uri: 'https://example.com/img.jpg' }); // true
+ *
+ * // Different sources
+ * isSameSource({ uri: 'https://example.com/img1.jpg' }, { uri: 'https://example.com/img2.jpg' }); // false
+ *
+ * // Same require() values
+ * isSameSource(require('./img.png'), require('./img.png')); // true (if same number)
+ * ```
+ */
+export function isSameSource(
+  source1?: ImageSourcePropType,
+  source2?: ImageSourcePropType
+): boolean {
+  // Both undefined/null
+  if (!source1 && !source2) {
+    return true;
+  }
+
+  // One is undefined/null, the other is not
+  if (!source1 || !source2) {
+    return false;
+  }
+
+  // Both are numbers (require() statements)
+  if (typeof source1 === 'number' && typeof source2 === 'number') {
+    return source1 === source2;
+  }
+
+  // One is a number, the other is not
+  if (typeof source1 === 'number' || typeof source2 === 'number') {
+    return false;
+  }
+
+  // Both are arrays
+  if (Array.isArray(source1) && Array.isArray(source2)) {
+    if (source1.length !== source2.length) {
+      return false;
+    }
+    // Compare each element's URI
+    return source1.every((s1, index) => {
+      const s2 = source2[index];
+      return s1?.uri === s2?.uri;
+    });
+  }
+
+  // One is an array, the other is not
+  if (Array.isArray(source1) || Array.isArray(source2)) {
+    return false;
+  }
+
+  // Both are objects - compare URI values
+  return source1.uri === source2.uri;
+}


### PR DESCRIPTION
## 📝 Description

Fixes the Avatar component resetting to 'loading' status when the source prop reference changes but the actual image value remains unchanged. Adds a new `isSameSource` utility function that performs deep comparison of image sources to prevent unnecessary status resets and visual flickering.

## ⛳️ Current behavior (updates)

The Avatar component resets to 'loading' status whenever the source prop reference changes, even when the URI or image value is identical, causing visual flickering and unnecessary re-renders.

## 🚀 New behavior

- Deep comparison of image sources using `isSameSource` utility to detect actual value changes
- Status only resets when source value actually changes, not just reference equality
- Improved cleanup logic to prevent unnecessary error state transitions
- Fixed type import from `ImageLoadEventData` to `ImageLoadEvent`

## 💣 Is this a breaking change (Yes/No):

**No** - This is a bug fix that improves internal behavior without changing the component API or props interface.

## 📝 Additional Information

The `isSameSource` utility function handles all source types including number sources (require statements), object sources (URI comparison), and array sources (element-by-element URI comparison). This fix prevents status resets when parent components re-render with new source object references but identical image values.