### PR TITLE
refactor(tabs): migrate indicator animation to translateX transforms

### DIFF
--- a/src/components/tabs/tabs.animation.ts
+++ b/src/components/tabs/tabs.animation.ts
@@ -40,7 +40,7 @@ export function useTabsRootAnimation(options: {
 
 /**
  * Animation hook for Tabs Indicator component
- * Handles width, height, left position, and opacity animations
+ * Handles width, height, translateX position, and opacity animations
  */
 export function useTabsIndicatorAnimation(options: {
   animation: TabsIndicatorAnimation | undefined;
@@ -99,14 +99,14 @@ export function useTabsIndicatorAnimation(options: {
   // Get animation configs for each property
   const widthConfig = getPropertyConfig(animationConfig?.width);
   const heightConfig = getPropertyConfig(animationConfig?.height);
-  const leftConfig = getPropertyConfig(animationConfig?.left);
+  const translateXConfig = getPropertyConfig(animationConfig?.translateX);
 
   const rContainerStyle = useAnimatedStyle(() => {
     if (!activeMeasurements) {
       return {
         width: 0,
         height: 0,
-        left: 0,
+        transform: [{ translateX: 0 }],
         opacity: 0,
       };
     }
@@ -116,7 +116,7 @@ export function useTabsIndicatorAnimation(options: {
       return {
         width: activeMeasurements.width,
         height: activeMeasurements.height,
-        left: activeMeasurements.x,
+        transform: [{ translateX: activeMeasurements.x }],
         opacity: 1,
       };
     }
@@ -126,7 +126,7 @@ export function useTabsIndicatorAnimation(options: {
       return {
         width: activeMeasurements.width,
         height: activeMeasurements.height,
-        left: activeMeasurements.x,
+        transform: [{ translateX: activeMeasurements.x }],
         opacity: 1,
       };
     }
@@ -142,15 +142,15 @@ export function useTabsIndicatorAnimation(options: {
         ? withTiming(activeMeasurements.height, heightConfig.timingConfig)
         : withSpring(activeMeasurements.height, heightConfig.springConfig);
 
-    const leftAnimation =
-      leftConfig.type === 'timing'
-        ? withTiming(activeMeasurements.x, leftConfig.timingConfig)
-        : withSpring(activeMeasurements.x, leftConfig.springConfig);
+    const translateXAnimation =
+      translateXConfig.type === 'timing'
+        ? withTiming(activeMeasurements.x, translateXConfig.timingConfig)
+        : withSpring(activeMeasurements.x, translateXConfig.springConfig);
 
     return {
       width: widthAnimation,
       height: heightAnimation,
-      left: leftAnimation,
+      transform: [{ translateX: translateXAnimation }],
       opacity: 1,
     };
   }, [
@@ -158,7 +158,7 @@ export function useTabsIndicatorAnimation(options: {
     isAnimationDisabledValue,
     widthConfig,
     heightConfig,
-    leftConfig,
+    translateXConfig,
   ]);
 
   return {

--- a/src/components/tabs/tabs.md
+++ b/src/components/tabs/tabs.md
@@ -315,7 +315,7 @@ export default function TabsExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/beta/example/src/app/(home)/components/tabs.tsx).
+You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/beta/example/src/app/(home)/components/tabs.tsx>).
 
 ## API Reference
 
@@ -395,15 +395,15 @@ Animation configuration for Tabs.Indicator component. Can be:
 - `true` or `undefined`: Use default animations
 - `object`: Custom animation configuration
 
-| prop            | type                                   | default                                                                      | description                                     |
-| --------------- | -------------------------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------- |
-| `state`         | `'disabled' \| boolean`                | -                                                                            | Disable animations while customizing properties |
-| `width.type`    | `'spring' \| 'timing'`                 | `'spring'`                                                                   | Type of animation to use                        |
-| `width.config`  | `WithSpringConfig \| WithTimingConfig` | `{ stiffness: 1200, damping: 120 }` (spring) or `{ duration: 200 }` (timing) | Reanimated animation configuration              |
-| `height.type`   | `'spring' \| 'timing'`                 | `'spring'`                                                                   | Type of animation to use                        |
-| `height.config` | `WithSpringConfig \| WithTimingConfig` | `{ stiffness: 1200, damping: 120 }` (spring) or `{ duration: 200 }` (timing) | Reanimated animation configuration              |
-| `left.type`     | `'spring' \| 'timing'`                 | `'spring'`                                                                   | Type of animation to use                        |
-| `left.config`   | `WithSpringConfig \| WithTimingConfig` | `{ stiffness: 1200, damping: 120 }` (spring) or `{ duration: 200 }` (timing) | Reanimated animation configuration              |
+| prop                | type                                   | default                                                                      | description                                     |
+| ------------------- | -------------------------------------- | ---------------------------------------------------------------------------- | ----------------------------------------------- |
+| `state`             | `'disabled' \| boolean`                | -                                                                            | Disable animations while customizing properties |
+| `width.type`        | `'spring' \| 'timing'`                 | `'spring'`                                                                   | Type of animation to use                        |
+| `width.config`      | `WithSpringConfig \| WithTimingConfig` | `{ stiffness: 1200, damping: 120 }` (spring) or `{ duration: 200 }` (timing) | Reanimated animation configuration              |
+| `height.type`       | `'spring' \| 'timing'`                 | `'spring'`                                                                   | Type of animation to use                        |
+| `height.config`     | `WithSpringConfig \| WithTimingConfig` | `{ stiffness: 1200, damping: 120 }` (spring) or `{ duration: 200 }` (timing) | Reanimated animation configuration              |
+| `translateX.type`   | `'spring' \| 'timing'`                 | `'spring'`                                                                   | Type of animation to use                        |
+| `translateX.config` | `WithSpringConfig \| WithTimingConfig` | `{ stiffness: 1200, damping: 120 }` (spring) or `{ duration: 200 }` (timing) | Reanimated animation configuration              |
 
 ### Tabs.Content
 

--- a/src/components/tabs/tabs.styles.ts
+++ b/src/components/tabs/tabs.styles.ts
@@ -69,7 +69,7 @@ const label = tv({
  * The following properties are animated and cannot be overridden using Tailwind classes:
  * - `width` - Animated for indicator width transitions when switching tabs
  * - `height` - Animated for indicator height transitions when switching tabs
- * - `left` - Animated for indicator position transitions when switching tabs
+ * - `translateX` - Animated for indicator position transitions when switching tabs (uses translateX for GPU-accelerated performance)
  * - `opacity` - Animated for indicator visibility transitions (0 when no active tab, 1 when active tab is selected)
  *
  * To customize these properties, use the `animation` prop on `Tabs.Indicator`:
@@ -78,7 +78,7 @@ const label = tv({
  *   animation={{
  *     width: { type: 'spring', config: { stiffness: 1200, damping: 120 } },
  *     height: { type: 'spring', config: { stiffness: 1200, damping: 120 } },
- *     left: { type: 'timing', config: { duration: 200 } }
+ *     translateX: { type: 'timing', config: { duration: 200 } }
  *   }}
  * />
  * ```
@@ -87,7 +87,7 @@ const label = tv({
  * set `isAnimatedStyleActive={false}` on `Tabs.Indicator`.
  */
 const indicator = tv({
-  base: 'absolute',
+  base: 'absolute left-0',
   variants: {
     variant: {
       pill: 'rounded-3xl shadow-sm dark:shadow-none shadow-black/5 bg-segment',

--- a/src/components/tabs/tabs.types.ts
+++ b/src/components/tabs/tabs.types.ts
@@ -155,7 +155,7 @@ type TabsIndicatorTimingAnimationValue = AnimationValue<{
 }>;
 
 /**
- * Animation value for tabs indicator properties (width, height, left)
+ * Animation value for tabs indicator properties (width, height, translateX)
  */
 type TabsIndicatorPropertyAnimationValue =
   | TabsIndicatorSpringAnimationValue
@@ -174,9 +174,10 @@ export type TabsIndicatorAnimation = Animation<{
    */
   height?: TabsIndicatorPropertyAnimationValue;
   /**
-   * Left position animation configuration
+   * TranslateX animation configuration
+   * Controls the horizontal position animation using GPU-accelerated transforms
    */
-  left?: TabsIndicatorPropertyAnimationValue;
+  translateX?: TabsIndicatorPropertyAnimationValue;
 }>;
 
 /**
@@ -189,7 +190,7 @@ export interface TabsIndicatorProps extends TabsPrimitivesTypes.IndicatorProps {
    * @note The following style properties are occupied by animations and cannot be set via className:
    * - `width` - Animated for indicator width transitions when switching tabs
    * - `height` - Animated for indicator height transitions when switching tabs
-   * - `left` - Animated for indicator position transitions when switching tabs
+   * - `translateX` - Animated for indicator position transitions when switching tabs (uses translateX for GPU-accelerated performance)
    * - `opacity` - Animated for indicator visibility transitions (0 when no active tab, 1 when active tab is selected)
    *
    * To customize these properties, use the `animation` prop:
@@ -198,7 +199,7 @@ export interface TabsIndicatorProps extends TabsPrimitivesTypes.IndicatorProps {
    *   animation={{
    *     width: { type: 'spring', config: { stiffness: 1200, damping: 120 } },
    *     height: { type: 'spring', config: { stiffness: 1200, damping: 120 } },
-   *     left: { type: 'timing', config: { duration: 200 } }
+   *     translateX: { type: 'timing', config: { duration: 200 } }
    *   }}
    * />
    * ```


### PR DESCRIPTION
## 📝 Description

Refactors the Tabs indicator animation to use `translateX` transforms instead of `left` positioning for GPU-accelerated performance. Updates animation API, types, documentation, and styles to reflect this change.

## ⛳️ Current behavior (updates)

The Tabs indicator uses the `left` CSS property for horizontal positioning animations, which is not GPU-accelerated and can cause performance issues during transitions.

## 🚀 New behavior

- Indicator positioning now uses `translateX` transform for GPU-accelerated animations
- Animation API changed from `left` to `translateX` in `TabsIndicatorAnimation` configuration
- Added `left-0` base class to indicator styles to maintain initial positioning
- Updated all documentation, type definitions, and code comments to reflect the new API

## 💣 Is this a breaking change (Yes/No):

**Yes** - The animation configuration API has changed from `left` to `translateX`. Users customizing indicator animations must update their `animation` prop from `left: { type, config }` to `translateX: { type, config }`.

## 📝 Additional Information

This change improves animation performance by leveraging GPU acceleration through CSS transforms. All documentation examples and type definitions have been updated to reflect the new API. The visual behavior remains identical, only the underlying implementation has changed.