### PR TITLE
fix(use-theme-color): remove non-null assertion with safe fallback

### DIFF
--- a/src/helpers/external/hooks/use-theme-color.ts
+++ b/src/helpers/external/hooks/use-theme-color.ts
@@ -1,6 +1,37 @@
 import { useCSSVariable } from 'uniwind';
 
 /**
+ * Unique brand symbol used to prevent accidental array destructuring of a
+ * single theme color value returned from `useThemeColor`.
+ */
+declare const _colorValueBrand: unique symbol;
+
+/**
+ * A resolved theme color string.
+ *
+ * This type intentionally removes `[Symbol.iterator]` so that TypeScript
+ * surfaces a `never`-typed element when the value is array-destructured,
+ * making the misuse visible in the IDE immediately.
+ *
+ * @example
+ * // ✅ Correct – single value
+ * const color = useThemeColor('muted');
+ *
+ * @example
+ * // ✅ Correct – multiple values
+ * const [primary, bg] = useThemeColor(['accent', 'background']);
+ *
+ * @example
+ * // ❌ Wrong – destructuring a single-color result yields `never`
+ * const [color] = useThemeColor('muted');
+ */
+export type ThemeColorValue = string & {
+  readonly [_colorValueBrand]: void;
+  /** Removed to prevent accidental array destructuring. */
+  readonly [Symbol.iterator]: never;
+};
+
+/**
  * Theme colors as const array for efficient mapping
  * Ordered to match the order in src/styles/theme.css
  */
@@ -95,24 +126,24 @@ type CreateStringTuple<
  * Supports both single color and multiple colors for efficient batch retrieval.
  *
  * @param themeColor - Single theme color name or array of theme color names
- * @returns Single color string or array of color strings
+ * @returns `ThemeColorValue` for a single name, or a string tuple/array for multiple names.
  *
  * @example
- * // Single color
+ * // Single color – returns `ThemeColorValue` (not destructurable)
  * const primaryColor = useThemeColor('accent');
  *
  * @example
- * // Multiple colors (more efficient)
+ * // Multiple colors – returns a typed string tuple (destructurable)
  * const [primaryColor, backgroundColor] = useThemeColor(['accent', 'background']);
  */
-export function useThemeColor(themeColor: ThemeColor): string;
+export function useThemeColor(themeColor: ThemeColor): ThemeColorValue;
 export function useThemeColor<T extends readonly [ThemeColor, ...ThemeColor[]]>(
   themeColor: T
 ): CreateStringTuple<T['length']>;
 export function useThemeColor(themeColor: ThemeColor[]): string[];
 export function useThemeColor(
   themeColor: ThemeColor | ThemeColor[]
-): string | string[] {
+): ThemeColorValue | string[] {
   const isArray = Array.isArray(themeColor);
   const cssVariables = isArray
     ? themeColor.map((color) => `--color-${color}`)
@@ -133,5 +164,7 @@ export function useThemeColor(
   if (isArray) {
     return processedColors;
   }
-  return processedColors[0]!;
+
+  /** `cssVariables` always contains one entry when `isArray` is false, so index 0 is always defined. */
+  return (processedColors[0] ?? 'invalid') as ThemeColorValue;
 }


### PR DESCRIPTION
## 📝 Description

Introduces a `ThemeColorValue` branded type for the single-color overload of `useThemeColor`, making misuse of array destructuring on a single-color result immediately visible as a `never` type in the IDE. The change also removes the non-null assertion operator (`!`) in favor of a safe nullish coalescing fallback.

## ⛳️ Current behavior (updates)

`useThemeColor('muted')` returns a plain `string`, allowing silent incorrect usage like `const [color] = useThemeColor('muted')` with no TypeScript error.

## 🚀 New behavior

- Single-color calls now return `ThemeColorValue`, a branded `string` type with `[Symbol.iterator]: never`
- Array-destructuring a single `ThemeColorValue` produces a `never`-typed element, surfacing the misuse in the IDE immediately
- Non-null assertion (`processedColors[0]!`) replaced with `processedColors[0] ?? 'invalid'` cast to `ThemeColorValue`
- JSDoc updated to document correct vs. incorrect usage patterns

## 💣 Is this a breaking change (Yes/No):

**No** — `ThemeColorValue` extends `string`, so it is assignable everywhere a `string` is expected. Existing call sites are unaffected at runtime.

## 📝 Additional Information

No new dependencies. The `_colorValueBrand` symbol is declared with `declare const` so it has zero runtime footprint. Manual testing via TypeScript IDE feedback is the primary verification path.