### PR TITLE
docs: update @source path for relative path

### DIFF
--- a/src/styles/theme.md
+++ b/src/styles/theme.md
@@ -20,9 +20,16 @@ Inside your `global.css` file add the following imports:
 
 @import 'heroui-native/styles';
 
-// Path to the heroui-native lib inside node_modules from the root of your project
-@source './node_modules/heroui-native/lib';
+@source '<path-to-node_modules>/heroui-native/lib';
 ```
+
+**Important:** The `@source` path is **relative to your CSS file location**, not the project root.
+
+| `global.css` location | `@source` path |
+|----------------------|----------------|
+| `./global.css` (root) | `@source './node_modules/heroui-native/lib';` |
+| `./app/global.css` | `@source '../node_modules/heroui-native/lib';` |
+| `./src/global.css` | `@source '../node_modules/heroui-native/lib';` |
 
 ## Theme Structure
 


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

Closes # <!-- Github issue # here -->

## 📝 Description

Improves documentation for the @source directive in the theming setup guide by clarifying that the path is relative to the CSS file location, not the project root. Added a reference table with common global.css locations and their corresponding @source paths.


## ⛳️ Current behavior (updates)

The documentation previously showed a hardcoded example path `(./node_modules/heroui-native/lib)` without explaining that this path is relative to where the global.css file is located. This could lead to confusion for users who place their global.css in different directories `(e.g., ./app/global.css or ./src/global.css)`, causing the @source directive to fail silently.

## 🚀 New behavior

Changed the example to use a placeholder path `(<path-to-node_modules>)` making it clear that users need to adjust it
Added an Important note explaining that the @source path is relative to the CSS file location
Added a reference table with common configurations:
| global.css location | @source path |
|----------------------|----------------|
| ./global.css (root) | @source './node_modules/heroui-native/lib'; |
| ./app/global.css | @source '../node_modules/heroui-native/lib'; |
| ./src/global.css | @source '../node_modules/heroui-native/lib'; |

## 💣 Is this a breaking change (Yes/No):

No - This is a documentation-only change.

## 📝 Additional Information
This addresses potential setup issues where users might copy the example path directly without realizing they need to adjust it based on their project structure.
