### PR TITLE
fix(bottom-sheet): skip android back handler when enablePanDownToClose is false

### DIFF
--- a/src/helpers/internal/components/bottom-sheet-content-container.tsx
+++ b/src/helpers/internal/components/bottom-sheet-content-container.tsx
@@ -24,6 +24,7 @@ export function BottomSheetContentContainer({
   contentContainerClassName,
   contentContainerProps,
   onOpenChange,
+  enablePanDownToClose,
 }: BottomSheetContentContainerProps) {
   const { close, snapToIndex } = useBottomSheet();
   const prevIsOpenRef = useRef(isOpen);
@@ -51,7 +52,7 @@ export function BottomSheetContentContainer({
    * instances (Popover, Select, other BottomSheets) don't consume the event.
    */
   useEffect(() => {
-    if (!isOpen) return;
+    if (!isOpen || !enablePanDownToClose) return;
 
     const backHandler = BackHandler.addEventListener(
       'hardwareBackPress',
@@ -66,7 +67,7 @@ export function BottomSheetContentContainer({
       backHandler.remove();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen]);
+  }, [isOpen, enablePanDownToClose]);
 
   useEffect(() => {
     const wasOpen = prevIsOpenRef.current;

--- a/src/helpers/internal/components/bottom-sheet-content.tsx
+++ b/src/helpers/internal/components/bottom-sheet-content.tsx
@@ -146,6 +146,7 @@ export const BottomSheetContent = forwardRef<
             contentContainerClassName={contentContainerClassName}
             contentContainerProps={contentContainerProps}
             onOpenChange={onOpenChange}
+            enablePanDownToClose={restProps.enablePanDownToClose ?? true}
           >
             {children}
           </BottomSheetContentContainer>

--- a/src/helpers/internal/types/bottom-sheet.ts
+++ b/src/helpers/internal/types/bottom-sheet.ts
@@ -52,6 +52,10 @@ export interface BottomSheetContentContainerProps {
    * Callback when the bottom sheet is opened
    */
   onOpenChange: (open: boolean) => void;
+  /**
+   * Whether the bottom sheet can be closed by panning down
+   */
+  enablePanDownToClose: boolean;
 }
 
 /**


### PR DESCRIPTION
## 📝 Description

Fixes the Android hardware back button closing the bottom sheet even when `enablePanDownToClose` is set to `false`. The back handler now respects the `enablePanDownToClose` prop, ensuring consistent dismissal behavior across gesture and hardware interactions.

## ⛳️ Current behavior (updates)

When `enablePanDownToClose` is `false`, the bottom sheet correctly prevents swipe-down dismissal, but the Android hardware back button still closes it — creating inconsistent behavior.

## 🚀 New behavior

- The `enablePanDownToClose` prop is threaded through to `BottomSheetContentContainer` (defaults to `true`)
- The `BackHandler` event listener is only registered when both `isOpen` and `enablePanDownToClose` are `true`
- Bottom sheets with `enablePanDownToClose={false}` are no longer dismissible via the Android back button

## 💣 Is this a breaking change (Yes/No):

**No** — The default value of `enablePanDownToClose` is `true`, preserving existing behavior. Only bottom sheets that explicitly set `enablePanDownToClose={false}` are affected, and the new behavior aligns with the expected intent of that prop.

## 📝 Additional Information

The fix touches three files: the `BottomSheetContentContainerProps` type definition, the `BottomSheetContent` component (prop passthrough), and the `BottomSheetContentContainer` component (back handler guard). No new dependencies were added.