### PR TITLE
refactor(theme): move surface levels from calculated to theme-defined variables

### DIFF
--- a/docs/theming.md
+++ b/docs/theming.md
@@ -87,6 +87,12 @@ Create multiple themes using Uniwind's variant system. For complete custom theme
       --surface: oklch(0.98 0.01 230);
       --surface-foreground: oklch(0.3 0.045 230);
 
+      --surface-secondary: oklch(0.96 0.012 230);
+      --surface-secondary-foreground: oklch(0.3 0.045 230);
+
+      --surface-tertiary: oklch(0.94 0.015 230);
+      --surface-tertiary-foreground: oklch(0.3 0.045 230);
+
       /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) */
       --overlay: oklch(0.998 0.003 230);
       --overlay-foreground: oklch(0.3 0.045 230);
@@ -146,6 +152,12 @@ Create multiple themes using Uniwind's variant system. For complete custom theme
       /* Surface: Used for non-overlay components (cards, accordions, disclosure groups) */
       --surface: oklch(0.2 0.048 230);
       --surface-foreground: oklch(0.9 0.015 230);
+
+      --surface-secondary: oklch(0.24 0.046 230);
+      --surface-secondary-foreground: oklch(0.9 0.015 230);
+
+      --surface-tertiary: oklch(0.27 0.044 230);
+      --surface-tertiary-foreground: oklch(0.9 0.015 230);
 
       /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) */
       --overlay: oklch(0.23 0.045 230);
@@ -335,6 +347,12 @@ We use Tailwind's `@theme` directive to automatically create calculated variable
   --color-surface-foreground: var(--surface-foreground);
   --color-surface-hover: color-mix(in oklab, var(--surface) 92%, var(--surface-foreground) 8%);
 
+  --color-surface-secondary: var(--surface-secondary);
+  --color-surface-secondary-foreground: var(--surface-secondary-foreground);
+
+  --color-surface-tertiary: var(--surface-tertiary);
+  --color-surface-tertiary-foreground: var(--surface-tertiary-foreground);
+
   --color-overlay: var(--overlay);
   --color-overlay-foreground: var(--overlay-foreground);
 
@@ -413,28 +431,6 @@ We use Tailwind's `@theme` directive to automatically create calculated variable
   --color-success-soft: color-mix(in oklab, var(--success) 15%, transparent);
   --color-success-soft-foreground: var(--success);
   --color-success-soft-hover: color-mix(in oklab, var(--success) 20%, transparent);
-
-  /* Surface Levels - progressively darker/lighter shades for layering */
-  --color-surface-secondary: color-mix(in oklab, var(--surface) 94%, var(--surface-foreground) 6%);
-  --color-surface-tertiary: color-mix(in oklab, var(--surface) 92%, var(--surface-foreground) 8%);
-
-  /* On Surface Colors */
-  --color-on-surface: color-mix(in oklab, var(--surface) 93%, var(--surface-foreground) 7%);
-  --color-on-surface-foreground: var(--surface-foreground);
-  --color-on-surface-hover: color-mix(in oklab, var(--surface) 91%, var(--surface-foreground) 9%);
-  --color-on-surface-focus: color-mix(in oklab, var(--surface) 93%, var(--surface-foreground) 7%);
-
-  /* On Surface Colors - Secondary (on secondary surface) */
-  --color-on-surface-secondary: color-mix(in oklab, var(--surface) 87%, var(--surface-foreground) 13%);
-  --color-on-surface-secondary-foreground: var(--surface-foreground);
-  --color-on-surface-secondary-hover: color-mix(in oklab, var(--surface) 85%, var(--surface-foreground) 15%);
-  --color-on-surface-secondary-focus: color-mix(in oklab, var(--surface) 87%, var(--surface-foreground) 13%);
-
-   /* On Surface Colors - Tertiary (on tertiary surface) */
-  --color-on-surface-tertiary: color-mix(in oklab, var(--surface) 85%, var(--surface-foreground) 15%);
-  --color-on-surface-tertiary-foreground: var(--surface-foreground);
-  --color-on-surface-tertiary-hover: color-mix(in oklab, var(--surface) 84%, var(--surface-foreground) 16%);
-  --color-on-surface-tertiary-focus: color-mix(in oklab, var(--surface) 85%, var(--surface-foreground) 15%);
 
   /* Separator Colors - Levels */
   --color-separator-secondary: color-mix(in oklab, var(--surface) 85%, var(--surface-foreground) 15%);

--- a/example/themes/alpha.css
+++ b/example/themes/alpha.css
@@ -16,6 +16,12 @@
       --surface: var(--white);
       --surface-foreground: var(--foreground);
 
+      --surface-secondary: oklch(0.9524 0.0013 286.37);
+      --surface-secondary-foreground: var(--foreground);
+
+      --surface-tertiary: oklch(0.9373 0.0013 286.37);
+      --surface-tertiary-foreground: var(--foreground);
+
       /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) */
       --overlay: var(--white);
       --overlay-foreground: var(--foreground);
@@ -81,6 +87,12 @@
       /* Surface: Used for non-overlay components (cards, accordions, disclosure groups) */
       --surface: var(--eclipse);
       --surface-foreground: var(--foreground);
+
+      --surface-secondary: oklch(0.257 0.0037 286.14);
+      --surface-secondary-foreground: var(--foreground);
+
+      --surface-tertiary: oklch(0.2721 0.0024 247.91);
+      --surface-tertiary-foreground: var(--foreground);
 
       /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) */
       --overlay: var(--color-neutral-800);

--- a/example/themes/lavander.css
+++ b/example/themes/lavander.css
@@ -13,8 +13,14 @@
       --foreground: oklch(21.03% 0.0059 305.00);
 
       /* Surface: Used for non-overlay components (cards, accordions, disclosure groups) */
-      --surface: oklch(100.00% 0.0076 305.00);
-      --surface-foreground: oklch(21.03% 0.0059 305.00);
+      --surface: oklch(100.00% 0.0100 305.00);
+      --surface-foreground: oklch(21.03% 0.0100 305.00);
+
+      --surface-secondary: oklch(95.24% 0.0160 305.00);
+      --surface-secondary-foreground: oklch(21.03% 0.0200 305.00);
+
+      --surface-tertiary: oklch(93.73% 0.0160 305.00);
+      --surface-tertiary-foreground: oklch(21.03% 0.0200 305.00);
 
       /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) */
       --overlay: oklch(100.00% 0.0045 305.00);
@@ -75,8 +81,14 @@
       --foreground: oklch(99.11% 0.0000 0.00);
 
       /* Surface: Used for non-overlay components (cards, accordions, disclosure groups) */
-      --surface: oklch(21.03% 0.0302 305.00);
-      --surface-foreground: oklch(99.11% 0.0000 0.00);
+      --surface: oklch(21.03% 0.0400 305.00);
+      --surface-foreground: oklch(99.11% 0.0200 305.00);
+
+      --surface-secondary: oklch(25.70% 0.0300 305.00);
+      --surface-secondary-foreground: oklch(99.11% 0.0200 305.00);
+  
+      --surface-tertiary: oklch(27.21% 0.0300 305.00);
+      --surface-tertiary-foreground: oklch(99.11% 0.0200 305.00);
 
       /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) */
       --overlay: oklch(21.03% 0.0302 305.00);

--- a/example/themes/mint.css
+++ b/example/themes/mint.css
@@ -13,8 +13,14 @@
       --foreground: oklch(21.03% 0.0059 155.00);
 
       /* Surface: Used for non-overlay components (cards, accordions, disclosure groups) */
-      --surface: oklch(100.00% 0.0060 155.00);
-      --surface-foreground: oklch(21.03% 0.0059 155.00);
+      --surface: oklch(100.00% 0.0065 155.00);
+      --surface-foreground: oklch(21.03% 0.0130 155.00);
+
+      --surface-secondary: oklch(95.24% 0.0104 155.00);
+      --surface-secondary-foreground: oklch(21.03% 0.0130 155.00);
+
+      --surface-tertiary: oklch(93.73% 0.0104 155.00);
+      --surface-tertiary-foreground: oklch(21.03% 0.0130 155.00);
 
       /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) */
       --overlay: oklch(100.00% 0.0036 155.00);
@@ -80,8 +86,14 @@
       --foreground: oklch(99.11% 0.0000 0.00);
 
       /* Surface: Used for non-overlay components (cards, accordions, disclosure groups) */
-      --surface: oklch(21.03% 0.0242 155.00);
-      --surface-foreground: oklch(99.11% 0.0000 0.00);
+      --surface: oklch(21.03% 0.0260 155.00);
+      --surface-foreground: oklch(99.11% 0.0130 155.00);
+
+      --surface-secondary: oklch(25.70% 0.0195 155.00);
+      --surface-secondary-foreground: oklch(99.11% 0.0130 155.00);
+      
+      --surface-tertiary: oklch(27.21% 0.0195 155.00);
+      --surface-tertiary-foreground: oklch(99.11% 0.0130 155.00);
 
       /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) */
       --overlay: oklch(21.03% 0.0242 155.00);

--- a/example/themes/sky.css
+++ b/example/themes/sky.css
@@ -13,8 +13,14 @@
       --foreground: oklch(21.03% 0.0059 225.00);
 
       /* Surface: Used for non-overlay components (cards, accordions, disclosure groups) */
-      --surface: oklch(100.00% 0.0024 225.00);
-      --surface-foreground: oklch(21.03% 0.0059 225.00);
+      --surface: oklch(100.00% 0.0031 225.00);
+      --surface-foreground: oklch(21.03% 0.0062 225.00);
+
+      --surface-secondary: oklch(95.24% 0.0050 225.00);
+      --surface-secondary-foreground: oklch(21.03% 0.0062 225.00);
+
+      --surface-tertiary: oklch(93.73% 0.0050 225.00);
+      --surface-tertiary-foreground: oklch(21.03% 0.0062 225.00);
 
       /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) */
       --overlay: oklch(100.00% 0.0014 225.00);
@@ -80,8 +86,14 @@
       --foreground: oklch(99.11% 0.0000 0.00);
 
       /* Surface: Used for non-overlay components (cards, accordions, disclosure groups) */
-      --surface: oklch(21.03% 0.0096 225.00);
-      --surface-foreground: oklch(99.11% 0.0000 0.00);
+      --surface: oklch(21.03% 0.0124 225.00);
+      --surface-foreground: oklch(99.11% 0.0062 225.00);
+
+      --surface-secondary: oklch(25.70% 0.0093 225.00);
+      --surface-secondary-foreground: oklch(99.11% 0.0062 225.00);
+      
+      --surface-tertiary: oklch(27.21% 0.0093 225.00);
+      --surface-tertiary-foreground: oklch(99.11% 0.0062 225.00);
 
       /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) */
       --overlay: oklch(21.03% 0.0096 225.00);

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -6,6 +6,12 @@
   --color-surface-foreground: var(--surface-foreground);
   --color-surface-hover: color-mix(in oklab, var(--surface) 92%, var(--surface-foreground) 8%);
 
+  --color-surface-secondary: var(--surface-secondary);
+  --color-surface-secondary-foreground: var(--surface-secondary-foreground);
+
+  --color-surface-tertiary: var(--surface-tertiary);
+  --color-surface-tertiary-foreground: var(--surface-tertiary-foreground);
+
   --color-overlay: var(--overlay);
   --color-overlay-foreground: var(--overlay-foreground);
 
@@ -84,28 +90,6 @@
   --color-success-soft: color-mix(in oklab, var(--success) 15%, transparent);
   --color-success-soft-foreground: var(--success);
   --color-success-soft-hover: color-mix(in oklab, var(--success) 20%, transparent);
-
-  /* Surface Levels - progressively darker/lighter shades for layering */
-  --color-surface-secondary: color-mix(in oklab, var(--surface) 94%, var(--surface-foreground) 6%);
-  --color-surface-tertiary: color-mix(in oklab, var(--surface) 92%, var(--surface-foreground) 8%);
-
-  /* On Surface Colors */
-  --color-on-surface: color-mix(in oklab, var(--surface) 93%, var(--surface-foreground) 7%);
-  --color-on-surface-foreground: var(--surface-foreground);
-  --color-on-surface-hover: color-mix(in oklab, var(--surface) 91%, var(--surface-foreground) 9%);
-  --color-on-surface-focus: color-mix(in oklab, var(--surface) 93%, var(--surface-foreground) 7%);
-
-  /* On Surface Colors - Secondary (on secondary surface) */
-  --color-on-surface-secondary: color-mix(in oklab, var(--surface) 87%, var(--surface-foreground) 13%);
-  --color-on-surface-secondary-foreground: var(--surface-foreground);
-  --color-on-surface-secondary-hover: color-mix(in oklab, var(--surface) 85%, var(--surface-foreground) 15%);
-  --color-on-surface-secondary-focus: color-mix(in oklab, var(--surface) 87%, var(--surface-foreground) 13%);
-
-   /* On Surface Colors - Tertiary (on tertiary surface) */
-  --color-on-surface-tertiary: color-mix(in oklab, var(--surface) 85%, var(--surface-foreground) 15%);
-  --color-on-surface-tertiary-foreground: var(--surface-foreground);
-  --color-on-surface-tertiary-hover: color-mix(in oklab, var(--surface) 84%, var(--surface-foreground) 16%);
-  --color-on-surface-tertiary-focus: color-mix(in oklab, var(--surface) 85%, var(--surface-foreground) 15%);
 
   /* Separator Colors - Levels */
   --color-separator-secondary: color-mix(in oklab, var(--surface) 85%, var(--surface-foreground) 15%);

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -28,6 +28,12 @@
       --surface: var(--white);
       --surface-foreground: var(--foreground);
 
+      --surface-secondary: oklch(0.9524 0.0013 286.37);
+      --surface-secondary-foreground: var(--foreground);
+
+      --surface-tertiary: oklch(0.9373 0.0013 286.37);
+      --surface-tertiary-foreground: var(--foreground);
+
       /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) */
       --overlay: var(--white);
       --overlay-foreground: var(--foreground);
@@ -86,6 +92,12 @@
       /* Surface: Used for non-overlay components (cards, accordions, disclosure groups) */
       --surface: oklch(0.2103 0.0059 285.89);
       --surface-foreground: var(--foreground);
+
+      --surface-secondary: oklch(0.257 0.0037 286.14);
+      --surface-secondary-foreground: var(--foreground);
+
+      --surface-tertiary: oklch(0.2721 0.0024 247.91);
+      --surface-tertiary-foreground: var(--foreground);
 
       /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) - lighter for contrast */
       --overlay: oklch(0.2103 0.0059 285.89);


### PR DESCRIPTION
## 📝 Description

This PR refactors surface color variables so `surface-secondary` and `surface-tertiary` (and their foregrounds) are defined explicitly in each theme instead of via `color-mix`. The former `color-mix`-based surface levels and the `on-surface` palette are removed in favor of theme-defined values.

## ⛳️ Current behavior (updates)

Surface secondary and tertiary colors are calculated in the base theme with `color-mix`. Additional `on-surface`, `on-surface-secondary`, and `on-surface-tertiary` palettes (including hover/focus) are also defined in the base theme.

## 🚀 New behavior

- `surface-secondary` and `surface-tertiary` (with foregrounds) are now defined in each theme (alpha, lavander, mint, sky, variables.css)
- Base theme uses `var(--surface-secondary)` and `var(--surface-tertiary)` instead of `color-mix`
- Removed `on-surface`, `on-surface-secondary`, and `on-surface-tertiary` palettes from theme.css
- Theming docs updated with the new variable structure and examples

## 💣 Is this a breaking change (Yes/No):

**Yes** – The `on-surface`, `on-surface-secondary`, and `on-surface-tertiary` CSS variables and their variants were removed. `useThemeColor` still references them; those usages must be updated or these variables re-added before merge.

## 📝 Additional Information

All example themes (alpha, lavander, mint, sky) define the new surface variables with theme-specific oklch values. The default theme in `variables.css` was updated for consistency. Manual verification of surface components across themes is recommended.