### PR TITLE
feat(portal): add disableFullWindowOverlay to BottomSheet, Dialog, Popover, Select, Toast

### DIFF
--- a/src/components/bottom-sheet/bottom-sheet.md
+++ b/src/components/bottom-sheet/bottom-sheet.md
@@ -314,13 +314,14 @@ Animation configuration for bottom sheet root component. Can be:
 
 ### BottomSheet.Portal
 
-| prop         | type                   | default | description                                      |
-| ------------ | ---------------------- | ------- | ------------------------------------------------ |
-| `children`   | `React.ReactNode`      | -       | Portal content (overlay and bottom sheet)        |
-| `className`  | `string`               | -       | Additional CSS classes for portal container      |
-| `style`      | `StyleProp<ViewStyle>` | -       | Additional styles for portal container           |
-| `hostName`   | `string`               | -       | Optional portal host name for specific container |
-| `forceMount` | `boolean`              | -       | Force mount when closed for animation purposes   |
+| prop                     | type                   | default | description                                                                                           |
+| ------------------------ | ---------------------- | ------- | ----------------------------------------------------------------------------------------------------- |
+| `children`               | `React.ReactNode`      | -       | Portal content (overlay and bottom sheet)                                                              |
+| `disableFullWindowOverlay` | `boolean`            | `false` | When true on iOS, uses View instead of FullWindowOverlay. Enables element inspector; overlay won't appear above native modals |
+| `className`              | `string`               | -       | Additional CSS classes for portal container                                                           |
+| `style`                  | `StyleProp<ViewStyle>` | -       | Additional styles for portal container                                                                |
+| `hostName`               | `string`               | -       | Optional portal host name for specific container                                                      |
+| `forceMount`             | `boolean`              | -       | Force mount when closed for animation purposes                                                        |
 
 ### BottomSheet.Overlay
 
@@ -448,6 +449,10 @@ const MyContent = () => {
 See the [Text Input with Keyboard Avoidance](#text-input-with-keyboard-avoidance) section for more details and complete examples.
 
 ## Special Notes
+
+### Element Inspector (iOS)
+
+BottomSheet uses FullWindowOverlay on iOS, which renders in a separate native window. This breaks the React Native element inspector. To enable the inspector during development, set `disableFullWindowOverlay={true}` on `BottomSheet.Portal`. Tradeoff: the bottom sheet will not appear above native modals when disabled.
 
 ### Handling Close Callbacks
 

--- a/src/components/bottom-sheet/bottom-sheet.tsx
+++ b/src/components/bottom-sheet/bottom-sheet.tsx
@@ -108,7 +108,11 @@ const BottomSheetTrigger = forwardRef<
 
 // --------------------------------------------------
 
-const BottomSheetPortal = ({ children, ...props }: BottomSheetPortalProps) => {
+const BottomSheetPortal = ({
+  children,
+  disableFullWindowOverlay = false,
+  ...props
+}: BottomSheetPortalProps) => {
   const animationSettingsContext = useAnimationSettings();
   const animationContext = useBottomSheetAnimation();
 
@@ -116,7 +120,9 @@ const BottomSheetPortal = ({ children, ...props }: BottomSheetPortalProps) => {
     <BottomSheetPrimitives.Portal {...props}>
       <AnimationSettingsProvider value={animationSettingsContext}>
         <BottomSheetAnimationProvider value={animationContext}>
-          <FullWindowOverlay>
+          <FullWindowOverlay
+            disableFullWindowOverlay={disableFullWindowOverlay}
+          >
             <Animated.View
               style={StyleSheet.absoluteFill}
               pointerEvents="box-none"

--- a/src/components/bottom-sheet/bottom-sheet.types.ts
+++ b/src/components/bottom-sheet/bottom-sheet.types.ts
@@ -54,6 +54,12 @@ export interface BottomSheetTriggerProps
 export interface BottomSheetPortalProps
   extends BottomSheetPrimitivesTypes.PortalProps {
   /**
+   * When true, uses a regular View instead of FullWindowOverlay on iOS.
+   * Enables React Native element inspector but overlay won't appear above native modals.
+   * @default false
+   */
+  disableFullWindowOverlay?: boolean;
+  /**
    * The portal content
    */
   children: ReactNode;

--- a/src/components/dialog/dialog.md
+++ b/src/components/dialog/dialog.md
@@ -135,20 +135,20 @@ export default function DialogExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/beta/example/src/app/(home)/components/dialog.tsx).
+You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/beta/example/src/app/(home)/components/dialog.tsx>).
 
 ## API Reference
 
 ### Dialog
 
-| prop                       | type                       | default | description                                                                          |
-| -------------------------- | -------------------------- | ------- | ------------------------------------------------------------------------------------ |
-| `children`                 | `React.ReactNode`          | -       | Dialog content and trigger elements                                                  |
-| `isOpen`                   | `boolean`                  | -       | Controlled open state of the dialog                                                  |
-| `isDefaultOpen`            | `boolean`                  | `false` | Initial open state when uncontrolled                                                 |
-| `animation`                | `AnimationRootDisableAll`  | -       | Animation configuration                                                              |
-| `onOpenChange`             | `(value: boolean) => void` | -       | Callback when open state changes                                                     |
-| `...ViewProps`             | `ViewProps`                | -       | All standard React Native View props are supported                                   |
+| prop            | type                       | default | description                                        |
+| --------------- | -------------------------- | ------- | -------------------------------------------------- |
+| `children`      | `React.ReactNode`          | -       | Dialog content and trigger elements                |
+| `isOpen`        | `boolean`                  | -       | Controlled open state of the dialog                |
+| `isDefaultOpen` | `boolean`                  | `false` | Initial open state when uncontrolled               |
+| `animation`     | `AnimationRootDisableAll`  | -       | Animation configuration                            |
+| `onOpenChange`  | `(value: boolean) => void` | -       | Callback when open state changes                   |
+| `...ViewProps`  | `ViewProps`                | -       | All standard React Native View props are supported |
 
 #### AnimationRootDisableAll
 
@@ -168,13 +168,14 @@ Animation configuration for dialog root component. Can be:
 
 ### Dialog.Portal
 
-| prop         | type                   | default | description                                      |
-| ------------ | ---------------------- | ------- | ------------------------------------------------ |
-| `children`   | `React.ReactNode`      | -       | Portal content (overlay and dialog)              |
-| `className`  | `string`               | -       | Additional CSS classes for portal container      |
-| `style`      | `StyleProp<ViewStyle>` | -       | Additional styles for portal container           |
-| `hostName`   | `string`               | -       | Optional portal host name for specific container |
-| `forceMount` | `boolean`              | -       | Force mount when closed for animation purposes   |
+| prop                       | type                   | default | description                                                                                                                   |
+| -------------------------- | ---------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `children`                 | `React.ReactNode`      | -       | Portal content (overlay and dialog)                                                                                           |
+| `disableFullWindowOverlay` | `boolean`              | `false` | When true on iOS, uses View instead of FullWindowOverlay. Enables element inspector; overlay won't appear above native modals |
+| `className`                | `string`               | -       | Additional CSS classes for portal container                                                                                   |
+| `style`                    | `StyleProp<ViewStyle>` | -       | Additional styles for portal container                                                                                        |
+| `hostName`                 | `string`               | -       | Optional portal host name for specific container                                                                              |
+| `forceMount`               | `boolean`              | -       | Force mount when closed for animation purposes                                                                                |
 
 ### Dialog.Overlay
 
@@ -197,24 +198,24 @@ Animation configuration for dialog overlay component. Can be:
 - `true` or `undefined`: Use default animations
 - `object`: Custom animation configuration
 
-| prop            | type                       | default                    | description                                                                 |
-| --------------- | -------------------------- | -------------------------- | --------------------------------------------------------------------------- |
-| `state`         | `'disabled' \| boolean`    | -                          | Disable animations while customizing properties                             |
-| `opacity.value` | `[number, number, number]` | `[0, 1, 0]`                | Opacity values [idle, open, close] (progress-based, for dialog presentation) |
-| `entering`      | `EntryOrExitLayoutType`    | `FadeIn.duration(200)`     | Custom entering animation (for popover presentation)                        |
-| `exiting`       | `EntryOrExitLayoutType`    | `FadeOut.duration(150)`    | Custom exiting animation (for popover presentation)                           |
+| prop            | type                       | default                 | description                                                                  |
+| --------------- | -------------------------- | ----------------------- | ---------------------------------------------------------------------------- |
+| `state`         | `'disabled' \| boolean`    | -                       | Disable animations while customizing properties                              |
+| `opacity.value` | `[number, number, number]` | `[0, 1, 0]`             | Opacity values [idle, open, close] (progress-based, for dialog presentation) |
+| `entering`      | `EntryOrExitLayoutType`    | `FadeIn.duration(200)`  | Custom entering animation (for popover presentation)                         |
+| `exiting`       | `EntryOrExitLayoutType`    | `FadeOut.duration(150)` | Custom exiting animation (for popover presentation)                          |
 
 ### Dialog.Content
 
-| prop                    | type                     | default | description                                                  |
-| ----------------------- | ------------------------ | ------- | ------------------------------------------------------------ |
-| `children`              | `React.ReactNode`        | -       | Dialog content                                               |
-| `className`             | `string`                 | -       | Additional CSS classes for content container                 |
-| `style`                 | `StyleProp<ViewStyle>`   | -       | Additional styles for content container                      |
-| `animation`             | `DialogContentAnimation` | -       | Animation configuration                                      |
-| `isSwipeable`           | `boolean`                | `true`  | Whether the dialog content can be swiped to dismiss          |
-| `forceMount`            | `boolean`                | -       | Force mount when closed for animation purposes               |
-| `...Animated.ViewProps` | `Animated.ViewProps`     | -       | All Reanimated Animated.View props are supported             |
+| prop                    | type                     | default | description                                         |
+| ----------------------- | ------------------------ | ------- | --------------------------------------------------- |
+| `children`              | `React.ReactNode`        | -       | Dialog content                                      |
+| `className`             | `string`                 | -       | Additional CSS classes for content container        |
+| `style`                 | `StyleProp<ViewStyle>`   | -       | Additional styles for content container             |
+| `animation`             | `DialogContentAnimation` | -       | Animation configuration                             |
+| `isSwipeable`           | `boolean`                | `true`  | Whether the dialog content can be swiped to dismiss |
+| `forceMount`            | `boolean`                | -       | Force mount when closed for animation purposes      |
+| `...Animated.ViewProps` | `Animated.ViewProps`     | -       | All Reanimated Animated.View props are supported    |
 
 #### DialogContentAnimation
 
@@ -224,11 +225,11 @@ Animation configuration for dialog content component. Can be:
 - `true` or `undefined`: Use default animations
 - `object`: Custom animation configuration
 
-| prop       | type                    | default                                                                                                 | description                                     |
-| ---------- | ----------------------- | ------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| `state`    | `'disabled' \| boolean` | -                                                                                                       | Disable animations while customizing properties |
-| `entering` | `EntryOrExitLayoutType` | Keyframe with `scale: 0.96→1` and `opacity: 0→1` (200ms, easing: `Easing.out(Easing.ease)`)           | Custom entering animation                       |
-| `exiting`  | `EntryOrExitLayoutType` | Keyframe with `scale: 1→0.96` and `opacity: 1→0` (150ms, easing: `Easing.in(Easing.ease)`)             | Custom exiting animation                        |
+| prop       | type                    | default                                                                                     | description                                     |
+| ---------- | ----------------------- | ------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `state`    | `'disabled' \| boolean` | -                                                                                           | Disable animations while customizing properties |
+| `entering` | `EntryOrExitLayoutType` | Keyframe with `scale: 0.96→1` and `opacity: 0→1` (200ms, easing: `Easing.out(Easing.ease)`) | Custom entering animation                       |
+| `exiting`  | `EntryOrExitLayoutType` | Keyframe with `scale: 1→0.96` and `opacity: 1→0` (150ms, easing: `Easing.in(Easing.ease)`)  | Custom exiting animation                        |
 
 ### Dialog.Close
 
@@ -274,8 +275,14 @@ const { progress, isDragging, isGestureReleaseAnimationRunning } =
   useDialogAnimation();
 ```
 
-| property                           | type                  | description                                  |
-| ---------------------------------- | --------------------- | -------------------------------------------- |
-| `progress`                         | `SharedValue<number>` | Animation progress (0=idle, 1=open, 2=close) |
+| property                           | type                   | description                                  |
+| ---------------------------------- | ---------------------- | -------------------------------------------- |
+| `progress`                         | `SharedValue<number>`  | Animation progress (0=idle, 1=open, 2=close) |
 | `isDragging`                       | `SharedValue<boolean>` | Whether dialog is being dragged              |
 | `isGestureReleaseAnimationRunning` | `SharedValue<boolean>` | Whether gesture release animation is running |
+
+## Special Notes
+
+### Element Inspector (iOS)
+
+Dialog uses FullWindowOverlay on iOS. To enable the React Native element inspector during development, set `disableFullWindowOverlay={true}` on `Dialog.Portal`. Tradeoff: the dialog will not appear above native modals when disabled.

--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -109,6 +109,7 @@ const DialogPortal = ({
   className,
   children,
   style,
+  disableFullWindowOverlay = false,
   ...props
 }: DialogPortalProps) => {
   const animationSettingsContext = useAnimationSettings();
@@ -120,7 +121,9 @@ const DialogPortal = ({
     <DialogPrimitives.Portal {...props}>
       <AnimationSettingsProvider value={animationSettingsContext}>
         <DialogAnimationProvider value={animationContext}>
-          <FullWindowOverlay>
+          <FullWindowOverlay
+            disableFullWindowOverlay={disableFullWindowOverlay}
+          >
             <Animated.View
               className={portalClassName}
               style={style}

--- a/src/components/dialog/dialog.types.ts
+++ b/src/components/dialog/dialog.types.ts
@@ -58,6 +58,12 @@ export interface DialogTriggerProps extends DialogPrimitivesTypes.TriggerProps {
  */
 export interface DialogPortalProps extends DialogPrimitivesTypes.PortalProps {
   /**
+   * When true, uses a regular View instead of FullWindowOverlay on iOS.
+   * Enables React Native element inspector but overlay won't appear above native modals.
+   * @default false
+   */
+  disableFullWindowOverlay?: boolean;
+  /**
    * Additional CSS class for the portal container
    */
   className?: string;

--- a/src/components/popover/popover.md
+++ b/src/components/popover/popover.md
@@ -100,7 +100,9 @@ Control the width of the popover content using the `width` prop.
   <Popover.Trigger>...</Popover.Trigger>
   <Popover.Portal>
     <Popover.Overlay />
-    <Popover.Content presentation="popover" width={320}>...</Popover.Content>
+    <Popover.Content presentation="popover" width={320}>
+      ...
+    </Popover.Content>
   </Popover.Portal>
 </Popover>;
 
@@ -111,7 +113,9 @@ Control the width of the popover content using the `width` prop.
   <Popover.Trigger>...</Popover.Trigger>
   <Popover.Portal>
     <Popover.Overlay />
-    <Popover.Content presentation="popover" width="trigger">...</Popover.Content>
+    <Popover.Content presentation="popover" width="trigger">
+      ...
+    </Popover.Content>
   </Popover.Portal>
 </Popover>;
 
@@ -122,7 +126,9 @@ Control the width of the popover content using the `width` prop.
   <Popover.Trigger>...</Popover.Trigger>
   <Popover.Portal>
     <Popover.Overlay />
-    <Popover.Content presentation="popover" width="full">...</Popover.Content>
+    <Popover.Content presentation="popover" width="full">
+      ...
+    </Popover.Content>
   </Popover.Portal>
 </Popover>;
 
@@ -133,7 +139,9 @@ Control the width of the popover content using the `width` prop.
   <Popover.Trigger>...</Popover.Trigger>
   <Popover.Portal>
     <Popover.Overlay />
-    <Popover.Content presentation="popover" width="content-fit">...</Popover.Content>
+    <Popover.Content presentation="popover" width="content-fit">
+      ...
+    </Popover.Content>
   </Popover.Portal>
 </Popover>;
 ```
@@ -166,7 +174,9 @@ Control where the popover appears relative to the trigger element.
 <Popover>
   <Popover.Trigger>...</Popover.Trigger>
   <Popover.Portal>
-    <Popover.Content presentation="popover" placement="left">...</Popover.Content>
+    <Popover.Content presentation="popover" placement="left">
+      ...
+    </Popover.Content>
   </Popover.Portal>
 </Popover>
 ```
@@ -264,7 +274,11 @@ export default function PopoverExample() {
       </Popover.Trigger>
       <Popover.Portal>
         <Popover.Overlay />
-        <Popover.Content presentation="popover" width={320} className="gap-1 rounded-xl px-6 py-4">
+        <Popover.Content
+          presentation="popover"
+          width={320}
+          className="gap-1 rounded-xl px-6 py-4"
+        >
           <Popover.Close className="absolute top-3 right-3 z-50" />
           <Popover.Title>Information</Popover.Title>
           <Popover.Description>
@@ -278,22 +292,22 @@ export default function PopoverExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/beta/example/src/app/(home)/components/popover.tsx).
+You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/beta/example/src/app/(home)/components/popover.tsx>).
 
 ## API Reference
 
 ### Popover
 
-| prop            | type                        | default | description                                                               |
-| --------------- | --------------------------- | ------- | ------------------------------------------------------------------------- |
-| `children`      | `ReactNode`                 | -       | Children elements to be rendered inside the popover                       |
-| `isOpen`        | `boolean`                   | -       | Whether the popover is open (controlled mode)                             |
-| `isDefaultOpen` | `boolean`                   | -       | The open state of the popover when initially rendered (uncontrolled mode) |
-| `onOpenChange`  | `(isOpen: boolean) => void` | -       | Callback when the popover open state changes                              |
-| `animation`     | `AnimationRootDisableAll`      | -       | Animation configuration. Can be `false`, `"disabled"`, `"disable-all"`, `true`, or `undefined` |
-| `presentation` | `'popover' \| 'bottom-sheet'`  | `'popover'` | Presentation mode for the popover content                                 |
-| `asChild`       | `boolean`                   | `false` | Whether to render as a child element                                      |
-| `...ViewProps`  | `ViewProps`                 | -       | All standard React Native View props are supported                        |
+| prop            | type                          | default     | description                                                                                    |
+| --------------- | ----------------------------- | ----------- | ---------------------------------------------------------------------------------------------- |
+| `children`      | `ReactNode`                   | -           | Children elements to be rendered inside the popover                                            |
+| `isOpen`        | `boolean`                     | -           | Whether the popover is open (controlled mode)                                                  |
+| `isDefaultOpen` | `boolean`                     | -           | The open state of the popover when initially rendered (uncontrolled mode)                      |
+| `onOpenChange`  | `(isOpen: boolean) => void`   | -           | Callback when the popover open state changes                                                   |
+| `animation`     | `AnimationRootDisableAll`     | -           | Animation configuration. Can be `false`, `"disabled"`, `"disable-all"`, `true`, or `undefined` |
+| `presentation`  | `'popover' \| 'bottom-sheet'` | `'popover'` | Presentation mode for the popover content                                                      |
+| `asChild`       | `boolean`                     | `false`     | Whether to render as a child element                                                           |
+| `...ViewProps`  | `ViewProps`                   | -           | All standard React Native View props are supported                                             |
 
 #### AnimationRootDisableAll
 
@@ -314,13 +328,14 @@ Animation configuration for popover root component. Can be:
 
 ### Popover.Portal
 
-| prop           | type        | default | description                                        |
-| -------------- | ----------- | ------- | -------------------------------------------------- |
-| `children`     | `ReactNode` | -       | The portal content (required)                      |
-| `hostName`     | `string`    | -       | Optional name of the host element for the portal   |
-| `forceMount`   | `boolean`   | -       | Whether to force mount the component in the DOM    |
-| `className`    | `string`    | -       | Additional CSS classes for the portal container    |
-| `...ViewProps` | `ViewProps` | -       | All standard React Native View props are supported |
+| prop                       | type        | default | description                                                                                                                   |
+| -------------------------- | ----------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `children`                 | `ReactNode` | -       | The portal content (required)                                                                                                 |
+| `disableFullWindowOverlay` | `boolean`   | `false` | When true on iOS, uses View instead of FullWindowOverlay. Enables element inspector; overlay won't appear above native modals |
+| `hostName`                 | `string`    | -       | Optional name of the host element for the portal                                                                              |
+| `forceMount`               | `boolean`   | -       | Whether to force mount the component in the DOM                                                                               |
+| `className`                | `string`    | -       | Additional CSS classes for the portal container                                                                               |
+| `...ViewProps`             | `ViewProps` | -       | All standard React Native View props are supported                                                                            |
 
 ### Popover.Overlay
 
@@ -342,46 +357,46 @@ Animation configuration for popover overlay component. Can be:
 - `true` or `undefined`: Use default animations
 - `object`: Custom animation configuration
 
-| prop      | type                    | default     | description                                     |
-| --------- | ----------------------- | ----------- | ----------------------------------------------- |
-| `state`   | `'disabled' \| boolean` | -           | Disable animations while customizing properties |
-| `opacity.value` | `[number, number, number]` | `[0, 1, 0]` | Opacity values [idle, open, close] - Takes effect for bottom-sheet/dialog presentation |
-| `entering` | `EntryOrExitLayoutType` | FadeIn with duration 200ms | Custom Keyframe animation for entering transition - Takes effect for popover presentation |
-| `exiting` | `EntryOrExitLayoutType` | FadeOut with duration 150ms | Custom Keyframe animation for exiting transition - Takes effect for popover presentation |
+| prop            | type                       | default                     | description                                                                               |
+| --------------- | -------------------------- | --------------------------- | ----------------------------------------------------------------------------------------- |
+| `state`         | `'disabled' \| boolean`    | -                           | Disable animations while customizing properties                                           |
+| `opacity.value` | `[number, number, number]` | `[0, 1, 0]`                 | Opacity values [idle, open, close] - Takes effect for bottom-sheet/dialog presentation    |
+| `entering`      | `EntryOrExitLayoutType`    | FadeIn with duration 200ms  | Custom Keyframe animation for entering transition - Takes effect for popover presentation |
+| `exiting`       | `EntryOrExitLayoutType`    | FadeOut with duration 150ms | Custom Keyframe animation for exiting transition - Takes effect for popover presentation  |
 
 ### Popover.Content (Popover Presentation)
 
-| prop                      | type                                             | default         | description                                                  |
-| ------------------------- | ------------------------------------------------ | --------------- | ------------------------------------------------------------ |
-| `children`                | `ReactNode`                                      | -               | The popover content                                          |
+| prop                      | type                                             | default         | description                                                                                             |
+| ------------------------- | ------------------------------------------------ | --------------- | ------------------------------------------------------------------------------------------------------- |
+| `children`                | `ReactNode`                                      | -               | The popover content                                                                                     |
 | `presentation`            | `'popover'`                                      | `'popover'`     | Presentation mode - must match Popover.Root presentation prop. When not provided, defaults to 'popover' |
-| `width`                   | `number \| 'trigger' \| 'content-fit' \| 'full'` | `'content-fit'` | Width sizing strategy for the content                        |
-| `placement`               | `'top' \| 'bottom' \| 'left' \| 'right'`         | `'bottom'`      | Placement of the popover relative to trigger                 |
-| `align`                   | `'start' \| 'center' \| 'end'`                   | `'center'`      | Alignment along the placement axis                           |
-| `avoidCollisions`         | `boolean`                                        | `true`          | Whether to flip placement when close to viewport edges       |
-| `offset`                  | `number`                                         | `9`             | Distance from trigger element in pixels                      |
-| `alignOffset`             | `number`                                         | `0`             | Offset along the alignment axis in pixels                    |
-| `disablePositioningStyle` | `boolean`                                        | `false`         | Whether to disable automatic positioning styles              |
-| `forceMount`              | `boolean`                                        | -               | Whether to force mount the component in the DOM              |
-| `insets`                  | `Insets`                                         | -               | Screen edge insets to respect when positioning               |
-| `className`               | `string`                                         | -               | Additional CSS classes for the content container             |
-| `animation`               | `PopupPopoverContentAnimation`                   | -               | Animation configuration                                      |
-| `isAnimatedStyleActive`   | `boolean`                                        | `true`          | Whether animated styles (react-native-reanimated) are active |
-| `asChild`                 | `boolean`                                        | `false`         | Whether to render as a child element                         |
-| `...Animated.ViewProps`   | `Animated.ViewProps`                             | -               | All Reanimated Animated.View props are supported             |
+| `width`                   | `number \| 'trigger' \| 'content-fit' \| 'full'` | `'content-fit'` | Width sizing strategy for the content                                                                   |
+| `placement`               | `'top' \| 'bottom' \| 'left' \| 'right'`         | `'bottom'`      | Placement of the popover relative to trigger                                                            |
+| `align`                   | `'start' \| 'center' \| 'end'`                   | `'center'`      | Alignment along the placement axis                                                                      |
+| `avoidCollisions`         | `boolean`                                        | `true`          | Whether to flip placement when close to viewport edges                                                  |
+| `offset`                  | `number`                                         | `9`             | Distance from trigger element in pixels                                                                 |
+| `alignOffset`             | `number`                                         | `0`             | Offset along the alignment axis in pixels                                                               |
+| `disablePositioningStyle` | `boolean`                                        | `false`         | Whether to disable automatic positioning styles                                                         |
+| `forceMount`              | `boolean`                                        | -               | Whether to force mount the component in the DOM                                                         |
+| `insets`                  | `Insets`                                         | -               | Screen edge insets to respect when positioning                                                          |
+| `className`               | `string`                                         | -               | Additional CSS classes for the content container                                                        |
+| `animation`               | `PopupPopoverContentAnimation`                   | -               | Animation configuration                                                                                 |
+| `isAnimatedStyleActive`   | `boolean`                                        | `true`          | Whether animated styles (react-native-reanimated) are active                                            |
+| `asChild`                 | `boolean`                                        | `false`         | Whether to render as a child element                                                                    |
+| `...Animated.ViewProps`   | `Animated.ViewProps`                             | -               | All Reanimated Animated.View props are supported                                                        |
 
 ### Popover.Content (Bottom Sheet Presentation)
 
-| prop                        | type                   | default | description                                      |
-| --------------------------- | ---------------------- | ------- | ------------------------------------------------ |
-| `children`                  | `ReactNode`            | -       | The bottom sheet content                         |
+| prop                        | type                   | default | description                                                                                    |
+| --------------------------- | ---------------------- | ------- | ---------------------------------------------------------------------------------------------- |
+| `children`                  | `ReactNode`            | -       | The bottom sheet content                                                                       |
 | `presentation`              | `'bottom-sheet'`       | -       | Presentation mode - must be 'bottom-sheet' and match Popover.Root presentation prop (required) |
-| `contentContainerClassName` | `string`               | -       | Additional CSS classes for the content container |
-| `contentContainerProps`     | `BottomSheetViewProps` | -       | Props for the content container                  |
-| `enablePanDownToClose`      | `boolean`              | `true`  | Whether pan down gesture closes the sheet        |
-| `backgroundStyle`           | `ViewStyle`            | -       | Style for the bottom sheet background            |
-| `handleIndicatorStyle`      | `ViewStyle`            | -       | Style for the bottom sheet handle indicator      |
-| `...BottomSheetProps`       | `BottomSheetProps`     | -       | All @gorhom/bottom-sheet props are supported     |
+| `contentContainerClassName` | `string`               | -       | Additional CSS classes for the content container                                               |
+| `contentContainerProps`     | `BottomSheetViewProps` | -       | Props for the content container                                                                |
+| `enablePanDownToClose`      | `boolean`              | `true`  | Whether pan down gesture closes the sheet                                                      |
+| `backgroundStyle`           | `ViewStyle`            | -       | Style for the bottom sheet background                                                          |
+| `handleIndicatorStyle`      | `ViewStyle`            | -       | Style for the bottom sheet handle indicator                                                    |
+| `...BottomSheetProps`       | `BottomSheetProps`     | -       | All @gorhom/bottom-sheet props are supported                                                   |
 
 #### PopupPopoverContentAnimation
 
@@ -391,11 +406,11 @@ Animation configuration for popover content component (popover presentation). Ca
 - `true` or `undefined`: Use default animations
 - `object`: Custom animation configuration
 
-| prop      | type                    | default                                                         | description                                     |
-| --------- | ----------------------- | --------------------------------------------------------------- | ----------------------------------------------- |
-| `state`   | `'disabled' \| boolean` | -                                                               | Disable animations while customizing properties |
+| prop       | type                    | default                                                         | description                                       |
+| ---------- | ----------------------- | --------------------------------------------------------------- | ------------------------------------------------- |
+| `state`    | `'disabled' \| boolean` | -                                                               | Disable animations while customizing properties   |
 | `entering` | `EntryOrExitLayoutType` | Keyframe with translateY/translateX, scale, and opacity (200ms) | Custom Keyframe animation for entering transition |
-| `exiting` | `EntryOrExitLayoutType` | Keyframe mirroring entering animation (150ms)                   | Custom Keyframe animation for exiting transition |
+| `exiting`  | `EntryOrExitLayoutType` | Keyframe mirroring entering animation (150ms)                   | Custom Keyframe animation for exiting transition  |
 
 ### Popover.Arrow
 
@@ -479,9 +494,15 @@ const CustomContent = () => {
 
 **Returns:** `UsePopoverAnimationReturn`
 
-| property     | type                  | description                                                        |
-| ------------ | --------------------- | ------------------------------------------------------------------ |
-| `progress`   | `SharedValue<number>` | Progress value for the popover animation (0=idle, 1=open, 2=close) |
+| property     | type                   | description                                                        |
+| ------------ | ---------------------- | ------------------------------------------------------------------ |
+| `progress`   | `SharedValue<number>`  | Progress value for the popover animation (0=idle, 1=open, 2=close) |
 | `isDragging` | `SharedValue<boolean>` | Dragging state shared value                                        |
 
 **Note:** This hook must be used within a `Popover` component. It will throw an error if called outside of the popover animation context.
+
+## Special Notes
+
+### Element Inspector (iOS)
+
+Popover uses FullWindowOverlay on iOS. To enable the React Native element inspector during development, set `disableFullWindowOverlay={true}` on `Popover.Portal`. Tradeoff: the popover will not appear above native modals when disabled.

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -141,6 +141,7 @@ const PopoverTrigger = forwardRef<
 const PopoverPortal = ({
   className,
   children,
+  disableFullWindowOverlay = false,
   ...props
 }: PopoverPortalProps) => {
   const animationSettingsContext = useAnimationSettings();
@@ -152,7 +153,9 @@ const PopoverPortal = ({
     <PopoverPrimitives.Portal {...props}>
       <AnimationSettingsProvider value={animationSettingsContext}>
         <PopoverAnimationProvider value={animationContext}>
-          <FullWindowOverlay>
+          <FullWindowOverlay
+            disableFullWindowOverlay={disableFullWindowOverlay}
+          >
             <View className={portalClassName} pointerEvents="box-none">
               {children}
             </View>

--- a/src/components/popover/popover.types.ts
+++ b/src/components/popover/popover.types.ts
@@ -93,6 +93,12 @@ export interface PopoverTriggerProps
  */
 export interface PopoverPortalProps extends PopoverPrimitivesTypes.PortalProps {
   /**
+   * When true, uses a regular View instead of FullWindowOverlay on iOS.
+   * Enables React Native element inspector but overlay won't appear above native modals.
+   * @default false
+   */
+  disableFullWindowOverlay?: boolean;
+  /**
    * Additional CSS class for the portal container
    */
   className?: string;

--- a/src/components/select/select.md
+++ b/src/components/select/select.md
@@ -127,7 +127,7 @@ Control the width of the select content using the `width` prop. This only works 
   <Select.Trigger>...</Select.Trigger>
   <Select.Portal>
     <Select.Overlay />
-    <Select.Content presentation="popover"  width="trigger" >
+    <Select.Content presentation="popover" width="trigger">
       <Select.Item value="1" label="Item 1" />
     </Select.Content>
   </Select.Portal>
@@ -153,7 +153,7 @@ Control the width of the select content using the `width` prop. This only works 
   <Select.Trigger>...</Select.Trigger>
   <Select.Portal>
     <Select.Overlay />
-    <Select.Content presentation="popover" width="content-fit" >
+    <Select.Content presentation="popover" width="content-fit">
       <Select.Item value="1" label="Item 1" />
     </Select.Content>
   </Select.Portal>
@@ -408,26 +408,26 @@ export default function SelectExample() {
 }
 ```
 
-You can find more examples in the [GitHub repository](https://github.com/heroui-inc/heroui-native/blob/beta/example/src/app/(home)/components/select.tsx).
+You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/beta/example/src/app/(home)/components/select.tsx>).
 
 ## API Reference
 
 ### Select
 
-| prop                       | type                            | default     | description                                                            |
-| -------------------------- | ------------------------------- | ----------- | ---------------------------------------------------------------------- |
-| `children`                 | `ReactNode`                     | -           | The content of the select                                              |
-| `value`                    | `SelectOption`                  | -           | The selected value (controlled mode)                                   |
-| `onValueChange`            | `(value: SelectOption) => void` | -           | Callback when the value changes                                        |
-| `defaultValue`             | `SelectOption`                  | -           | The default selected value (uncontrolled mode)                         |
-| `isOpen`                   | `boolean`                       | -           | Whether the select is open (controlled mode)                           |
-| `isDefaultOpen`            | `boolean`                       | -           | Whether the select is open when initially rendered (uncontrolled mode) |
-| `onOpenChange`             | `(isOpen: boolean) => void`     | -           | Callback when the select open state changes                            |
-| `isDisabled`               | `boolean`                       | `false`     | Whether the select is disabled                                         |
-| `presentation`             | `'popover' \| 'bottom-sheet' \| 'dialog'` | `'popover'` | Presentation mode for the select content                               |
-| `animation`                | `SelectRootAnimation`           | -           | Animation configuration                                                |
-| `asChild`                  | `boolean`                       | `false`     | Whether to render as a child element                                   |
-| `...ViewProps`             | `ViewProps`                     | -           | All standard React Native View props are supported                     |
+| prop            | type                                      | default     | description                                                            |
+| --------------- | ----------------------------------------- | ----------- | ---------------------------------------------------------------------- |
+| `children`      | `ReactNode`                               | -           | The content of the select                                              |
+| `value`         | `SelectOption`                            | -           | The selected value (controlled mode)                                   |
+| `onValueChange` | `(value: SelectOption) => void`           | -           | Callback when the value changes                                        |
+| `defaultValue`  | `SelectOption`                            | -           | The default selected value (uncontrolled mode)                         |
+| `isOpen`        | `boolean`                                 | -           | Whether the select is open (controlled mode)                           |
+| `isDefaultOpen` | `boolean`                                 | -           | Whether the select is open when initially rendered (uncontrolled mode) |
+| `onOpenChange`  | `(isOpen: boolean) => void`               | -           | Callback when the select open state changes                            |
+| `isDisabled`    | `boolean`                                 | `false`     | Whether the select is disabled                                         |
+| `presentation`  | `'popover' \| 'bottom-sheet' \| 'dialog'` | `'popover'` | Presentation mode for the select content                               |
+| `animation`     | `SelectRootAnimation`                     | -           | Animation configuration                                                |
+| `asChild`       | `boolean`                                 | `false`     | Whether to render as a child element                                   |
+| `...ViewProps`  | `ViewProps`                               | -           | All standard React Native View props are supported                     |
 
 #### SelectRootAnimation
 
@@ -460,14 +460,14 @@ Animation configuration for Select component. Can be:
 
 ### Select.Trigger
 
-| prop                | type                        | default     | description                                             |
-| ------------------- | --------------------------- | ----------- | ------------------------------------------------------- |
-| `variant`           | `'default' \| 'unstyled'`  | `'default'` | The variant of the trigger. `'default'` applies pre-styled container styles, `'unstyled'` removes default styling |
-| `children`          | `ReactNode`                 | -           | The trigger element content                             |
-| `className`         | `string`                    | -           | Additional CSS classes for the trigger                  |
-| `asChild`           | `boolean`                   | `true`      | Whether to render as a child element                    |
-| `isDisabled`        | `boolean`                   | -           | Whether the trigger is disabled                         |
-| `...PressableProps` | `PressableProps`            | -           | All standard React Native Pressable props are supported |
+| prop                | type                      | default     | description                                                                                                       |
+| ------------------- | ------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------- |
+| `variant`           | `'default' \| 'unstyled'` | `'default'` | The variant of the trigger. `'default'` applies pre-styled container styles, `'unstyled'` removes default styling |
+| `children`          | `ReactNode`               | -           | The trigger element content                                                                                       |
+| `className`         | `string`                  | -           | Additional CSS classes for the trigger                                                                            |
+| `asChild`           | `boolean`                 | `true`      | Whether to render as a child element                                                                              |
+| `isDisabled`        | `boolean`                 | -           | Whether the trigger is disabled                                                                                   |
+| `...PressableProps` | `PressableProps`          | -           | All standard React Native Pressable props are supported                                                           |
 
 ### Select.Value
 
@@ -478,31 +478,33 @@ Animation configuration for Select component. Can be:
 | `...TextProps` | `TextProps` | -       | All standard React Native Text props are supported |
 
 **Note:** The value component automatically applies different text colors based on selection state:
+
 - When a value is selected: `text-foreground`
 - When no value is selected (placeholder): `text-field-placeholder`
 
 ### Select.TriggerIndicator
 
-| prop                    | type                                 | default | description                                                  |
-| ----------------------- | ------------------------------------ | ------- | ------------------------------------------------------------ |
-| `children`              | `ReactNode`                          | -       | Custom indicator content. Defaults to animated chevron icon  |
-| `className`             | `string`                             | -       | Additional CSS classes for the trigger indicator             |
-| `style`                 | `ViewStyle`                          | -       | Custom styles for the trigger indicator                      |
-| `iconProps`             | `SelectTriggerIndicatorIconProps`     | -       | Chevron icon configuration                                   |
-| `animation`             | `SelectTriggerIndicatorAnimation`   | -       | Animation configuration                                      |
-| `isAnimatedStyleActive` | `boolean`                            | `true`  | Whether animated styles (react-native-reanimated) are active |
-| `...ViewProps`          | `ViewProps`                          | -       | All standard React Native View props are supported           |
+| prop                    | type                              | default | description                                                  |
+| ----------------------- | --------------------------------- | ------- | ------------------------------------------------------------ |
+| `children`              | `ReactNode`                       | -       | Custom indicator content. Defaults to animated chevron icon  |
+| `className`             | `string`                          | -       | Additional CSS classes for the trigger indicator             |
+| `style`                 | `ViewStyle`                       | -       | Custom styles for the trigger indicator                      |
+| `iconProps`             | `SelectTriggerIndicatorIconProps` | -       | Chevron icon configuration                                   |
+| `animation`             | `SelectTriggerIndicatorAnimation` | -       | Animation configuration                                      |
+| `isAnimatedStyleActive` | `boolean`                         | `true`  | Whether animated styles (react-native-reanimated) are active |
+| `...ViewProps`          | `ViewProps`                       | -       | All standard React Native View props are supported           |
 
 **Note:** The following style properties are occupied by animations and cannot be set via className:
+
 - `transform` (specifically `rotate`) - Animated for open/close rotation transitions
 
 To customize this property, use the `animation` prop. To completely disable animated styles and use your own via className or style prop, set `isAnimatedStyleActive={false}`.
 
 #### SelectTriggerIndicatorIconProps
 
-| prop    | type     | default | description       |
-| ------- | -------- | ------- | ----------------- |
-| `size`  | `number` | `16`    | Size of the icon  |
+| prop    | type     | default | description                                            |
+| ------- | -------- | ------- | ------------------------------------------------------ |
+| `size`  | `number` | `16`    | Size of the icon                                       |
 | `color` | `string` | -       | Color of the icon (defaults to foreground theme color) |
 
 #### SelectTriggerIndicatorAnimation
@@ -513,21 +515,22 @@ Animation configuration for Select.TriggerIndicator component. Can be:
 - `true` or `undefined`: Use default animations (rotation from 0° to -180°)
 - `object`: Custom animation configuration
 
-| prop                    | type               | default                        | description                                     |
-| ----------------------- | ------------------ | ------------------------------ | ----------------------------------------------- |
-| `state`                 | `'disabled' \| boolean` | -                          | Disable animations while customizing properties |
-| `rotation.value`         | `[number, number]` | `[0, -180]`                    | Rotation values [closed, open] in degrees       |
-| `rotation.springConfig` | `WithSpringConfig` | `{ damping: 140, stiffness: 1000, mass: 4 }` | Spring animation configuration for rotation      |
+| prop                    | type                    | default                                      | description                                     |
+| ----------------------- | ----------------------- | -------------------------------------------- | ----------------------------------------------- |
+| `state`                 | `'disabled' \| boolean` | -                                            | Disable animations while customizing properties |
+| `rotation.value`        | `[number, number]`      | `[0, -180]`                                  | Rotation values [closed, open] in degrees       |
+| `rotation.springConfig` | `WithSpringConfig`      | `{ damping: 140, stiffness: 1000, mass: 4 }` | Spring animation configuration for rotation     |
 
 ### Select.Portal
 
-| prop           | type        | default | description                                        |
-| -------------- | ----------- | ------- | -------------------------------------------------- |
-| `children`     | `ReactNode` | -       | The portal content (required)                      |
-| `className`    | `string`    | -       | Additional CSS classes for the portal container    |
-| `hostName`     | `string`    | -       | Optional name of the host element for the portal   |
-| `forceMount`   | `boolean`   | -       | Whether to force mount the component in the DOM    |
-| `...ViewProps` | `ViewProps` | -       | All standard React Native View props are supported |
+| prop                       | type        | default | description                                                                                                                   |
+| -------------------------- | ----------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `children`                 | `ReactNode` | -       | The portal content (required)                                                                                                 |
+| `disableFullWindowOverlay` | `boolean`   | `false` | When true on iOS, uses View instead of FullWindowOverlay. Enables element inspector; overlay won't appear above native modals |
+| `className`                | `string`    | -       | Additional CSS classes for the portal container                                                                               |
+| `hostName`                 | `string`    | -       | Optional name of the host element for the portal                                                                              |
+| `forceMount`               | `boolean`   | -       | Whether to force mount the component in the DOM                                                                               |
+| `...ViewProps`             | `ViewProps` | -       | All standard React Native View props are supported                                                                            |
 
 ### Select.Overlay
 
@@ -549,31 +552,31 @@ Animation configuration for Select.Overlay component. Can be:
 - `true` or `undefined`: Use default animations (progress-based opacity for bottom-sheet/dialog, Keyframe animations for popover)
 - `object`: Custom animation configuration
 
-| prop            | type                       | default     | description                                     |
-| --------------- | -------------------------- | ----------- | ----------------------------------------------- |
-| `state`         | `'disabled' \| boolean`    | -           | Disable animations while customizing properties |
-| `opacity.value` | `[number, number, number]` | `[0, 1, 0]` | Opacity values [idle, open, close] (for bottom-sheet/dialog presentation) |
+| prop            | type                       | default     | description                                                                  |
+| --------------- | -------------------------- | ----------- | ---------------------------------------------------------------------------- |
+| `state`         | `'disabled' \| boolean`    | -           | Disable animations while customizing properties                              |
+| `opacity.value` | `[number, number, number]` | `[0, 1, 0]` | Opacity values [idle, open, close] (for bottom-sheet/dialog presentation)    |
 | `entering`      | `EntryOrExitLayoutType`    | -           | Custom Keyframe animation for entering transition (for popover presentation) |
-| `exiting`       | `EntryOrExitLayoutType`    | -           | Custom Keyframe animation for exiting transition (for popover presentation) |
+| `exiting`       | `EntryOrExitLayoutType`    | -           | Custom Keyframe animation for exiting transition (for popover presentation)  |
 
 ### Select.Content (Popover Presentation)
 
-| prop                    | type                                             | default         | description                                                  |
-| ----------------------- | ------------------------------------------------ | --------------- | ------------------------------------------------------------ |
-| `children`              | `ReactNode`                                      | -               | The select content                                           |
-| `width`                 | `number \| 'trigger' \| 'content-fit' \| 'full'` | `'content-fit'` | Width sizing strategy for the content                        |
-| `presentation`          | `'popover'`                                      | `'popover'`     | Presentation mode for the select                             |
-| `placement`             | `'top' \| 'bottom' \| 'left' \| 'right'`         | `'bottom'`      | Placement of the content relative to trigger                 |
-| `align`                 | `'start' \| 'center' \| 'end'`                   | `'center'`      | Alignment along the placement axis                           |
-| `avoidCollisions`       | `boolean`                                        | `true`          | Whether to flip placement when close to viewport edges       |
-| `offset`                | `number`                                         | `8`             | Distance from trigger element in pixels                      |
-| `alignOffset`           | `number`                                         | `0`             | Offset along the alignment axis in pixels                    |
-| `className`             | `string`                                         | -               | Additional CSS classes for the content container             |
-| `animation`             | `SelectContentPopoverAnimation`                  | -               | Animation configuration                                      |
-| `forceMount`            | `boolean`                                        | -               | Whether to force mount the component in the DOM              |
-| `insets`                | `Insets`                                         | -               | Screen edge insets to respect when positioning               |
-| `asChild`               | `boolean`                                        | `false`         | Whether to render as a child element                         |
-| `...Animated.ViewProps` | `Animated.ViewProps`                             | -               | All Reanimated Animated.View props are supported             |
+| prop                    | type                                             | default         | description                                            |
+| ----------------------- | ------------------------------------------------ | --------------- | ------------------------------------------------------ |
+| `children`              | `ReactNode`                                      | -               | The select content                                     |
+| `width`                 | `number \| 'trigger' \| 'content-fit' \| 'full'` | `'content-fit'` | Width sizing strategy for the content                  |
+| `presentation`          | `'popover'`                                      | `'popover'`     | Presentation mode for the select                       |
+| `placement`             | `'top' \| 'bottom' \| 'left' \| 'right'`         | `'bottom'`      | Placement of the content relative to trigger           |
+| `align`                 | `'start' \| 'center' \| 'end'`                   | `'center'`      | Alignment along the placement axis                     |
+| `avoidCollisions`       | `boolean`                                        | `true`          | Whether to flip placement when close to viewport edges |
+| `offset`                | `number`                                         | `8`             | Distance from trigger element in pixels                |
+| `alignOffset`           | `number`                                         | `0`             | Offset along the alignment axis in pixels              |
+| `className`             | `string`                                         | -               | Additional CSS classes for the content container       |
+| `animation`             | `SelectContentPopoverAnimation`                  | -               | Animation configuration                                |
+| `forceMount`            | `boolean`                                        | -               | Whether to force mount the component in the DOM        |
+| `insets`                | `Insets`                                         | -               | Screen edge insets to respect when positioning         |
+| `asChild`               | `boolean`                                        | `false`         | Whether to render as a child element                   |
+| `...Animated.ViewProps` | `Animated.ViewProps`                             | -               | All Reanimated Animated.View props are supported       |
 
 #### SelectContentPopoverAnimation
 
@@ -583,11 +586,11 @@ Animation configuration for Select.Content component (popover presentation). Can
 - `true` or `undefined`: Use default Keyframe animations (translateY/translateX, scale, opacity based on placement)
 - `object`: Custom animation configuration with `entering` and/or `exiting` Keyframe animations
 
-| prop       | type                    | default | description                                     |
-| ---------- | ----------------------- | ------- | ----------------------------------------------- |
-| `state`    | `'disabled' \| boolean` | -       | Disable animations while customizing properties |
+| prop       | type                    | default | description                                                                                                                                |
+| ---------- | ----------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `state`    | `'disabled' \| boolean` | -       | Disable animations while customizing properties                                                                                            |
 | `entering` | `EntryOrExitLayoutType` | -       | Custom Keyframe animation for entering transition (default: Keyframe with translateY/translateX, scale, opacity based on placement, 200ms) |
-| `exiting`  | `EntryOrExitLayoutType` | -       | Custom Keyframe animation for exiting transition (default: Keyframe mirroring entering animation, 150ms) |
+| `exiting`  | `EntryOrExitLayoutType` | -       | Custom Keyframe animation for exiting transition (default: Keyframe mirroring entering animation, 150ms)                                   |
 
 ### Select.Content (Bottom Sheet Presentation)
 
@@ -600,24 +603,24 @@ Animation configuration for Select.Content component (popover presentation). Can
 
 ### Select.Content (Dialog Presentation)
 
-| prop                    | type                                     | default | description                                                  |
-| ----------------------- | ---------------------------------------- | ------- | ------------------------------------------------------------ |
-| `children`              | `ReactNode`                              | -       | The dialog content                                           |
-| `presentation`          | `'dialog'`                               | -       | Presentation mode for the select                             |
-| `classNames`            | `{ wrapper?: string; content?: string }` | -       | Additional CSS classes for wrapper and content               |
-| `styles`                | `Partial<Record<DialogContentFallbackSlots, ViewStyle>>` | - | Styles for different parts of the dialog content            |
-| `animation`             | `SelectContentAnimation`                 | -       | Animation configuration                                      |
-| `isSwipeable`           | `boolean`                                | `true`  | Whether the dialog content can be swiped to dismiss          |
-| `forceMount`            | `boolean`                                | -       | Whether to force mount the component in the DOM              |
-| `asChild`               | `boolean`                                | `false` | Whether to render as a child element                         |
-| `...ViewProps`          | `ViewProps`                              | -       | All standard React Native View props are supported           |
+| prop           | type                                                     | default | description                                         |
+| -------------- | -------------------------------------------------------- | ------- | --------------------------------------------------- |
+| `children`     | `ReactNode`                                              | -       | The dialog content                                  |
+| `presentation` | `'dialog'`                                               | -       | Presentation mode for the select                    |
+| `classNames`   | `{ wrapper?: string; content?: string }`                 | -       | Additional CSS classes for wrapper and content      |
+| `styles`       | `Partial<Record<DialogContentFallbackSlots, ViewStyle>>` | -       | Styles for different parts of the dialog content    |
+| `animation`    | `SelectContentAnimation`                                 | -       | Animation configuration                             |
+| `isSwipeable`  | `boolean`                                                | `true`  | Whether the dialog content can be swiped to dismiss |
+| `forceMount`   | `boolean`                                                | -       | Whether to force mount the component in the DOM     |
+| `asChild`      | `boolean`                                                | `false` | Whether to render as a child element                |
+| `...ViewProps` | `ViewProps`                                              | -       | All standard React Native View props are supported  |
 
 #### `styles`
 
-| prop      | type        | description                          |
-| --------- | ----------- | ------------------------------------ |
-| `wrapper` | `ViewStyle` | Styles for the wrapper container     |
-| `content` | `ViewStyle` | Styles for the dialog content         |
+| prop      | type        | description                      |
+| --------- | ----------- | -------------------------------- |
+| `wrapper` | `ViewStyle` | Styles for the wrapper container |
+| `content` | `ViewStyle` | Styles for the dialog content    |
 
 #### SelectContentAnimation
 
@@ -627,10 +630,10 @@ Animation configuration for Select.Content component (dialog presentation). Can 
 - `true` or `undefined`: Use default Keyframe animations (scale and opacity transitions)
 - `object`: Custom animation configuration with `entering` and/or `exiting` Keyframe animations
 
-| prop       | type                    | default | description                                     |
-| ---------- | ----------------------- | ------- | ----------------------------------------------- |
-| `state`    | `'disabled' \| boolean` | -       | Disable animations while customizing properties |
-| `entering` | `EntryOrExitLayoutType` | -       | Custom Keyframe animation for entering transition (default: Keyframe with scale and opacity, 200ms) |
+| prop       | type                    | default | description                                                                                              |
+| ---------- | ----------------------- | ------- | -------------------------------------------------------------------------------------------------------- |
+| `state`    | `'disabled' \| boolean` | -       | Disable animations while customizing properties                                                          |
+| `entering` | `EntryOrExitLayoutType` | -       | Custom Keyframe animation for entering transition (default: Keyframe with scale and opacity, 200ms)      |
 | `exiting`  | `EntryOrExitLayoutType` | -       | Custom Keyframe animation for exiting transition (default: Keyframe mirroring entering animation, 150ms) |
 
 ### Select.Close
@@ -754,11 +757,11 @@ const { selectState, progress, isDragging, isGestureReleaseAnimationRunning } =
 
 #### Return Value
 
-| property                           | type                          | description                                                |
-| ---------------------------------- | ----------------------------- | ---------------------------------------------------------- |
-| `progress`                         | `SharedValue<number>`         | Progress value for animations (0=idle, 1=open, 2=close)    |
-| `isDragging`                       | `SharedValue<boolean>`        | Whether the select content is currently being dragged      |
-| `isGestureReleaseAnimationRunning` | `SharedValue<boolean>`        | Whether the gesture release animation is currently running |
+| property                           | type                   | description                                                |
+| ---------------------------------- | ---------------------- | ---------------------------------------------------------- |
+| `progress`                         | `SharedValue<number>`  | Progress value for animations (0=idle, 1=open, 2=close)    |
+| `isDragging`                       | `SharedValue<boolean>` | Whether the select content is currently being dragged      |
+| `isGestureReleaseAnimationRunning` | `SharedValue<boolean>` | Whether the gesture release animation is currently running |
 
 **Note:** This hook must be used within a `Select` component. It will throw an error if called outside of the select animation context.
 
@@ -785,3 +788,9 @@ const { itemValue, label } = useSelectItem();
 | ----------- | -------- | ---------------------------------- |
 | `itemValue` | `string` | The value of the current item      |
 | `label`     | `string` | The label text of the current item |
+
+## Special Notes
+
+### Element Inspector (iOS)
+
+Select uses FullWindowOverlay on iOS. To enable the React Native element inspector during development, set `disableFullWindowOverlay={true}` on `Select.Portal`. Tradeoff: the select dropdown will not appear above native modals when disabled.

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -230,7 +230,12 @@ const SelectTriggerIndicator = forwardRef<ViewRef, SelectTriggerIndicatorProps>(
 
 // --------------------------------------------------
 
-const SelectPortal = ({ className, children, ...props }: SelectPortalProps) => {
+const SelectPortal = ({
+  className,
+  children,
+  disableFullWindowOverlay = false,
+  ...props
+}: SelectPortalProps) => {
   const animationSettingsContext = useAnimationSettings();
   const animationContext = useSelectAnimation();
 
@@ -240,7 +245,9 @@ const SelectPortal = ({ className, children, ...props }: SelectPortalProps) => {
     <SelectPrimitives.Portal {...props}>
       <AnimationSettingsProvider value={animationSettingsContext}>
         <SelectAnimationProvider value={animationContext}>
-          <FullWindowOverlay>
+          <FullWindowOverlay
+            disableFullWindowOverlay={disableFullWindowOverlay}
+          >
             <View className={portalClassName}>{children}</View>
           </FullWindowOverlay>
         </SelectAnimationProvider>

--- a/src/components/select/select.types.ts
+++ b/src/components/select/select.types.ts
@@ -190,6 +190,12 @@ export interface SelectTriggerIndicatorProps
  */
 export interface SelectPortalProps extends SelectPrimitivesTypes.PortalProps {
   /**
+   * When true, uses a regular View instead of FullWindowOverlay on iOS.
+   * Enables React Native element inspector but overlay won't appear above native modals.
+   * @default false
+   */
+  disableFullWindowOverlay?: boolean;
+  /**
    * Additional CSS class for the portal container
    */
   className?: string;

--- a/src/components/toast/toast.md
+++ b/src/components/toast/toast.md
@@ -332,13 +332,14 @@ For inherited props including `isDisabled` and all Button props, see [Button API
 
 Props for configuring toast behavior globally via `HeroUINativeProvider` config prop.
 
-| prop               | type                                                | default | description                                                      |
-| ------------------ | --------------------------------------------------- | ------- | ---------------------------------------------------------------- |
-| `defaultProps`     | `ToastGlobalConfig`                                 | -       | Global toast configuration used as defaults for all toasts       |
-| `insets`           | `ToastInsets`                                       | -       | Insets for spacing from screen edges (added to safe area insets) |
-| `maxVisibleToasts` | `number`                                            | `3`     | Maximum number of visible toasts before opacity starts fading    |
-| `contentWrapper`   | `(children: React.ReactNode) => React.ReactElement` | -       | Custom wrapper function to wrap toast content                    |
-| `children`         | `React.ReactNode`                                   | -       | Children to render                                               |
+| prop                       | type                                                | default | description                                                                                                                  |
+| -------------------------- | --------------------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| `defaultProps`             | `ToastGlobalConfig`                                 | -       | Global toast configuration used as defaults for all toasts                                                                   |
+| `disableFullWindowOverlay` | `boolean`                                           | `false` | When true on iOS, uses View instead of FullWindowOverlay. Enables element inspector; toasts won't appear above native modals |
+| `insets`                   | `ToastInsets`                                       | -       | Insets for spacing from screen edges (added to safe area insets)                                                             |
+| `maxVisibleToasts`         | `number`                                            | `3`     | Maximum number of visible toasts before opacity starts fading                                                                |
+| `contentWrapper`           | `(children: React.ReactNode) => React.ReactElement` | -       | Custom wrapper function to wrap toast content                                                                                |
+| `children`                 | `React.ReactNode`                                   | -       | Children to render                                                                                                           |
 
 #### ToastGlobalConfig
 
@@ -412,3 +413,8 @@ Options for showing a toast. Can be either a config object with default styling 
 | `onShow`    | `() => void`                                         | -       | Callback function called when the toast is shown                                    |
 | `onHide`    | `() => void`                                         | -       | Callback function called when the toast is hidden                                   |
 
+## Special Notes
+
+### Element Inspector (iOS)
+
+Toast uses FullWindowOverlay on iOS. To enable the React Native element inspector during development, set `disableFullWindowOverlay={true}` on `ToastProvider` (via `config.toast` when using HeroUINativeProvider). Tradeoff: toasts will not appear above native modals when disabled.

--- a/src/helpers/internal/components/full-window-overlay.tsx
+++ b/src/helpers/internal/components/full-window-overlay.tsx
@@ -1,6 +1,48 @@
-import React from 'react';
+import type { ReactNode } from 'react';
 import { Platform } from 'react-native';
 import { FullWindowOverlay as NativeFullWindowOverlay } from 'react-native-screens';
 
-export const FullWindowOverlay =
-  Platform.OS === 'ios' ? NativeFullWindowOverlay : React.Fragment;
+/**
+ * Props for the FullWindowOverlay component
+ *
+ * @description
+ * FullWindowOverlay renders content in a separate native window on iOS,
+ * which allows overlays (bottom sheets, dialogs, toasts) to appear above
+ * native modals and the keyboard. However, this breaks the React Native
+ * element inspector because it attaches to the main window.
+ *
+ * Set `disableFullWindowOverlay={true}` when you need to use the element
+ * inspector during development. Note: when disabled, overlay content will
+ * not render above native modals. iOS only; has no effect on Android.
+ */
+export interface FullWindowOverlayProps {
+  /**
+   * When true, uses a regular View instead of FullWindowOverlay on iOS.
+   * Enables element inspector but overlay content won't appear above native modals.
+   * @default false
+   */
+  disableFullWindowOverlay: boolean;
+  /**
+   * Content to render inside the overlay
+   */
+  children: ReactNode;
+}
+
+/**
+ * Wrapper for react-native-screens FullWindowOverlay with optional disable prop.
+ *
+ * @description
+ * On iOS, FullWindowOverlay creates a separate native window for overlay content,
+ * which breaks the React Native element inspector. Use `disableFullWindowOverlay`
+ * when debugging to render content in the main window instead.
+ */
+export function FullWindowOverlay({
+  disableFullWindowOverlay,
+  children,
+}: FullWindowOverlayProps) {
+  if (Platform.OS !== 'ios' || disableFullWindowOverlay) {
+    return <>{children}</>;
+  }
+
+  return <NativeFullWindowOverlay>{children}</NativeFullWindowOverlay>;
+}

--- a/src/providers/toast/insets-container.tsx
+++ b/src/providers/toast/insets-container.tsx
@@ -1,11 +1,17 @@
 import type { ReactNode } from 'react';
-import { Fragment, useMemo } from 'react';
+import { useMemo } from 'react';
 import { Platform, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { FullWindowOverlay } from 'react-native-screens';
+import { FullWindowOverlay } from '../../helpers/internal/components';
 import type { ToastInsets } from './types';
 
 interface InsetsContainerProps {
+  /**
+   * When true, uses a regular View instead of FullWindowOverlay on iOS.
+   * Enables element inspector but toasts won't appear above native modals.
+   * @default false
+   */
+  disableFullWindowOverlay: boolean;
   /**
    * Optional inset values for all edges
    * If not provided, defaults to platform-specific values:
@@ -40,6 +46,7 @@ export function InsetsContainer({
   insets,
   contentWrapper,
   children,
+  disableFullWindowOverlay,
 }: InsetsContainerProps) {
   const safeAreaInsets = useSafeAreaInsets();
 
@@ -54,21 +61,27 @@ export function InsetsContainer({
     };
   }, [safeAreaInsets, insets]);
 
-  const WindowOverlay = Platform.OS === 'ios' ? FullWindowOverlay : Fragment;
+  const content = (
+    <View
+      className="absolute inset-0 pointer-events-box-none"
+      style={{
+        paddingTop: finalInsets.top,
+        paddingBottom: finalInsets.bottom,
+        paddingLeft: finalInsets.left,
+        paddingRight: finalInsets.right,
+      }}
+    >
+      {contentWrapper ? contentWrapper(children) : children}
+    </View>
+  );
+
+  if (Platform.OS !== 'ios') {
+    return content;
+  }
 
   return (
-    <WindowOverlay>
-      <View
-        className="absolute inset-0 pointer-events-box-none"
-        style={{
-          paddingTop: finalInsets.top,
-          paddingBottom: finalInsets.bottom,
-          paddingLeft: finalInsets.left,
-          paddingRight: finalInsets.right,
-        }}
-      >
-        {contentWrapper ? contentWrapper(children) : children}
-      </View>
-    </WindowOverlay>
+    <FullWindowOverlay disableFullWindowOverlay={disableFullWindowOverlay}>
+      {content}
+    </FullWindowOverlay>
   );
 }

--- a/src/providers/toast/provider.tsx
+++ b/src/providers/toast/provider.tsx
@@ -122,6 +122,7 @@ export function ToastProvider({
   maxVisibleToasts = 3,
   contentWrapper,
   children,
+  disableFullWindowOverlay = false,
 }: ToastProviderProps) {
   const [toasts, dispatch] = useReducer(toastReducer, []);
 
@@ -369,7 +370,11 @@ export function ToastProvider({
       <ToasterContext.Provider value={contextValue}>
         {children}
         {toasts.length > 0 && (
-          <InsetsContainer insets={insets} contentWrapper={contentWrapper}>
+          <InsetsContainer
+            insets={insets}
+            contentWrapper={contentWrapper}
+            disableFullWindowOverlay={disableFullWindowOverlay}
+          >
             <View className="flex-1">
               {toasts.map((toastItem, index) => (
                 <ToastItemRenderer

--- a/src/providers/toast/types.ts
+++ b/src/providers/toast/types.ts
@@ -42,6 +42,12 @@ export interface ToastInsets {
  */
 export interface ToastProviderProps {
   /**
+   * When true, uses a regular View instead of FullWindowOverlay on iOS for toasts.
+   * Enables React Native element inspector but toasts won't appear above native modals.
+   * @default false
+   */
+  disableFullWindowOverlay?: boolean;
+  /**
    * Global toast configuration
    * These values are used as defaults for all toasts unless overridden locally
    * Local configs have precedence over global config


### PR DESCRIPTION
Closes #272

## 📝 Description

Adds a `disableFullWindowOverlay` prop to BottomSheet.Portal, Dialog.Portal, Popover.Portal, Select.Portal, and ToastProvider. On iOS, FullWindowOverlay uses a separate native window and breaks the React Native element inspector. Setting this prop to `true` renders content in the main window instead, enabling the inspector during development. The tradeoff is that overlays will no longer appear above native modals.

## ⛳️ Current behavior (updates)

Portal-based components (BottomSheet, Dialog, Popover, Select) and Toast use FullWindowOverlay on iOS so overlays render above native modals and the keyboard. There is no way to bypass this for debugging, so the element inspector cannot inspect portal content.

## 🚀 New behavior

- Added `disableFullWindowOverlay` (default `false`) to BottomSheet.Portal, Dialog.Portal, Popover.Portal, Select.Portal, and ToastProvider
- When `true` on iOS, uses a regular View instead of FullWindowOverlay and restores element inspector support
- Refactored `FullWindowOverlay` to accept and honor the new prop
- Updated docs with “Element Inspector (iOS)” sections and API tables
- Toast: prop passed via `config.toast` when using HeroUINativeProvider

## 💣 Is this a breaking change (Yes/No):

**No** - The prop is optional and defaults to `false`. Existing behavior is unchanged when the prop is omitted.

## 📝 Additional Information

Only affects iOS; Android uses `Fragment` and is unchanged. Documented tradeoff: with `disableFullWindowOverlay={true}`, overlays no longer appear above native modals or the keyboard. Minor doc updates: table alignment and angle-bracketed GitHub links.