### PR TITLE
fix(checkbox): style issue on invalid state change

### DIFF
--- a/src/components/checkbox/checkbox.styles.ts
+++ b/src/components/checkbox/checkbox.styles.ts
@@ -18,15 +18,15 @@ const root = tv({
       false: '',
     },
     isInvalid: {
-      true: '',
-      false: '',
+      true: 'border border-danger',
+      false: 'border-0',
     },
   },
   compoundVariants: [
     {
       isSelected: false,
       isInvalid: true,
-      className: 'bg-transparent border border-danger',
+      className: 'bg-transparent',
     },
   ],
   defaultVariants: {


### PR DESCRIPTION
## 📝 Description

Fixed a styling bug in the Checkbox component where the indicator could disappear completely on Android during invalid state changes. The fix ensures proper border handling by explicitly setting `border-0` for valid states and moving border logic from compound variants to base variants.

## ⛳️ Current behavior (updates)

On Android, the checkbox indicator can disappear entirely when the `isInvalid` state changes, making the component unusable in invalid states.

## 🚀 New behavior

- Checkbox indicator remains visible on Android during all state transitions
- Invalid state consistently shows `border-danger` styling
- Valid state explicitly applies `border-0` to prevent Android rendering issues
- Border styling moved from compound variant to base `isInvalid` variant for proper state handling

## 💣 Is this a breaking change (Yes/No):

**No** - This is a platform-specific bug fix that corrects Android rendering behavior without changing the component API or functionality on other platforms.

## 📝 Additional Information

The `border-0` declaration on valid states is required due to an Android-specific rendering quirk where border state changes can cause the indicator to disappear. The refactored variant structure ensures consistent cross-platform behavior.