### PR TITLE
fix(pressable-feedback): reset animation state on scroll issue

### DIFF
--- a/src/components/pressable-feedback/pressable-feedback.animation.ts
+++ b/src/components/pressable-feedback/pressable-feedback.animation.ts
@@ -160,6 +160,29 @@ export function usePressableFeedbackRootAnimation(options: {
     return currentDiagonal > 0 ? currentDiagonal / baseDiagonal : 1;
   });
 
+  /**
+   * Resets the pressable feedback animation state to idle.
+   * For ripple variant, triggers the fade-out animation phase.
+   * This is a worklet that runs on the UI thread.
+   */
+  function resetAnimationState() {
+    'worklet';
+
+    isPressed.set(false);
+    scale.set(withTiming(0, scaleTimingConfig));
+
+    if (variant === 'highlight') return;
+
+    const adjustedDuration = Math.min(
+      Math.max(
+        rippleProgressBaseDuration * durationCoefficient.get(),
+        rippleProgressMinBaseDuration
+      ),
+      rippleProgressBaseDuration * 2
+    );
+    rippleProgress.set(withTiming(2, { duration: adjustedDuration }));
+  }
+
   // Gesture handling
   const gesture = Gesture.Tap()
     .maxDuration(30000)
@@ -184,17 +207,11 @@ export function usePressableFeedbackRootAnimation(options: {
       }
     })
     .onFinalize(() => {
-      isPressed.set(false);
-      scale.set(withTiming(0, scaleTimingConfig));
-      if (variant === 'highlight') return;
-      const adjustedDuration = Math.min(
-        Math.max(
-          rippleProgressBaseDuration * durationCoefficient.get(),
-          rippleProgressMinBaseDuration
-        ),
-        rippleProgressBaseDuration * 2
-      );
-      rippleProgress.set(withTiming(2, { duration: adjustedDuration }));
+      resetAnimationState();
+    })
+    .onTouchesCancelled(() => {
+      if (!isPressed.get()) return;
+      resetAnimationState();
     });
 
   const styleTransform = getStyleTransform(style);


### PR DESCRIPTION
Closes #131 

## 📝 Description

This PR fixes an issue where the pressable feedback animation state wasn't properly reset when scroll gestures cancelled touch events. The fix extracts animation reset logic into a reusable worklet function and adds a `onTouchesCancelled` handler to ensure clean state management during scroll interactions.

## ⛳️ Current behavior (updates)

When users scroll over pressable components, touch cancellation events leave the animation in a pressed state, causing visual glitches and incorrect animation behavior.

## 🚀 New behavior

- Animation state properly resets when touches are cancelled (e.g., during scrolling)
- Extracted `resetAnimationState()` worklet for code reusability
- Both `onFinalize` and `onTouchesCancelled` handlers now use the same reset logic
- Ripple and highlight variants correctly fade out when interrupted

## 💣 Is this a breaking change (Yes/No):

**No** - This is a bug fix that improves existing animation behavior without changing the public API or requiring any code changes from library users.

## 📝 Additional Information

The fix addresses the scroll interaction issue reported in the codebase by properly handling the `onTouchesCancelled` gesture event. All animation timing calculations and visual effects remain unchanged, ensuring backward compatibility.