### PR TITLE
Component border radius fix

### DIFF
--- a/src/components/button/button.styles.ts
+++ b/src/components/button/button.styles.ts
@@ -22,7 +22,7 @@ import { combineStyles } from '../../helpers/theme/utils/combine-styles';
  * set `isAnimatedStyleActive={false}` on `PressableFeedback`.
  */
 const root = tv({
-  base: 'flex-row items-center justify-center rounded-full',
+  base: 'flex-row items-center justify-center',
   variants: {
     variant: {
       primary: 'bg-accent',
@@ -33,9 +33,9 @@ const root = tv({
       ['danger-soft']: 'bg-danger-soft',
     },
     size: {
-      sm: 'h-[36px] px-3.5 gap-1.5',
-      md: 'h-[48px] px-4 gap-2',
-      lg: 'h-[56px] px-5 gap-2.5',
+      sm: 'h-[36px] px-3.5 gap-1.5 rounded-2xl',
+      md: 'h-[48px] px-4 gap-2 rounded-3xl',
+      lg: 'h-[56px] px-5 gap-2.5 rounded-4xl',
     },
     isIconOnly: {
       true: 'p-0 aspect-square',

--- a/src/components/chip/chip.styles.ts
+++ b/src/components/chip/chip.styles.ts
@@ -3,7 +3,7 @@ import { tv } from 'tailwind-variants';
 import { combineStyles } from '../../helpers/theme/utils/combine-styles';
 
 const root = tv({
-  base: 'self-start flex-row items-center justify-center rounded-full gap-1 overflow-hidden',
+  base: 'self-start flex-row items-center justify-center gap-1 overflow-hidden',
   variants: {
     variant: {
       primary: 'border-0',
@@ -12,9 +12,9 @@ const root = tv({
       soft: 'border-0',
     },
     size: {
-      sm: 'px-2 h-5',
-      md: 'px-3 h-6',
-      lg: 'px-4 h-7',
+      sm: 'px-2 h-5 rounded-xl',
+      md: 'px-3 h-6 rounded-xl',
+      lg: 'px-4 h-7 rounded-2xl',
     },
     color: {
       accent: '',

--- a/src/components/tabs/tabs.styles.ts
+++ b/src/components/tabs/tabs.styles.ts
@@ -10,7 +10,7 @@ const list = tv({
   base: 'self-start flex-row items-center gap-1',
   variants: {
     variant: {
-      pill: 'rounded-full bg-default p-[3px]',
+      pill: 'rounded-3xl bg-default p-[3px]',
       line: 'border-b border-border',
     },
   },
@@ -23,7 +23,7 @@ const scrollView = tv({
   base: '',
   variants: {
     variant: {
-      pill: 'rounded-full',
+      pill: 'rounded-3xl',
       line: '',
     },
   },
@@ -90,7 +90,7 @@ const indicator = tv({
   base: 'absolute',
   variants: {
     variant: {
-      pill: 'rounded-full shadow-sm dark:shadow-none shadow-black/5 bg-segment',
+      pill: 'rounded-3xl shadow-sm dark:shadow-none shadow-black/5 bg-segment',
       line: 'border-b-2 border-accent bottom-0',
     },
   },


### PR DESCRIPTION
## 📝 Description

Refines border radius styling across Button, Chip, and Tabs components by replacing uniform `rounded-full` with size-specific rounded corners. This provides more granular control and better visual hierarchy based on component size.

## ⛳️ Current behavior (updates)

All components currently use `rounded-full` for border radius, which applies the same maximum rounding regardless of component size.

## 🚀 New behavior

- **Button**: Size-specific rounded corners (`rounded-2xl` for sm, `rounded-3xl` for md, `rounded-4xl` for lg)
- **Chip**: Size-specific rounded corners (`rounded-xl` for sm/md, `rounded-2xl` for lg)
- **Tabs**: Changed pill variant from `rounded-full` to `rounded-3xl` for list, scrollView, and indicator elements

## 💣 Is this a breaking change (Yes/No):

**No** - This is a visual styling refinement that maintains component functionality while improving visual consistency across different sizes.

## 📝 Additional Information

No dependencies were added or removed. The changes are purely CSS class modifications and maintain backward compatibility with existing component APIs.