### PR TITLE
fix(bottom-sheet): dismiss on Android hardware back press

### DIFF
--- a/src/helpers/internal/components/bottom-sheet-content-container.tsx
+++ b/src/helpers/internal/components/bottom-sheet-content-container.tsx
@@ -1,5 +1,6 @@
 import { BottomSheetView, useBottomSheet } from '@gorhom/bottom-sheet';
 import { useEffect, useRef } from 'react';
+import { BackHandler } from 'react-native';
 import { useAnimatedReaction } from 'react-native-reanimated';
 import { scheduleOnRN } from 'react-native-worklets';
 import type { BottomSheetContentContainerProps } from '../types/bottom-sheet';
@@ -43,6 +44,29 @@ export function BottomSheetContentContainer({
       }
     }
   );
+
+  /**
+   * Dismiss the bottom sheet when the Android hardware back button is pressed.
+   * Only registers the listener while the sheet is open so that closed
+   * instances (Popover, Select, other BottomSheets) don't consume the event.
+   */
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const backHandler = BackHandler.addEventListener(
+      'hardwareBackPress',
+      () => {
+        close();
+        onOpenChange(false);
+        return true;
+      }
+    );
+
+    return () => {
+      backHandler.remove();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
 
   useEffect(() => {
     const wasOpen = prevIsOpenRef.current;


### PR DESCRIPTION
## 📝 Description

Adds Android hardware back button support to the shared `BottomSheetContentContainer`, so pressing the back button dismisses any open bottom sheet (BottomSheet, Popover, Select). The listener is only active while the sheet is open to prevent closed instances from consuming the event.

## ⛳️ Current behavior (updates)

Pressing the Android hardware back button while a bottom sheet is open has no effect — the sheet stays visible and the back event is not handled.

## 🚀 New behavior

- Pressing the Android hardware back button dismisses the currently open bottom sheet
- The `BackHandler` listener is registered only while `isOpen` is `true`, so closed/unmounted sheets don't intercept the event
- Applies globally to all bottom-sheet-based components (BottomSheet, Popover, Select) via the shared `BottomSheetContentContainer`

## 💣 Is this a breaking change (Yes/No):

**No** — This is an additive behavior fix. Existing APIs and props are unchanged.

## 📝 Additional Information

The fix lives in `src/helpers/internal/components/bottom-sheet-content-container.tsx`, the shared container used by BottomSheet, Popover, and Select. Uses React Native's `BackHandler` API which is a no-op on iOS, so no platform-specific branching is needed.