### PR TITLE
feat(styling): add styles prop to accordion, avatar, field-error, label, pressable-feedback, and select

### DIFF
--- a/src/components/accordion/accordion.md
+++ b/src/components/accordion/accordion.md
@@ -135,6 +135,29 @@ Hide the separators between accordion items.
 </Accordion>
 ```
 
+### Custom Styling
+
+Apply custom styles using className, classNames, or styles props.
+
+```tsx
+<Accordion
+  className="rounded-lg"
+  classNames={{
+    container: "bg-surface",
+    separator: "bg-separator/50"
+  }}
+  styles={{
+    container: { padding: 16 },
+    separator: { height: 2 }
+  }}
+>
+  <Accordion.Item value="1">
+    <Accordion.Trigger>...</Accordion.Trigger>
+    <Accordion.Content>...</Accordion.Content>
+  </Accordion.Item>
+</Accordion>
+```
+
 ### With PressableFeedback
 
 Use `Accordion.Trigger` with `asChild` prop and wrap content with `PressableFeedback` to add custom press feedback animations.
@@ -239,6 +262,7 @@ You can find more examples in the [GitHub repository](https://github.com/heroui-
 | `animation`             | `AccordionRootAnimation`                           | -           | Animation configuration for accordion                             |
 | `className`             | `string`                                           | -           | Additional CSS classes for the container                          |
 | `classNames`            | `ElementSlots<RootSlots>`                          | -           | Additional CSS classes for the slots                              |
+| `styles`                | `Partial<Record<RootSlots, ViewStyle>>`            | -           | Styles for different parts of the accordion root                  |
 | `onValueChange`         | `(value: string \| string[] \| undefined) => void` | -           | Callback when expanded items change                               |
 | `...Animated.ViewProps` | `Animated.ViewProps`                               | -           | All Reanimated Animated.View props are supported                  |
 
@@ -248,6 +272,13 @@ You can find more examples in the [GitHub repository](https://github.com/heroui-
 | ----------- | -------- | ----------------------------------------------- |
 | `container` | `string` | Custom class name for the accordion container   |
 | `separator` | `string` | Custom class name for the separator between items |
+
+#### `styles`
+
+| prop        | type        | description                                   |
+| ----------- | ----------- | --------------------------------------------- |
+| `container` | `ViewStyle` | Styles for the accordion container            |
+| `separator` | `ViewStyle` | Styles for the separator between items        |
 
 #### AccordionRootAnimation
 

--- a/src/components/accordion/accordion.tsx
+++ b/src/components/accordion/accordion.tsx
@@ -57,6 +57,7 @@ const Root = forwardRef<View, AccordionRootProps>((props, ref) => {
     hideSeparator = false,
     className,
     classNames,
+    styles,
     style,
     animation,
     ...restProps
@@ -64,11 +65,11 @@ const Root = forwardRef<View, AccordionRootProps>((props, ref) => {
 
   const { container, separator } = accordionClassNames.root({ variant });
 
-  const containerStyles = container({
+  const containerClassName = container({
     className: [className, classNames?.container],
   });
 
-  const separatorStyles = separator({ className: classNames?.separator });
+  const separatorClassName = separator({ className: classNames?.separator });
 
   const { layoutTransition, isAllAnimationsDisabled } =
     useAccordionRootAnimation({
@@ -102,8 +103,8 @@ const Root = forwardRef<View, AccordionRootProps>((props, ref) => {
         <AccordionInnerProvider value={contextValue}>
           <AnimatedRootView
             ref={ref}
-            className={containerStyles}
-            style={[accordionStyleSheet.root, style]}
+            className={containerClassName}
+            style={[accordionStyleSheet.root, style, styles?.container]}
             layout={layoutTransition}
             {...restProps}
           >
@@ -112,7 +113,8 @@ const Root = forwardRef<View, AccordionRootProps>((props, ref) => {
                 {child}
                 {!hideSeparator && index < Children.count(children) - 1 && (
                   <Animated.View
-                    className={separatorStyles}
+                    className={separatorClassName}
+                    style={styles?.separator}
                     layout={layoutTransition}
                   />
                 )}

--- a/src/components/accordion/accordion.types.ts
+++ b/src/components/accordion/accordion.types.ts
@@ -1,3 +1,4 @@
+import type { ViewStyle } from 'react-native';
 import type {
   AnimatedProps,
   EntryOrExitLayoutType,
@@ -82,6 +83,10 @@ export type AccordionRootProps = Omit<
    * Additional CSS classes for the slots
    */
   classNames?: ElementSlots<RootSlots>;
+  /**
+   * Styles for different parts of the accordion root
+   */
+  styles?: Partial<Record<RootSlots, ViewStyle>>;
   /**
    * Animation configuration for accordion
    * - `false` or `"disabled"`: Disable only root animations

--- a/src/components/avatar/avatar.md
+++ b/src/components/avatar/avatar.md
@@ -307,12 +307,20 @@ Animation configuration for avatar image component. Can be:
 | `color`                 | `'default' \| 'accent' \| 'success' \| 'warning' \| 'danger'` | inherited from parent | Color variant of the fallback                                                     |
 | `className`             | `string`                                                      | -                     | Additional CSS classes for the container                                          |
 | `classNames`            | `ElementSlots<AvatarFallbackSlots>`                           | -                     | Additional CSS classes for different parts                                        |
+| `styles`                | `{ container?: ViewStyle; text?: TextStyle }` | - | Styles for different parts of the avatar fallback                                 |
 | `textProps`             | `TextProps`                                                   | -                     | Props to pass to Text component when children is a string                         |
 | `iconProps`             | `PersonIconProps`                                             | -                     | Props to customize the default person icon                                        |
 | `animation`             | `AvatarFallbackAnimation`                                     | -                     | Animation configuration                                                           |
 | `...Animated.ViewProps` | `Animated.ViewProps`                                          | -                     | All Reanimated Animated.View props are supported                                  |
 
 **classNames prop:** `ElementSlots<AvatarFallbackSlots>` provides type-safe CSS classes for different parts of the fallback component. Available slots: `container`, `text`.
+
+#### `styles`
+
+| prop        | type                    | description                          |
+| ----------- | ----------------------- | ------------------------------------ |
+| `container` | `ViewStyle`             | Styles for the container             |
+| `text`      | `TextStyle`             | Styles for the text content          |
 
 #### AvatarFallbackAnimation
 

--- a/src/components/avatar/avatar.tsx
+++ b/src/components/avatar/avatar.tsx
@@ -205,9 +205,10 @@ const AvatarFallback = forwardRef<AvatarFallbackRef, AvatarFallbackProps>(
       color: colorProp,
       className,
       classNames,
+      style,
+      styles,
       textProps,
       iconProps,
-      style,
       delayMs,
       animation,
       ...restProps
@@ -241,12 +242,16 @@ const AvatarFallback = forwardRef<AvatarFallbackRef, AvatarFallbackProps>(
         ref={ref}
         entering={entering}
         className={fallbackContainerClassName}
-        style={[avatarStyleSheet.borderCurve, style]}
+        style={[avatarStyleSheet.borderCurve, style, styles?.container]}
         {...restProps}
       >
         {children ? (
           stringifiedChildren ? (
-            <HeroText className={fallbackTextClassName} {...textProps}>
+            <HeroText
+              className={fallbackTextClassName}
+              style={styles?.text}
+              {...textProps}
+            >
               {stringifiedChildren}
             </HeroText>
           ) : (

--- a/src/components/avatar/avatar.types.ts
+++ b/src/components/avatar/avatar.types.ts
@@ -1,4 +1,4 @@
-import type { ImageProps, TextProps } from 'react-native';
+import type { ImageProps, TextProps, TextStyle, ViewStyle } from 'react-native';
 import type {
   AnimatedProps,
   EntryOrExitLayoutType,
@@ -186,6 +186,14 @@ export interface AvatarFallbackProps
    * Additional CSS classes for different parts of the fallback
    */
   classNames?: ElementSlots<AvatarFallbackSlots>;
+
+  /**
+   * Styles for different parts of the avatar fallback
+   */
+  styles?: {
+    container?: ViewStyle;
+    text?: TextStyle;
+  };
 
   /**
    * Props to pass to the Text component when children is a string

--- a/src/components/field-error/field-error.md
+++ b/src/components/field-error/field-error.md
@@ -175,10 +175,18 @@ You can find more examples in the [GitHub repository](https://github.com/heroui-
 | `animation`            | `FieldErrorRootAnimation`       | -           | Animation configuration                                                  |
 | `className`            | `string`                       | `undefined` | Additional CSS classes for the container                                 |
 | `classNames`           | `ElementSlots<FieldErrorSlots>` | `undefined` | Additional CSS classes for different parts of the component              |
+| `styles`                | `{ container?: ViewStyle; text?: TextStyle }` | `undefined` | Styles for different parts of the field error                            |
 | `textProps`            | `TextProps`                    | `undefined` | Additional props to pass to the Text component when children is a string |
 | `...AnimatedViewProps` | `AnimatedProps<ViewProps>`     | -           | All Reanimated Animated.View props are supported                         |
 
 **classNames prop:** `ElementSlots<FieldErrorSlots>` provides type-safe CSS classes for different parts of the field error component. Available slots: `container`, `text`.
+
+#### `styles`
+
+| prop        | type                    | description                          |
+| ----------- | ----------------------- | ------------------------------------ |
+| `container` | `ViewStyle`              | Styles for the container             |
+| `text`      | `TextStyle`             | Styles for the text content          |
 
 #### FieldErrorRootAnimation
 

--- a/src/components/field-error/field-error.tsx
+++ b/src/components/field-error/field-error.tsx
@@ -18,6 +18,8 @@ const FieldErrorRoot = forwardRef<ViewRef, FieldErrorRootProps>(
       children,
       className,
       classNames,
+      style,
+      styles,
       textProps,
       isInvalid: localIsInvalid,
       animation,
@@ -53,7 +55,7 @@ const FieldErrorRoot = forwardRef<ViewRef, FieldErrorRootProps>(
 
     const stringifiedChildren = childrenToString(children);
     const renderedChildren = stringifiedChildren ? (
-      <HeroText className={textClassName} {...textProps}>
+      <HeroText className={textClassName} style={styles?.text} {...textProps}>
         {stringifiedChildren}
       </HeroText>
     ) : (
@@ -66,6 +68,7 @@ const FieldErrorRoot = forwardRef<ViewRef, FieldErrorRootProps>(
         entering={entering}
         exiting={exiting}
         className={containerClassName}
+        style={[style, styles?.container]}
         {...restProps}
       >
         {renderedChildren}

--- a/src/components/field-error/field-error.types.ts
+++ b/src/components/field-error/field-error.types.ts
@@ -1,4 +1,4 @@
-import type { TextProps, ViewProps } from 'react-native';
+import type { TextProps, TextStyle, ViewProps, ViewStyle } from 'react-native';
 import type {
   AnimatedProps,
   EntryOrExitLayoutType,
@@ -55,6 +55,14 @@ export interface FieldErrorRootProps
    * Additional CSS classes for different parts of the component
    */
   classNames?: ElementSlots<FieldErrorSlots>;
+
+  /**
+   * Styles for different parts of the field error
+   */
+  styles?: {
+    container?: ViewStyle;
+    text?: TextStyle;
+  };
 
   /**
    * Additional props to pass to the Text component when children is a string

--- a/src/components/label/label.md
+++ b/src/components/label/label.md
@@ -178,3 +178,10 @@ You can find more examples in the [GitHub repository](https://github.com/heroui-
 | ---------- | -------- | ------------------------------ |
 | `text`     | `string` | CSS classes for the label text |
 | `asterisk` | `string` | CSS classes for the asterisk   |
+
+#### `styles`
+
+| prop       | type        | description                    |
+| ---------- | ----------- | ------------------------------ |
+| `text`     | `TextStyle` | Styles for the label text      |
+| `asterisk` | `TextStyle` | Styles for the asterisk        |

--- a/src/components/label/label.tsx
+++ b/src/components/label/label.tsx
@@ -111,7 +111,8 @@ const Label = forwardRef<PressableRef, LabelProps>((props, ref) => {
 // --------------------------------------------------
 
 const LabelText = forwardRef<TextRef, LabelTextProps>((props, ref) => {
-  const { children, className, classNames, styles, ...restProps } = props;
+  const { children, className, classNames, styles, style, ...restProps } =
+    props;
 
   const { isDisabled, isRequired, isInvalid } = useLabel();
 
@@ -132,7 +133,7 @@ const LabelText = forwardRef<TextRef, LabelTextProps>((props, ref) => {
     <HeroText
       ref={ref}
       className={textClassName}
-      style={styles?.text}
+      style={[style, styles?.text]}
       {...restProps}
     >
       {children}

--- a/src/components/label/label.types.ts
+++ b/src/components/label/label.types.ts
@@ -40,8 +40,7 @@ export interface LabelProps extends LabelPrimitivesTypes.RootProps {
 /**
  * Props for the Label.Text component
  */
-export interface LabelTextProps
-  extends Omit<LabelPrimitivesTypes.TextProps, 'style'> {
+export interface LabelTextProps extends LabelPrimitivesTypes.TextProps {
   /**
    * Additional CSS classes
    */

--- a/src/components/pressable-feedback/pressable-feedback.md
+++ b/src/components/pressable-feedback/pressable-feedback.md
@@ -209,11 +209,17 @@ Animation configuration for highlight overlay. Can be:
 | ----------------------- | ---------------------------------- | ------- | ------------------------------------------------------------ |
 | `className`             | `string`                           | -       | Additional CSS classes for container slot                    |
 | `classNames`            | `ElementSlots<RippleSlots>`        | -       | Additional CSS classes for slots (container, ripple)         |
-| `containerStyle`        | `ViewStyle`                        | -       | Style for the container slot                                 |
-| `rippleStyle`           | `ViewStyle`                        | -       | Style for the ripple slot                                    |
+| `styles`                | `Partial<Record<RippleSlots, ViewStyle>>` | - | Styles for different parts of the ripple overlay            |
 | `animation`             | `PressableFeedbackRippleAnimation` | -       | Animation configuration for ripple overlay                   |
 | `isAnimatedStyleActive` | `boolean`                          | `true`  | Whether animated styles (react-native-reanimated) are active |
 | `...ViewProps`          | `Omit<ViewProps, 'style'>`         | -       | All View props except style are supported                    |
+
+#### `styles`
+
+| prop        | type        | description                          |
+| ----------- | ----------- | ------------------------------------ |
+| `container` | `ViewStyle` | Styles for the container slot        |
+| `ripple`    | `ViewStyle` | Styles for the ripple slot           |
 
 #### PressableFeedbackRippleAnimation
 

--- a/src/components/pressable-feedback/pressable-feedback.tsx
+++ b/src/components/pressable-feedback/pressable-feedback.tsx
@@ -183,8 +183,8 @@ const PressableFeedbackRipple = forwardRef<
     animation,
     className,
     classNames,
-    containerStyle,
-    rippleStyle: rippleStyleProp,
+    style,
+    styles,
     isAnimatedStyleActive = true,
     onTouchStart,
     onTouchEnd,
@@ -199,17 +199,16 @@ const PressableFeedbackRipple = forwardRef<
     animationOnTouchStart,
   } = usePressableFeedbackRippleAnimation({ animation });
 
-  const { container, ripple: rippleSlot } =
-    pressableFeedbackClassNames.ripple();
+  const { container, ripple } = pressableFeedbackClassNames.ripple();
 
   const containerClassName = container({
     className: [className, classNames?.container],
   });
-  const rippleClassName = rippleSlot({ className: classNames?.ripple });
+  const rippleClassName = ripple({ className: classNames?.ripple });
 
   const rippleStyle = isAnimatedStyleActive
-    ? [rContainerStyle, rippleStyleProp]
-    : rippleStyleProp;
+    ? [rContainerStyle, styles?.ripple]
+    : styles?.ripple;
 
   const handleTouchStart = useCallback(
     (event: GestureResponderEvent) => {
@@ -238,7 +237,7 @@ const PressableFeedbackRipple = forwardRef<
     <View
       ref={ref}
       className={containerClassName}
-      style={containerStyle}
+      style={[style, styles?.container]}
       onTouchStart={handleTouchStart}
       onTouchEnd={handleTouchEnd}
       onTouchCancel={handleTouchCancel}

--- a/src/components/pressable-feedback/pressable-feedback.types.ts
+++ b/src/components/pressable-feedback/pressable-feedback.types.ts
@@ -1,4 +1,4 @@
-import type { PressableProps, ViewProps } from 'react-native';
+import type { PressableProps, ViewProps, ViewStyle } from 'react-native';
 import type {
   AnimatedProps,
   SharedValue,
@@ -281,7 +281,7 @@ export interface PressableFeedbackHighlightProps
 /**
  * Props for PressableFeedback ripple component
  */
-export interface PressableFeedbackRippleProps extends Omit<ViewProps, 'style'> {
+export interface PressableFeedbackRippleProps extends ViewProps {
   /**
    * Additional CSS classes for the container slot
    *
@@ -317,13 +317,9 @@ export interface PressableFeedbackRippleProps extends Omit<ViewProps, 'style'> {
    */
   classNames?: ElementSlots<RippleSlots>;
   /**
-   * Style for the container slot
+   * Styles for different parts of the ripple overlay
    */
-  containerStyle?: ViewProps['style'];
-  /**
-   * Style for the ripple slot
-   */
-  rippleStyle?: ViewProps['style'];
+  styles?: Partial<Record<RippleSlots, ViewStyle>>;
   /**
    * Animation configuration for the ripple overlay
    */

--- a/src/components/select/select.md
+++ b/src/components/select/select.md
@@ -548,11 +548,19 @@ Animation configuration for Select.Content component (popover presentation). Can
 | `children`              | `ReactNode`                              | -       | The dialog content                                           |
 | `presentation`          | `'dialog'`                               | -       | Presentation mode for the select                             |
 | `classNames`            | `{ wrapper?: string; content?: string }` | -       | Additional CSS classes for wrapper and content               |
+| `styles`                | `Partial<Record<DialogContentFallbackSlots, ViewStyle>>` | - | Styles for different parts of the dialog content            |
 | `animation`             | `SelectContentAnimation`                 | -       | Animation configuration                                      |
 | `isSwipeable`           | `boolean`                                | `true`  | Whether the dialog content can be swiped to dismiss          |
 | `forceMount`            | `boolean`                                | -       | Whether to force mount the component in the DOM              |
 | `asChild`               | `boolean`                                | `false` | Whether to render as a child element                         |
 | `...ViewProps`          | `ViewProps`                              | -       | All standard React Native View props are supported           |
+
+#### `styles`
+
+| prop      | type        | description                          |
+| --------- | ----------- | ------------------------------------ |
+| `wrapper` | `ViewStyle` | Styles for the wrapper container     |
+| `content` | `ViewStyle` | Styles for the dialog content         |
 
 #### SelectContentAnimation
 

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -375,7 +375,15 @@ const SelectContentDialog = forwardRef<
   SelectContentProps & { presentation: 'dialog' }
 >(
   (
-    { classNames, style, children, animation, isSwipeable = true, ...props },
+    {
+      classNames,
+      styles,
+      style,
+      children,
+      animation,
+      isSwipeable = true,
+      ...props
+    },
     ref
   ) => {
     const { isOpen, onOpenChange } = useSelect();
@@ -418,7 +426,7 @@ const SelectContentDialog = forwardRef<
     }, []);
 
     return (
-      <View className={wrapperClassName}>
+      <View className={wrapperClassName} style={styles?.wrapper}>
         <GestureDetector gesture={panGesture}>
           <Animated.View
             ref={dragContainerRef}
@@ -429,7 +437,11 @@ const SelectContentDialog = forwardRef<
               <SelectPrimitives.DialogContent
                 ref={ref}
                 className={contentClassName}
-                style={[selectStyleSheet.contentContainer, style]}
+                style={[
+                  selectStyleSheet.contentContainer,
+                  styles?.content,
+                  style,
+                ]}
                 {...props}
               >
                 {children}

--- a/src/components/select/select.types.ts
+++ b/src/components/select/select.types.ts
@@ -1,6 +1,6 @@
 import type BottomSheet from '@gorhom/bottom-sheet';
 import type { ReactNode } from 'react';
-import type { TextProps } from 'react-native';
+import type { TextProps, ViewStyle } from 'react-native';
 import type { SharedValue } from 'react-native-reanimated';
 import type {
   AnimationRootDisableAll,
@@ -189,6 +189,10 @@ export interface SelectContentDialogProps
    * Additional CSS classes for the content container
    */
   classNames?: ElementSlots<DialogContentFallbackSlots>;
+  /**
+   * Styles for different parts of the dialog content
+   */
+  styles?: Partial<Record<DialogContentFallbackSlots, ViewStyle>>;
   /**
    * The select content
    */


### PR DESCRIPTION
## 📝 Description

Adds a unified `styles` prop to multiple components (Accordion, Avatar, FieldError, Label, PressableFeedback, and Select) for slot-based styling. Refactors PressableFeedback to replace individual style props (`containerStyle`, `rippleStyle`) with the standardized `styles` prop pattern.

## ⛳️ Current behavior (updates)

Components support `className` and `classNames` props for styling, with some components having individual style props like `containerStyle` and `rippleStyle` in PressableFeedback.

## 🚀 New behavior

- Added `styles` prop to Accordion (container, separator slots)
- Added `styles` prop to AvatarFallback (container, text slots)
- Added `styles` prop to FieldError (container, text slots)
- Added `styles` prop to Label (text, asterisk slots) and fixed `style` prop handling
- Refactored PressableFeedback Ripple to use unified `styles` prop (container, ripple slots) instead of `containerStyle` and `rippleStyle`
- Added `styles` prop to SelectContentDialog (wrapper, content slots)
- Updated documentation for all affected components with examples and API tables

## 💣 Is this a breaking change (Yes/No):

**Yes** - PressableFeedback Ripple component's `containerStyle` and `rippleStyle` props are replaced with a unified `styles` prop. Migration: use `styles={{ container: ..., ripple: ... }}` instead of separate props.

## 📝 Additional Information

All changes maintain backward compatibility with existing `style` props and properly merge styles. Documentation includes examples demonstrating the new `styles` prop usage pattern for each component.