### PR TITLE
refactor(toast): improve toast styling and stacking behavior

### DIFF
--- a/docs/theming.md
+++ b/docs/theming.md
@@ -131,8 +131,8 @@ Create multiple themes using Uniwind's variant system. For complete custom theme
         0 2px 4px 0 rgba(0, 0, 0, 0.04), 0 1px 2px 0 rgba(0, 0, 0, 0.06),
         0 0 1px 0 rgba(0, 0, 0, 0.06);
       --overlay-shadow:
-        0 2px 8px 0 rgba(0, 0, 0, 0.06), 0 -6px 12px 0 rgba(0, 0, 0, 0.03),
-        0 14px 28px 0 rgba(0, 0, 0, 0.08);
+        0 2px 8px 0 rgba(0, 0, 0, 0.02), 0 -6px 12px 0 rgba(0, 0, 0, 0.01),
+        0 14px 28px 0 rgba(0, 0, 0, 0.03);
       --field-shadow:
         0 2px 4px 0 rgba(0, 0, 0, 0.04), 0 1px 2px 0 rgba(0, 0, 0, 0.06),
         0 0 1px 0 rgba(0, 0, 0, 0.06);

--- a/example/src/components/toast/achievement-toast.tsx
+++ b/example/src/components/toast/achievement-toast.tsx
@@ -134,8 +134,8 @@ export const AchievementToast = (props: ToastComponentProps) => {
   }));
 
   return (
-    <Toast className="bg-[#F5F1E8] border-2 border-orange-200" {...props}>
-      <View className="relative flex-row items-center gap-4 px-4 py-3">
+    <Toast className="bg-[#F5F1E8] p-3 border-2 border-orange-200" {...props}>
+      <View className="flex-row items-center gap-4">
         {/* Confetti decorative elements */}
         <StyleAnimatedView
           className="absolute right-8 top-2 size-2 rounded-full bg-orange-600/60"
@@ -183,7 +183,7 @@ export const AchievementToast = (props: ToastComponentProps) => {
 
         {/* Close button */}
         <Toast.Close
-          className="absolute right-2 top-2"
+          className="absolute right-0 top-0"
           iconProps={{ color: themeColorWarning }}
         />
       </View>

--- a/example/themes/alpha.css
+++ b/example/themes/alpha.css
@@ -58,9 +58,9 @@
       --surface-shadow:
         0 2px 4px 0 rgba(0, 0, 0, 0.04), 0 1px 2px 0 rgba(0, 0, 0, 0.06),
         0 0 1px 0 rgba(0, 0, 0, 0.06);
-      /* Overlay shadow */
       --overlay-shadow:
-        0 4px 16px 0 rgba(24, 24, 27, 0.08), 0 8px 24px 0 rgba(24, 24, 27, 0.09);
+        0 2px 8px 0 rgba(0, 0, 0, 0.02), 0 -6px 12px 0 rgba(0, 0, 0, 0.01),
+        0 14px 28px 0 rgba(0, 0, 0, 0.03);
       --field-shadow:
         0 2px 4px 0 rgba(0, 0, 0, 0.04), 0 1px 2px 0 rgba(0, 0, 0, 0.06),
         0 0 1px 0 rgba(0, 0, 0, 0.06);

--- a/example/themes/mint.css
+++ b/example/themes/mint.css
@@ -57,14 +57,14 @@
 
       /* Shadows */
       --surface-shadow:
-        0 2px 4px 0 rgba(0, 0, 0, 0.02), 0 1px 2px 0 rgba(0, 0, 0, 0.03),
-        0 0 1px 0 rgba(0, 0, 0, 0.03);
-      /* Overlay shadow */
+        0 2px 4px 0 rgba(0, 0, 0, 0.04), 0 1px 2px 0 rgba(0, 0, 0, 0.06),
+        0 0 1px 0 rgba(0, 0, 0, 0.06);
       --overlay-shadow:
-        0 4px 16px 0 rgba(24, 24, 27, 0.04), 0 8px 24px 0 rgba(24, 24, 27, 0.045);
+        0 2px 8px 0 rgba(0, 0, 0, 0.02), 0 -6px 12px 0 rgba(0, 0, 0, 0.01),
+        0 14px 28px 0 rgba(0, 0, 0, 0.03);
       --field-shadow:
-        0 2px 4px 0 rgba(0, 0, 0, 0.02), 0 1px 2px 0 rgba(0, 0, 0, 0.03),
-        0 0 1px 0 rgba(0, 0, 0, 0.03);
+        0 2px 4px 0 rgba(0, 0, 0, 0.04), 0 1px 2px 0 rgba(0, 0, 0, 0.06),
+        0 0 1px 0 rgba(0, 0, 0, 0.06);
     }
 
     @variant mint-dark {

--- a/example/themes/sky.css
+++ b/example/themes/sky.css
@@ -59,9 +59,9 @@
       --surface-shadow:
         0 2px 4px 0 rgba(0, 0, 0, 0.04), 0 1px 2px 0 rgba(0, 0, 0, 0.06),
         0 0 1px 0 rgba(0, 0, 0, 0.06);
-      /* Overlay shadow */
       --overlay-shadow:
-        0 4px 16px 0 rgba(24, 24, 27, 0.08), 0 8px 24px 0 rgba(24, 24, 27, 0.09);
+        0 2px 8px 0 rgba(0, 0, 0, 0.02), 0 -6px 12px 0 rgba(0, 0, 0, 0.01),
+        0 14px 28px 0 rgba(0, 0, 0, 0.03);
       --field-shadow:
         0 2px 4px 0 rgba(0, 0, 0, 0.04), 0 1px 2px 0 rgba(0, 0, 0, 0.06),
         0 0 1px 0 rgba(0, 0, 0, 0.06);

--- a/src/components/toast/toast.hooks.ts
+++ b/src/components/toast/toast.hooks.ts
@@ -1,0 +1,73 @@
+import { useMemo } from 'react';
+import type { StyleProp, ViewStyle } from 'react-native';
+import { StyleSheet } from 'react-native';
+import { useResolveClassNames } from 'uniwind';
+
+interface UseVerticalPlaceholderStylesParams {
+  rootClassName?: string;
+  style?: StyleProp<ViewStyle>;
+}
+
+export function useVerticalPlaceholderStyles({
+  rootClassName,
+  style,
+}: UseVerticalPlaceholderStylesParams) {
+  const resolvedRootClassName = useResolveClassNames(rootClassName ?? '');
+
+  return useMemo(() => {
+    const resolvedStyle = style ? StyleSheet.flatten(style) : undefined;
+
+    const stylePaddingTop =
+      resolvedStyle?.paddingTop ??
+      resolvedStyle?.paddingVertical ??
+      resolvedStyle?.padding;
+    const stylePaddingBottom =
+      resolvedStyle?.paddingBottom ??
+      resolvedStyle?.paddingVertical ??
+      resolvedStyle?.padding;
+
+    const classNamePaddingTop =
+      resolvedRootClassName?.paddingTop ??
+      resolvedRootClassName?.paddingVertical ??
+      resolvedRootClassName?.padding;
+    const classNamePaddingBottom =
+      resolvedRootClassName?.paddingBottom ??
+      resolvedRootClassName?.paddingVertical ??
+      resolvedRootClassName?.padding;
+
+    const paddingTopValue = stylePaddingTop ?? classNamePaddingTop;
+    const paddingBottomValue = stylePaddingBottom ?? classNamePaddingBottom;
+
+    const topHeight =
+      typeof paddingTopValue === 'number' && paddingTopValue >= 0
+        ? paddingTopValue
+        : 0;
+    const bottomHeight =
+      typeof paddingBottomValue === 'number' && paddingBottomValue >= 0
+        ? paddingBottomValue
+        : 0;
+
+    const styleBackgroundColor = resolvedStyle?.backgroundColor;
+    const classNameBackgroundColor = resolvedRootClassName?.backgroundColor;
+    const backgroundColor =
+      styleBackgroundColor ?? classNameBackgroundColor ?? undefined;
+
+    const topStyle: ViewStyle = {
+      height: topHeight,
+    };
+
+    const bottomStyle: ViewStyle = {
+      height: bottomHeight,
+    };
+
+    if (backgroundColor !== undefined) {
+      topStyle.backgroundColor = backgroundColor;
+      bottomStyle.backgroundColor = backgroundColor;
+    }
+
+    return {
+      topStyle,
+      bottomStyle,
+    };
+  }, [resolvedRootClassName, style]);
+}

--- a/src/components/toast/toast.md
+++ b/src/components/toast/toast.md
@@ -412,12 +412,3 @@ Options for showing a toast. Can be either a config object with default styling 
 | `onShow`    | `() => void`                                         | -       | Callback function called when the toast is shown                                    |
 | `onHide`    | `() => void`                                         | -       | Callback function called when the toast is hidden                                   |
 
-## Special Notes
-
-### Styling Notes
-
-#### Border as Padding
-
-Toast uses `border-[16px]` class which serves as padding. This is intentional because when visible toasts have different heights, the toast adapts to the last visible toast height. In cases where a toast originally has one height and gets smaller when a new toast comes to stack, content might be visible behind the last toast without proper padding. The border ensures consistent spacing regardless of toast height changes.
-
-For padding, use `border` classes. For actual borders, use `outline` classes.

--- a/src/components/toast/toast.styles.ts
+++ b/src/components/toast/toast.styles.ts
@@ -36,7 +36,7 @@ import { combineStyles } from '../../helpers/internal/utils';
  * set `isAnimatedStyleActive={false}` on `Toast.Root`.
  */
 const root = tv({
-  base: 'bg-surface rounded-3xl border-[16px] border-surface outline outline-surface-secondary shadow-2xl shadow-background-inverse/5 dark:shadow-none overflow-hidden',
+  base: 'bg-surface rounded-3xl p-4 shadow-overlay overflow-hidden',
 });
 
 const label = tv({

--- a/src/components/toast/toast.tsx
+++ b/src/components/toast/toast.tsx
@@ -15,6 +15,7 @@ import { Button } from '../button';
 import type { PressableFeedbackHighlightAnimation } from '../pressable-feedback';
 import { useToastRootAnimation } from './toast.animation';
 import { DISPLAY_NAME } from './toast.constants';
+import { useVerticalPlaceholderStyles } from './toast.hooks';
 import { toastClassNames, toastStyleSheet } from './toast.styles';
 import type {
   DefaultToastProps,
@@ -68,6 +69,12 @@ const ToastRoot = forwardRef<ViewRef, ToastRootProps>((props, ref) => {
 
   const rootClassName = toastClassNames.root({
     className,
+  });
+
+  // Extract padding and backgroundColor for placeholder Views
+  const { topStyle, bottomStyle } = useVerticalPlaceholderStyles({
+    rootClassName,
+    style,
   });
 
   const {
@@ -128,6 +135,20 @@ const ToastRoot = forwardRef<ViewRef, ToastRootProps>((props, ref) => {
               {...restProps}
             >
               {children}
+              {/* 
+                When visible toasts have different heights, the toast adapts to the last visible toast height.
+                In cases where a toast originally has one height and gets smaller when a new toast comes to stack,
+                content might be visible behind the last toast without proper padding.
+                The placeholder Views ensure that the content under active toast is hidden.
+              */}
+              <View
+                className="absolute left-0 right-0 top-0"
+                style={topStyle}
+              />
+              <View
+                className="absolute left-0 right-0 bottom-0"
+                style={bottomStyle}
+              />
             </AnimatedToastRoot>
             {/* Hidden toast instance for height measurement */}
             <AnimatedToastRoot

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -71,8 +71,8 @@
         0 2px 4px 0 rgba(0, 0, 0, 0.04), 0 1px 2px 0 rgba(0, 0, 0, 0.06),
         0 0 1px 0 rgba(0, 0, 0, 0.06);
       --overlay-shadow:
-        0 2px 8px 0 rgba(0, 0, 0, 0.04), 0 -6px 12px 0 rgba(0, 0, 0, 0.02),
-        0 14px 28px 0 rgba(0, 0, 0, 0.06);
+        0 2px 8px 0 rgba(0, 0, 0, 0.02), 0 -6px 12px 0 rgba(0, 0, 0, 0.01),
+        0 14px 28px 0 rgba(0, 0, 0, 0.03);
       --field-shadow:
         0 2px 4px 0 rgba(0, 0, 0, 0.04), 0 1px 2px 0 rgba(0, 0, 0, 0.06),
         0 0 1px 0 rgba(0, 0, 0, 0.06);


### PR DESCRIPTION
Closes #265 

## 📝 Description

Refactors Toast component styling by replacing the border-based padding approach with proper padding and vertical placeholder views. Updates overlay shadow values across all themes to be more subtle and consistent.

## ⛳️ Current behavior (updates)

Toast component uses `border-[16px]` as padding to handle content visibility when toasts stack. Overlay shadows have inconsistent opacity values across themes.

## 🚀 New behavior

- Toast now uses `p-4` padding instead of border-based padding
- Added `useVerticalPlaceholderStyles` hook to extract padding and background color for placeholder views
- Added absolute positioned placeholder Views at top and bottom to prevent content visibility when toasts stack
- Updated shadow system to use `shadow-overlay` token
- Standardized overlay shadow values across all themes (alpha, mint, sky) with lighter opacity
- Updated achievement toast example to use new padding approach

## 💣 Is this a breaking change (Yes/No):

**No** - The visual appearance remains similar, but custom toast implementations using border classes for padding may need to switch to padding classes.

## 📝 Additional Information

The placeholder Views ensure content remains hidden when toasts of different heights stack together. Shadow updates provide a more subtle, consistent appearance across all theme variants. Manual testing recommended for custom toast implementations.