### PR TITLE
feat: add link-button compound component

### DIFF
--- a/example/src/app/(home)/components/link-button.tsx
+++ b/example/src/app/(home)/components/link-button.tsx
@@ -1,0 +1,77 @@
+import { Button, Checkbox, ControlField, LinkButton } from 'heroui-native';
+import React from 'react';
+import { Alert, View } from 'react-native';
+import { AppText } from '../../../components/app-text';
+import type { UsageVariant } from '../../../components/component-presentation/types';
+import { UsageVariantFlatList } from '../../../components/component-presentation/usage-variant-flatlist';
+
+const TermsAndPrivacyContent = () => {
+  const [isAgreed, setIsAgreed] = React.useState(false);
+
+  const handleTermsPress = () => Alert.alert('Terms', 'Navigate to Terms');
+  const handlePrivacyPress = () =>
+    Alert.alert('Privacy', 'Navigate to Privacy Policy');
+
+  return (
+    <View className="flex-1 px-5 items-center justify-center">
+      <View className="w-full max-w-xs gap-6">
+        <ControlField
+          isSelected={isAgreed}
+          onSelectedChange={setIsAgreed}
+          className="items-start"
+        >
+          <ControlField.Indicator>
+            <Checkbox className="mt-0.5" />
+          </ControlField.Indicator>
+          <View className="flex-row flex-wrap flex-1">
+            <AppText className="text-sm text-muted">I agree to the </AppText>
+            <LinkButton size="sm" onPress={handleTermsPress}>
+              <LinkButton.Label className="text-accent">
+                Terms of Service
+              </LinkButton.Label>
+            </LinkButton>
+            <AppText className="text-sm text-muted"> and </AppText>
+            <LinkButton size="sm" onPress={handlePrivacyPress}>
+              <LinkButton.Label className="text-accent">
+                Privacy Policy
+              </LinkButton.Label>
+            </LinkButton>
+          </View>
+        </ControlField>
+        <Button isDisabled={!isAgreed}>Sign up</Button>
+      </View>
+    </View>
+  );
+};
+
+// ------------------------------------------------------------------------------
+
+const DisabledStateContent = () => {
+  return (
+    <View className="flex-1 px-5 items-center justify-center">
+      <View className="flex-row items-center gap-4">
+        <LinkButton>Enabled</LinkButton>
+        <LinkButton isDisabled>Disabled</LinkButton>
+      </View>
+    </View>
+  );
+};
+
+// ------------------------------------------------------------------------------
+
+const LINK_BUTTON_VARIANTS: UsageVariant[] = [
+  {
+    value: 'terms-and-privacy',
+    label: 'Terms & Privacy',
+    content: <TermsAndPrivacyContent />,
+  },
+  {
+    value: 'disabled-state',
+    label: 'Disabled state',
+    content: <DisabledStateContent />,
+  },
+];
+
+export default function LinkButtonScreen() {
+  return <UsageVariantFlatList data={LINK_BUTTON_VARIANTS} />;
+}

--- a/example/src/helpers/data/components.ts
+++ b/example/src/helpers/data/components.ts
@@ -78,6 +78,10 @@ export const COMPONENTS: ComponentItem[] = [
     path: 'label',
   },
   {
+    title: 'LinkButton',
+    path: 'link-button',
+  },
+  {
     title: 'ListGroup',
     path: 'list-group',
   },

--- a/src/components/button/button.tsx
+++ b/src/components/button/button.tsx
@@ -1,9 +1,8 @@
 import { forwardRef, useMemo } from 'react';
-import { View } from 'react-native';
 import { useThemeColor } from '../../helpers/external/hooks';
 import { colorKit } from '../../helpers/external/utils';
 import { HeroText } from '../../helpers/internal/components';
-import type { PressableRef } from '../../helpers/internal/types';
+import type { PressableRef, TextRef } from '../../helpers/internal/types';
 import { childrenToString, createContext } from '../../helpers/internal/utils';
 import {
   PressableFeedback,
@@ -236,7 +235,7 @@ const ButtonRoot = forwardRef<PressableRef, ButtonRootProps>((props, ref) => {
 
 // --------------------------------------------------
 
-const ButtonLabel = forwardRef<View, ButtonLabelProps>((props, ref) => {
+const ButtonLabel = forwardRef<TextRef, ButtonLabelProps>((props, ref) => {
   const { children, className, ...restProps } = props;
 
   const { size, variant } = useButton();

--- a/src/components/link-button/index.ts
+++ b/src/components/link-button/index.ts
@@ -1,0 +1,6 @@
+export { default as LinkButton } from './link-button';
+export { linkButtonClassNames } from './link-button.styles';
+export type {
+  LinkButtonLabelProps,
+  LinkButtonProps,
+} from './link-button.types';

--- a/src/components/link-button/link-button.constants.ts
+++ b/src/components/link-button/link-button.constants.ts
@@ -1,0 +1,7 @@
+/**
+ * Display names for LinkButton components
+ */
+export const DISPLAY_NAME = {
+  LINK_BUTTON_ROOT: 'HeroUINative.LinkButton.Root',
+  LINK_BUTTON_LABEL: 'HeroUINative.LinkButton.Label',
+};

--- a/src/components/link-button/link-button.md
+++ b/src/components/link-button/link-button.md
@@ -1,0 +1,154 @@
+# LinkButton
+
+A ghost-variant button with no highlight feedback, designed for inline link-style interactions.
+
+## Import
+
+```tsx
+import { LinkButton } from 'heroui-native';
+```
+
+## Anatomy
+
+```tsx
+<LinkButton>
+  <LinkButton.Label>...</LinkButton.Label>
+</LinkButton>
+```
+
+- **LinkButton**: Root pressable container. Renders a `Button` with the `ghost` variant and disabled highlight feedback enforced internally. These cannot be overridden by consumers.
+- **LinkButton.Label**: Text content of the link button. Inherits size and variant styling from the parent context.
+
+## Usage
+
+### Basic Usage
+
+The LinkButton component renders inline link-style text that responds to press events.
+
+```tsx
+<LinkButton onPress={handlePress}>Learn more</LinkButton>
+```
+
+### Sizes
+
+Control the text size with the `size` prop.
+
+```tsx
+<LinkButton size="sm">
+  Small
+</LinkButton>
+
+<LinkButton size="md">
+  Medium
+</LinkButton>
+
+<LinkButton size="lg">
+  Large
+</LinkButton>
+```
+
+### Disabled State
+
+Disable the link button to prevent interaction.
+
+```tsx
+<LinkButton isDisabled>Disabled link</LinkButton>
+```
+
+### Custom Styling
+
+Apply custom styles using the `className` prop on both root and label.
+
+```tsx
+<LinkButton className="px-2">
+  <LinkButton.Label className="text-accent underline">
+    Styled link
+  </LinkButton.Label>
+</LinkButton>
+```
+
+### Inline with Text
+
+Place link buttons inline alongside regular text for terms, policies, or contextual navigation.
+
+```tsx
+<View className="flex-row flex-wrap">
+  <Text className="text-sm text-muted">I agree to the </Text>
+  <LinkButton size="sm" onPress={handleTermsPress}>
+    <LinkButton.Label className="text-accent">
+      Terms of Service
+    </LinkButton.Label>
+  </LinkButton>
+  <Text className="text-sm text-muted"> and </Text>
+  <LinkButton size="sm" onPress={handlePrivacyPress}>
+    <LinkButton.Label className="text-accent">Privacy Policy</LinkButton.Label>
+  </LinkButton>
+</View>
+```
+
+## Example
+
+```tsx
+import { Button, Checkbox, ControlField, LinkButton } from 'heroui-native';
+import React from 'react';
+import { Alert, View } from 'react-native';
+
+export default function LinkButtonExample() {
+  const [isAgreed, setIsAgreed] = React.useState(false);
+
+  const handleTermsPress = () => Alert.alert('Terms', 'Navigate to Terms');
+  const handlePrivacyPress = () =>
+    Alert.alert('Privacy', 'Navigate to Privacy Policy');
+
+  return (
+    <View className="flex-1 px-5 items-center justify-center">
+      <View className="w-full max-w-xs gap-6">
+        <ControlField
+          isSelected={isAgreed}
+          onSelectedChange={setIsAgreed}
+          className="items-start"
+        >
+          <ControlField.Indicator>
+            <Checkbox className="mt-0.5" />
+          </ControlField.Indicator>
+          <View className="flex-row flex-wrap flex-1">
+            <Text className="text-sm text-muted">I agree to the </Text>
+            <LinkButton size="sm" onPress={handleTermsPress}>
+              <LinkButton.Label className="text-accent">
+                Terms of Service
+              </LinkButton.Label>
+            </LinkButton>
+            <Text className="text-sm text-muted"> and </Text>
+            <LinkButton size="sm" onPress={handlePrivacyPress}>
+              <LinkButton.Label className="text-accent">
+                Privacy Policy
+              </LinkButton.Label>
+            </LinkButton>
+          </View>
+        </ControlField>
+        <Button isDisabled={!isAgreed}>Sign up</Button>
+      </View>
+    </View>
+  );
+}
+```
+
+You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/rc/example/src/app/(home)/components/link-button.tsx>).
+
+## API Reference
+
+### LinkButton
+
+Extends all [Button](./button/button.md) props except `variant` (enforced as `ghost` internally).
+
+**Behavioral overrides applied internally:**
+
+| override    | value        | description                                         |
+| ----------- | ------------ | --------------------------------------------------- |
+| `variant`   | `ghost`      | Always renders as a ghost button, cannot be changed |
+| `highlight` | `false`      | Highlight feedback is disabled, cannot be changed   |
+| `className` | `h-auto p-0` | Removes default button height and padding           |
+
+### LinkButton.Label
+
+Equivalent to [Button.Label](./button/button.md). Accepts the same props.

--- a/src/components/link-button/link-button.styles.ts
+++ b/src/components/link-button/link-button.styles.ts
@@ -1,0 +1,13 @@
+import { tv } from 'tailwind-variants';
+import { combineStyles } from '../../helpers/internal/utils';
+
+const root = tv({
+  base: 'h-auto p-0',
+});
+
+const linkButtonClassNames = combineStyles({
+  root,
+});
+
+export { linkButtonClassNames };
+export default linkButtonClassNames;

--- a/src/components/link-button/link-button.tsx
+++ b/src/components/link-button/link-button.tsx
@@ -1,0 +1,63 @@
+import { forwardRef } from 'react';
+import type { PressableRef, TextRef } from '../../helpers/internal/types';
+import { Button } from '../button';
+import type { ButtonLabelProps } from '../button/button.types';
+import { resolveAnimationObject } from '../button/button.utils';
+import { DISPLAY_NAME } from './link-button.constants';
+import linkButtonClassNames from './link-button.styles';
+import type { LinkButtonProps } from './link-button.types';
+
+// --------------------------------------------------
+
+const LinkButtonRoot = forwardRef<PressableRef, LinkButtonProps>(
+  (props, ref) => {
+    const { className, animation, ...restProps } = props;
+
+    const rootClassName = linkButtonClassNames.root({ className });
+
+    const resolvedAnimation = {
+      ...resolveAnimationObject(animation),
+      highlight: false,
+    };
+
+    return (
+      <Button
+        ref={ref}
+        variant="ghost"
+        className={rootClassName}
+        animation={resolvedAnimation}
+        {...restProps}
+      />
+    );
+  }
+);
+
+// --------------------------------------------------
+
+const LinkButtonLabel = forwardRef<TextRef, ButtonLabelProps>((props, ref) => {
+  return <Button.Label ref={ref} {...props} />;
+});
+
+// --------------------------------------------------
+
+LinkButtonRoot.displayName = DISPLAY_NAME.LINK_BUTTON_ROOT;
+LinkButtonLabel.displayName = DISPLAY_NAME.LINK_BUTTON_LABEL;
+
+/**
+ * Compound LinkButton component
+ *
+ * @component LinkButton - A ghost-variant button with no highlight feedback,
+ * designed for inline link-style interactions (e.g. "Terms" / "Privacy Policy" links).
+ * The ghost variant and disabled highlight are enforced internally and cannot be overridden.
+ *
+ * @component LinkButton.Label - Text content of the link button. Inherits size and variant
+ * styling from the parent LinkButton context (delegates to Button.Label).
+ *
+ * @see Full documentation: https://v3.heroui.com/docs/native/components/link-button
+ */
+const LinkButton = Object.assign(LinkButtonRoot, {
+  /** Link button label - renders text or custom content */
+  Label: LinkButtonLabel,
+});
+
+export default LinkButton;

--- a/src/components/link-button/link-button.types.ts
+++ b/src/components/link-button/link-button.types.ts
@@ -1,0 +1,18 @@
+import type {
+  ButtonLabelProps,
+  ButtonRootPropsScaleHighlight,
+} from '../button/button.types';
+
+/**
+ * Props for the LinkButton component.
+ *
+ * Extends ButtonRootPropsScaleHighlight with `variant` omitted — the ghost
+ * variant is enforced internally and cannot be overridden by consumers.
+ */
+export type LinkButtonProps = Omit<ButtonRootPropsScaleHighlight, 'variant'>;
+
+/**
+ * Props for the LinkButton.Label sub-component.
+ * Equivalent to ButtonLabelProps.
+ */
+export type LinkButtonLabelProps = ButtonLabelProps;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -16,6 +16,7 @@ export * from './components/input';
 export * from './components/input-group';
 export * from './components/input-otp';
 export * from './components/label';
+export * from './components/link-button';
 export * from './components/list-group';
 export * from './components/menu';
 export * from './components/popover';


### PR DESCRIPTION
## 📝 Description

Adds a new `LinkButton` compound component that renders a ghost-variant button with no highlight feedback, designed for inline link-style interactions such as "Terms of Service" or "Privacy Policy" links. Also fixes the `ButtonLabel` ref type from `View` to `TextRef`.

## ⛳️ Current behavior (updates)

No dedicated component exists for inline link-style pressables — developers must manually configure a `Button` with `variant="ghost"` and disable highlight feedback.

## 🚀 New behavior

- **New `LinkButton` component** with compound `LinkButton.Label` sub-component, enforcing ghost variant and disabled highlight internally
- **Types**: `LinkButtonProps` (omits `variant` from `ButtonRootPropsScaleHighlight`) and `LinkButtonLabelProps`
- **Styles**: `h-auto p-0` base class via `tailwind-variants` to remove default button height/padding
- **Documentation**: Full `.md` docs with anatomy, usage examples, and API reference
- **Example app**: Two usage variants — "Terms & Privacy" (inline with `ControlField`/`Checkbox`) and "Disabled state"
- **Bug fix**: `ButtonLabel` ref type corrected from `View` to `TextRef`; removed unused `View` import from `button.tsx`
- **Barrel export**: `LinkButton` added to `src/index.tsx`

## 💣 Is this a breaking change (Yes/No):

**No** — This is a purely additive feature. The `ButtonLabel` ref type fix corrects an inaccuracy but does not change runtime behavior.

## 📝 Additional Information

The component delegates entirely to the existing `Button` infrastructure, using `resolveAnimationObject` to merge consumer animation config while enforcing `highlight: false`. No new dependencies were introduced. The example screen registers the component in the example app's component list for easy discovery.