### PR TITLE
fix(theme-toggle): incorrect padding y

### DIFF
--- a/example/src/components/theme-toggle.tsx
+++ b/example/src/components/theme-toggle.tsx
@@ -27,7 +27,7 @@ export const ThemeToggle: FC = () => {
         }
         toggleTheme();
       }}
-      className={cn('p-3', isLGAvailable && 'px-2.5 py-0')}
+      className={cn('p-3', isLGAvailable && 'px-2.5 py-2')}
     >
       {isLight ? (
         <Animated.View key="moon" entering={ZoomIn} exiting={FadeOut}>


### PR DESCRIPTION
## 📝 Description

Fixed incorrect padding on iOS devices if liquid glass available

## ⛳️ Current behavior (updates)

<img width="606" height="208" alt="hi" src="https://github.com/user-attachments/assets/d6d3653a-89a0-4f93-b2e1-4c23cee5a8f3" />

## 🚀 New behavior

<img width="588" height="222" alt="hi" src="https://github.com/user-attachments/assets/ca03d1a1-7233-485a-b81f-c5ce77c0c33e" />

## 💣 Is this a breaking change (Yes/No):

No
