### PR TITLE
refactor/divider

### DIFF
--- a/src/components/divider/divider.constants.ts
+++ b/src/components/divider/divider.constants.ts
@@ -4,8 +4,3 @@
 export const DISPLAY_NAME = {
   ROOT: 'HeroUINative.Divider.Root',
 } as const;
-
-/**
- * Default thickness for the thick variant (in pixels)
- */
-export const THICK_VARIANT_HEIGHT = 6;

--- a/src/components/divider/divider.styles.ts
+++ b/src/components/divider/divider.styles.ts
@@ -1,6 +1,4 @@
-import { StyleSheet } from 'react-native';
 import { tv } from 'tailwind-variants';
-import { combineStyles } from '../../helpers/theme/utils/combine-styles';
 
 const root = tv({
   base: 'bg-divider',
@@ -14,23 +12,36 @@ const root = tv({
       vertical: 'h-full',
     },
   },
+  compoundVariants: [
+    // Thin variant - horizontal orientation
+    {
+      variant: 'thin',
+      orientation: 'horizontal',
+      className: 'h-hairline',
+    },
+    // Thin variant - vertical orientation
+    {
+      variant: 'thin',
+      orientation: 'vertical',
+      className: 'w-hairline',
+    },
+    // Thick variant - horizontal orientation
+    {
+      variant: 'thick',
+      orientation: 'horizontal',
+      className: `h-[6px]`,
+    },
+    // Thick variant - vertical orientation
+    {
+      variant: 'thick',
+      orientation: 'vertical',
+      className: `w-[6px]`,
+    },
+  ],
   defaultVariants: {
     variant: 'thin',
     orientation: 'horizontal',
   },
 });
 
-export const styleSheet = StyleSheet.create({
-  hairlineWidth: {
-    height: StyleSheet.hairlineWidth,
-  },
-  hairlineWidthVertical: {
-    width: StyleSheet.hairlineWidth,
-  },
-});
-
-const dividerStyles = combineStyles({
-  root,
-});
-
-export default dividerStyles;
+export default root;

--- a/src/components/divider/divider.tsx
+++ b/src/components/divider/divider.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from 'react';
 import { View } from 'react-native';
-import { DISPLAY_NAME, THICK_VARIANT_HEIGHT } from './divider.constants';
-import dividerStyles, { styleSheet } from './divider.styles';
+import { DISPLAY_NAME } from './divider.constants';
+import dividerStyles from './divider.styles';
 import type { DividerProps } from './divider.types';
 
 // --------------------------------------------------
@@ -16,39 +16,28 @@ const DividerRoot = forwardRef<View, DividerProps>((props, ref) => {
     ...restProps
   } = props;
 
-  const tvStyles = dividerStyles.root({
+  const tvStyles = dividerStyles({
     variant,
     orientation,
     className,
   });
 
-  const thicknessStyles = (() => {
-    if (thickness !== undefined) {
-      return orientation === 'horizontal'
+  /**
+   * Custom thickness handling: when thickness prop is provided,
+   * override the variant-based thickness with inline styles
+   */
+  const customThicknessStyle =
+    thickness !== undefined
+      ? orientation === 'horizontal'
         ? { height: thickness }
-        : { width: thickness };
-    }
-
-    if (variant === 'thin') {
-      return orientation === 'horizontal'
-        ? styleSheet.hairlineWidth
-        : styleSheet.hairlineWidthVertical;
-    }
-
-    if (variant === 'thick') {
-      return orientation === 'horizontal'
-        ? { height: THICK_VARIANT_HEIGHT }
-        : { width: THICK_VARIANT_HEIGHT };
-    }
-
-    return {};
-  })();
+        : { width: thickness }
+      : undefined;
 
   return (
     <View
       ref={ref}
       className={tvStyles}
-      style={[thicknessStyles, style]}
+      style={customThicknessStyle ? [customThicknessStyle, style] : style}
       {...restProps}
     />
   );
@@ -63,7 +52,8 @@ DividerRoot.displayName = DISPLAY_NAME.ROOT;
  *
  * @component Divider - A simple line to separate content visually.
  * Supports horizontal and vertical orientations with thin and thick variants.
- * Uses StyleSheet.hairlineWidth for the thin variant by default.
+ * Uses hairline width utility classes for the thin variant by default.
+ * Custom thickness can be provided via the thickness prop to override variant-based sizing.
  *
  * @see Full documentation: https://heroui.com/components/divider
  */

--- a/src/components/divider/divider.types.ts
+++ b/src/components/divider/divider.types.ts
@@ -30,7 +30,6 @@ export interface DividerProps extends ViewProps {
 
   /**
    * Custom thickness of the divider. This controls the height (for horizontal) or width (for vertical) of the divider.
-   * Note: Setting height via className will not work - use this prop instead.
    */
   thickness?: number;
 


### PR DESCRIPTION
## 📝 Description

Refactors the Divider component to use pure Tailwind Variants with compoundVariants instead of StyleSheet-based styling. This simplifies the implementation by removing StyleSheet dependencies and consolidating variant logic into Tailwind's variant system.

## ⛳️ Current behavior (updates)

The Divider component uses React Native's StyleSheet for hairline width calculations and a constant for thick variant height, requiring manual style combination logic in the component.

## 🚀 New behavior

- Replaced StyleSheet-based styling with Tailwind Variants compoundVariants
- Thin and thick variants now handled via Tailwind utility classes (`h-hairline`, `w-hairline`, `h-[6px]`, `w-[6px]`)
- Simplified component logic by removing complex thickness calculation function
- Removed `THICK_VARIANT_HEIGHT` constant and `styleSheet` exports
- Custom thickness prop still works via inline styles when provided

## 💣 Is this a breaking change (Yes/No):

**No** - The component API remains unchanged and all existing props work identically. Only internal implementation details were refactored.

## 📝 Additional Information

This refactoring improves maintainability by aligning with the library's Tailwind-first approach and reduces bundle size by removing StyleSheet dependencies. All variant combinations (thin/thick × horizontal/vertical) are now handled declaratively through compoundVariants.