### PR TITLE
HeroUINativeProvider devInfo configs

### DIFF
--- a/example/src/app/_layout.tsx
+++ b/example/src/app/_layout.tsx
@@ -52,6 +52,9 @@ function AppContent() {
           toast: {
             contentWrapper,
           },
+          devInfo: {
+            stylingPrinciples: false,
+          },
         }}
       >
         <Slot />

--- a/src/providers/hero-ui-native/provider.md
+++ b/src/providers/hero-ui-native/provider.md
@@ -81,6 +81,23 @@ const config: HeroUINativeConfig = {
   **Note**: When set to `'disable-all'`, all animations across the application will be disabled. This is useful for accessibility or performance optimization.
 </Callout>
 
+### Developer Information Configuration
+
+Control developer-facing informational messages displayed in the console:
+
+```tsx
+const config: HeroUINativeConfig = {
+  devInfo: {
+    // Disable styling principles information message
+    stylingPrinciples: false,
+  },
+};
+```
+
+<Callout type="info">
+  **Note**: By default, informational messages are enabled. Set `stylingPrinciples: false` to disable the styling principles message that appears in the console during development.
+</Callout>
+
 ### Toast Configuration
 
 Configure the global toast system including insets, default props, and wrapper components:
@@ -139,6 +156,10 @@ const config: HeroUINativeConfig = {
   },
   // Global animation configuration
   animation: 'disable-all', // Optional: disable all animations
+  // Developer information messages configuration
+  devInfo: {
+    stylingPrinciples: true, // Optional: disable styling principles message
+  },
   // Global toast configuration
   toast: {
     defaultProps: {
@@ -299,6 +320,9 @@ const config: HeroUINativeConfig = {
     maxFontSizeMultiplier: 1.5,
   },
   animation: 'disable-all', // Optional: disable all animations
+  devInfo: {
+    stylingPrinciples: true, // Optional: disable styling principles message
+  },
   toast: {
     defaultProps: {
       variant: 'default',

--- a/src/providers/hero-ui-native/provider.tsx
+++ b/src/providers/hero-ui-native/provider.tsx
@@ -9,6 +9,7 @@ import type { HeroUINativeProviderProps } from './types';
 
 const LOG_COLOR = {
   BLUE: '\x1b[34m',
+  YELLOW: '\x1b[33m',
   RESET: '\x1b[0m',
 };
 
@@ -35,11 +36,12 @@ export const HeroUINativeProvider: React.FC<HeroUINativeProviderProps> = ({
   children,
   config = {},
 }) => {
-  const { textProps, toast, animation } = config;
+  const { textProps, toast, animation, devInfo } = config;
   const { ...toastProps } = toast || {};
+  const { stylingPrinciples = true } = devInfo || {};
 
   useEffect(() => {
-    if (__DEV__) {
+    if (__DEV__ && stylingPrinciples) {
       console.info(
         `${LOG_COLOR.BLUE}HeroUI Native Styling Principles${LOG_COLOR.RESET}\n` +
           `• className: this is your go-to styling solution. Use Tailwind CSS classes via className prop on all components.\n` +
@@ -48,10 +50,11 @@ export const HeroUINativeProvider: React.FC<HeroUINativeProviderProps> = ({
           `  - Hover over className in your IDE - TypeScript definitions show which properties are occupied by animated styles\n` +
           `  - Check component documentation - Each component page includes a link to the component's style source\n` +
           `• If styles are occupied by animation, modify them via the animation prop on components that support it.\n` +
-          `• To deactivate animated style completely and apply your own styles, use isAnimatedStyleActive prop.`
+          `• To deactivate animated style completely and apply your own styles, use isAnimatedStyleActive prop.\n` +
+          `${LOG_COLOR.YELLOW}💡 To disable this message, set HeroUINativeProvider config.devInfo.stylingPrinciples to false${LOG_COLOR.RESET}`
       );
     }
-  }, []);
+  }, [stylingPrinciples]);
 
   return (
     <SafeAreaListener

--- a/src/providers/hero-ui-native/types.ts
+++ b/src/providers/hero-ui-native/types.ts
@@ -4,6 +4,28 @@ import type { TextComponentContextValue } from '../text-component/types';
 import type { ToastProviderProps } from '../toast/types';
 
 /**
+ * Developer information messages configuration
+ *
+ * @interface DevInfoConfig
+ *
+ * @description
+ * Controls developer-facing informational messages displayed in the console.
+ * These messages provide important guidance and best practices.
+ */
+export interface DevInfoConfig {
+  /**
+   * Show styling principles information message
+   *
+   * @description
+   * When set to `false`, disables the styling principles information message
+   * that appears in the console during development.
+   *
+   * @default true
+   */
+  stylingPrinciples?: boolean;
+}
+
+/**
  * Configuration object for HeroUINativeProvider
  *
  * @interface HeroUINativeConfig
@@ -28,6 +50,14 @@ export interface HeroUINativeConfig extends TextComponentContextValue {
    * Configure the global toast system including insets and wrapper components.
    */
   toast?: ToastProviderProps;
+  /**
+   * Developer information messages configuration
+   *
+   * @description
+   * Controls developer-facing informational messages displayed in the console.
+   * Use this to disable specific informational messages during development.
+   */
+  devInfo?: DevInfoConfig;
 }
 
 /**


### PR DESCRIPTION
## 📝 Description

Adds a new `devInfo` configuration option to `HeroUINativeProvider` that allows developers to disable the styling principles console message. This provides better control over developer-facing informational messages during development.

## ⛳️ Current behavior (updates)

The styling principles information message is always displayed in the console during development when `__DEV__` is true, providing guidance on using className, style prop, and animation props.

## 🚀 New behavior

- Added `devInfo.stylingPrinciples` configuration option (defaults to `true`)
- Developers can now disable the styling principles console message by setting `config.devInfo.stylingPrinciples = false`
- Console message now includes a tip showing how to disable it
- Added TypeScript types for `DevInfoConfig` interface

## 💣 Is this a breaking change (Yes/No):

**No** - The new configuration option is optional and defaults to `true`, maintaining backward compatibility. Existing code will continue to work without any changes.

## 📝 Additional Information

The implementation adds a new `DevInfoConfig` interface to support future developer information message controls. Documentation has been updated to reflect the new configuration option with examples.