### PR TITLE
Popup controlled state fix

### DIFF
--- a/src/primitives/popover/popover.tsx
+++ b/src/primitives/popover/popover.tsx
@@ -138,13 +138,15 @@ const Trigger = forwardRef<TriggerRef, TriggerProps>(
 
     // Open popover on mount if isDefaultOpen is true
     useEffect(() => {
-      if (isDefaultOpen && !triggerPosition) {
+      if ((isDefaultOpen || isOpen) && !triggerPosition) {
         // Use setTimeout to ensure the component is mounted and can be measured
         const timeoutId = setTimeout(() => {
           augmentedRef.current?.measure(
             (_x, _y, width, height, pageX, pageY) => {
               setTriggerPosition({ width, pageX, pageY: pageY, height });
-              onOpenChange(true);
+              if (isDefaultOpen) {
+                onOpenChange(true);
+              }
             }
           );
         }, 0);


### PR DESCRIPTION
## 📝 Description

Fixes controlled Popover components not properly measuring and positioning on mount when `isOpen` is set externally. The component now correctly handles both controlled (`isOpen`) and uncontrolled (`isDefaultOpen`) scenarios during initial render.

## ⛳️ Current behavior (updates)

Controlled Popovers with `isOpen` prop set to `true` do not measure trigger position or position content on mount, causing layout issues.

## 🚀 New behavior

- Popover now measures trigger position when either `isDefaultOpen` or `isOpen` is true on mount
- `onOpenChange` callback only fires for `isDefaultOpen` to prevent double-triggering in controlled mode
- Controlled Popovers now properly position content on initial render

## 💣 Is this a breaking change (Yes/No):

**No** - This is a bug fix that improves controlled Popover behavior without changing the API or expected behavior.

## 📝 Additional Information

The fix ensures controlled Popovers measure and position correctly without interfering with external state management. No new dependencies or performance impacts.