### PR TITLE
fix: prevent react elements from being stringified in childrenToString

### DIFF
--- a/src/helpers/utils/children-to-string.ts
+++ b/src/helpers/utils/children-to-string.ts
@@ -2,6 +2,29 @@ import { Children, isValidElement, type ReactNode } from 'react';
 import type { SharedValue } from 'react-native-reanimated';
 
 /**
+ * Recursively checks if children contain any React elements.
+ * Used to determine if children can be stringified.
+ *
+ * @param children - React children to check
+ * @returns True if children contain React elements, false otherwise
+ */
+function hasReactElements(children: ReactNode): boolean {
+  if (children == null || typeof children === 'boolean') {
+    return false;
+  }
+
+  if (isValidElement(children)) {
+    return true;
+  }
+
+  if (Array.isArray(children)) {
+    return children.some((child) => hasReactElements(child));
+  }
+
+  return false;
+}
+
+/**
  * Converts React children to a string representation.
  * Handles cases where children might be an array of mixed types (strings, numbers, variables).
  *
@@ -31,21 +54,33 @@ export function childrenToString(
     return null;
   }
 
+  // Check if children is a React element - if so, cannot be stringified
+  if (isValidElement(children)) {
+    return null;
+  }
+
   // Handle array of children (e.g., {someVar} text)
   if (Array.isArray(children)) {
+    // Check if array contains any React elements - if so, cannot be stringified
+    // This handles cases where conditional children create arrays with React elements
+    if (hasReactElements(children)) {
+      return null;
+    }
+
     const stringified = children
       .map((child) => {
         // Recursively handle each child
         if (typeof child === 'string' || typeof child === 'number') {
           return String(child);
         }
-        // Skip React elements, booleans, null, undefined
-        if (
-          isValidElement(child) ||
-          child == null ||
-          typeof child === 'boolean'
-        ) {
+        // Skip booleans, null, undefined
+        if (child == null || typeof child === 'boolean') {
           return '';
+        }
+        // Recursively process nested arrays (only if they don't contain React elements)
+        if (Array.isArray(child)) {
+          const nested = childrenToString(child);
+          return nested ?? '';
         }
         return String(child);
       })
@@ -58,6 +93,10 @@ export function childrenToString(
   try {
     const childArray = Children.toArray(children as ReactNode);
     if (childArray.length > 0) {
+      // Check if any children are React elements
+      if (hasReactElements(childArray)) {
+        return null;
+      }
       return childrenToString(childArray);
     }
   } catch {


### PR DESCRIPTION
## 📝 Description

Enhances the `childrenToString` utility function to properly detect and skip React elements during string conversion. Adds a recursive `hasReactElements` helper function to check for React elements in nested children structures, preventing incorrect stringification that could cause rendering issues.

## ⛳️ Current behavior (updates)

The `childrenToString` function attempts to convert React children to strings but may incorrectly process React elements in certain scenarios, particularly when dealing with conditional children or nested arrays containing React components.

## 🚀 New behavior

- Added `hasReactElements` helper function that recursively checks for React elements in children
- Enhanced `childrenToString` to detect React elements directly and return `null` instead of stringifying them
- Improved array handling to check for React elements before processing nested arrays
- Added recursive processing for nested arrays while ensuring React elements are properly skipped

## 💣 Is this a breaking change (Yes/No):

**No** - This change fixes incorrect behavior by preventing React elements from being stringified. The function now correctly returns `null` when React elements are detected, which is the expected behavior for components that cannot be converted to strings.

## 📝 Additional Information

The changes improve type safety and prevent potential runtime errors when React elements are passed to components expecting string children. The recursive checking ensures proper handling of complex nested children structures including conditional rendering scenarios.