### PR TITLE
fix: replace Pressable with Touchable opacity

### DIFF
--- a/example/src/components/theme-toggle.tsx
+++ b/example/src/components/theme-toggle.tsx
@@ -1,14 +1,17 @@
 import { Ionicons } from '@expo/vector-icons';
+
 import { isLiquidGlassAvailable } from 'expo-glass-effect';
 import * as Haptics from 'expo-haptics';
 import { cn } from 'heroui-native';
 import { type FC } from 'react';
-import { Platform, Pressable } from 'react-native';
+import { Platform } from 'react-native';
+import { TouchableOpacity } from 'react-native-gesture-handler';
 import Animated, { FadeOut, ZoomIn } from 'react-native-reanimated';
 import { withUniwind } from 'uniwind';
 import { useAppTheme } from '../contexts/app-theme-context';
 
 const StyledIonicons = withUniwind(Ionicons);
+const StyledTouchableOpacity = withUniwind(TouchableOpacity);
 
 export const ThemeToggle: FC = () => {
   const { toggleTheme, isLight } = useAppTheme();
@@ -16,7 +19,8 @@ export const ThemeToggle: FC = () => {
   const isLGAvailable = isLiquidGlassAvailable();
 
   return (
-    <Pressable
+    <StyledTouchableOpacity
+      activeOpacity={1}
       onPress={() => {
         if (Platform.OS === 'ios') {
           Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
@@ -34,6 +38,6 @@ export const ThemeToggle: FC = () => {
           <StyledIonicons name="sunny" size={20} className="text-white" />
         </Animated.View>
       )}
-    </Pressable>
+    </StyledTouchableOpacity>
   );
 };


### PR DESCRIPTION
## 📝 Description

Replace Pressable with TouchableOpacity from react-native-gesture handler as on Samsung devices theme toggle is not working

## ⛳️ Current behavior (updates)

Theme Toggle not working on Samsung Devices

https://github.com/user-attachments/assets/0c1bb9ec-2723-4a39-8d5d-c218700e0e55


## 🚀 New behavior

https://github.com/user-attachments/assets/2c36ba9d-b9d3-40f2-a13b-ab835722c89b


## 💣 Is this a breaking change (No):


## 📝 Additional Information
NA
