### PR TITLE
feat(bottom-sheet): add stacked sheet support

### DIFF
--- a/example/src/app/(home)/components/bottom-sheet.tsx
+++ b/example/src/app/(home)/components/bottom-sheet.tsx
@@ -9,6 +9,7 @@ import { AppText } from '../../../components/app-text';
 import { BottomSheetBlurOverlay } from '../../../components/bottom-sheet-blur-overlay';
 import { BasicBottomSheetContent } from '../../../components/bottom-sheet/basic';
 import { ScrollableWithSnapPointsContent } from '../../../components/bottom-sheet/scrollable-with-snap-points';
+import { StackedBottomSheetContent } from '../../../components/bottom-sheet/stacked';
 import { WithOTPInputContent } from '../../../components/bottom-sheet/with-otp-input';
 import { WithTextInputContent } from '../../../components/bottom-sheet/with-text-input';
 import type { UsageVariant } from '../../../components/component-presentation/types';
@@ -204,6 +205,11 @@ const BOTTOM_SHEET_VARIANTS_IOS: UsageVariant[] = [
     content: <ScrollableWithSnapPointsContent />,
   },
   {
+    value: 'stacked-bottom-sheet',
+    label: 'Stacked bottom sheet',
+    content: <StackedBottomSheetContent />,
+  },
+  {
     value: 'native-modal-bottom-sheet',
     label: 'Bottom sheet from native modal',
     content: <NativeModalBottomSheetContent />,
@@ -235,6 +241,11 @@ const BOTTOM_SHEET_VARIANTS_ANDROID: UsageVariant[] = [
     value: 'scrollable-with-snap-points',
     label: 'Scrollable with snap points',
     content: <ScrollableWithSnapPointsContent />,
+  },
+  {
+    value: 'stacked-bottom-sheet',
+    label: 'Stacked bottom sheet',
+    content: <StackedBottomSheetContent />,
   },
   {
     value: 'with-text-input',

--- a/example/src/components/bottom-sheet/stacked.tsx
+++ b/example/src/components/bottom-sheet/stacked.tsx
@@ -63,7 +63,7 @@ export const StackedBottomSheetContent = () => {
           </BottomSheet.Trigger>
           <BottomSheet.Portal>
             <BottomSheet.Overlay />
-            <BottomSheet.Stack contentContainerClassName="gap-6">
+            <BottomSheet.Content contentContainerClassName="gap-6">
               <View className="gap-4">
                 <View className="items-center gap-3">
                   <View className="size-16 items-center justify-center rounded-full bg-blue-500/10">
@@ -109,10 +109,9 @@ export const StackedBottomSheetContent = () => {
                 </Button>
               </View>
 
-              <BottomSheet.Stack.Sheet
+              <BottomSheet.Sheet
                 isOpen={isDeliveryWindowSheetOpen}
                 onOpenChange={setDeliveryWindowSheetOpen}
-                backdropComponent={BottomSheet.Stack.Sheet.Overlay}
                 contentContainerClassName="gap-4"
               >
                 <View className="gap-2">
@@ -151,8 +150,8 @@ export const StackedBottomSheetContent = () => {
                     );
                   })}
                 </View>
-              </BottomSheet.Stack.Sheet>
-            </BottomSheet.Stack>
+              </BottomSheet.Sheet>
+            </BottomSheet.Content>
           </BottomSheet.Portal>
         </BottomSheet>
       </View>

--- a/example/src/components/bottom-sheet/stacked.tsx
+++ b/example/src/components/bottom-sheet/stacked.tsx
@@ -1,0 +1,161 @@
+import MaterialCommunityIcons from '@expo/vector-icons/MaterialCommunityIcons';
+import { BottomSheet, Button } from 'heroui-native';
+import { useCallback, useState } from 'react';
+import { View } from 'react-native';
+import { withUniwind } from 'uniwind';
+import { AppText } from '../app-text';
+
+const StyledMaterialCommunityIcons = withUniwind(MaterialCommunityIcons);
+
+const DELIVERY_WINDOWS = [
+  {
+    id: 'today-6-8',
+    label: 'Today, 6:00 PM - 8:00 PM',
+    fee: 'Free',
+  },
+  {
+    id: 'tomorrow-8-10',
+    label: 'Tomorrow, 8:00 AM - 10:00 AM',
+    fee: '$4.99',
+  },
+  {
+    id: 'tomorrow-12-2',
+    label: 'Tomorrow, 12:00 PM - 2:00 PM',
+    fee: '$2.99',
+  },
+] as const;
+
+type DeliveryWindowId = (typeof DELIVERY_WINDOWS)[number]['id'];
+
+export const StackedBottomSheetContent = () => {
+  const [isRootOpen, setRootOpen] = useState(false);
+  const [isDeliveryWindowSheetOpen, setDeliveryWindowSheetOpen] =
+    useState(false);
+  const [selectedWindowId, setSelectedWindowId] = useState<DeliveryWindowId>(
+    DELIVERY_WINDOWS[0].id
+  );
+
+  const selectedWindow = DELIVERY_WINDOWS.find(
+    (window) => window.id === selectedWindowId
+  );
+
+  const onRootOpenChange = useCallback((open: boolean) => {
+    setRootOpen(open);
+
+    if (!open) {
+      setDeliveryWindowSheetOpen(false);
+    }
+  }, []);
+
+  const onWindowSelect = useCallback((windowId: DeliveryWindowId) => {
+    setSelectedWindowId(windowId);
+    setDeliveryWindowSheetOpen(false);
+  }, []);
+
+  return (
+    <View className="flex-1">
+      <View className="flex-1 items-center justify-center">
+        <BottomSheet isOpen={isRootOpen} onOpenChange={onRootOpenChange}>
+          <BottomSheet.Trigger asChild>
+            <Button variant="secondary" isDisabled={isRootOpen}>
+              Stacked bottom sheet
+            </Button>
+          </BottomSheet.Trigger>
+          <BottomSheet.Portal>
+            <BottomSheet.Overlay />
+            <BottomSheet.Stack contentContainerClassName="gap-6">
+              <View className="gap-4">
+                <View className="items-center gap-3">
+                  <View className="size-16 items-center justify-center rounded-full bg-blue-500/10">
+                    <StyledMaterialCommunityIcons
+                      name="bike-fast"
+                      size={32}
+                      className="text-blue-500"
+                    />
+                  </View>
+                  <View className="items-center gap-2">
+                    <BottomSheet.Title className="text-center">
+                      Schedule your grocery delivery
+                    </BottomSheet.Title>
+                    <BottomSheet.Description className="text-center">
+                      Let shoppers know when to arrive, then confirm the order
+                      from the main sheet.
+                    </BottomSheet.Description>
+                  </View>
+                </View>
+
+                <View className="rounded-3xl border border-border bg-default-100 p-4">
+                  <AppText className="text-sm font-medium text-muted">
+                    Selected delivery window
+                  </AppText>
+                  <AppText className="mt-2 text-base font-medium text-foreground">
+                    {selectedWindow?.label}
+                  </AppText>
+                  <AppText className="mt-1 text-sm text-muted">
+                    Fee: {selectedWindow?.fee}
+                  </AppText>
+                </View>
+              </View>
+
+              <View className="gap-3">
+                <Button
+                  variant="secondary"
+                  onPress={() => setDeliveryWindowSheetOpen(true)}
+                >
+                  Choose another window
+                </Button>
+                <Button onPress={() => setRootOpen(false)}>
+                  Confirm $48.20 order
+                </Button>
+              </View>
+
+              <BottomSheet.Stack.Sheet
+                isOpen={isDeliveryWindowSheetOpen}
+                onOpenChange={setDeliveryWindowSheetOpen}
+                backdropComponent={BottomSheet.Stack.Sheet.Overlay}
+                contentContainerClassName="gap-4"
+              >
+                <View className="gap-2">
+                  <BottomSheet.Title>
+                    Select a delivery window
+                  </BottomSheet.Title>
+                  <BottomSheet.Description>
+                    This second sheet lets you adjust a single part of the flow
+                    without dismissing the order summary underneath.
+                  </BottomSheet.Description>
+                </View>
+
+                <View className="gap-3">
+                  {DELIVERY_WINDOWS.map((window) => {
+                    const isSelected = window.id === selectedWindowId;
+
+                    return (
+                      <Button
+                        key={window.id}
+                        variant={isSelected ? 'primary' : 'secondary'}
+                        onPress={() => onWindowSelect(window.id)}
+                      >
+                        <View className="w-full flex-row items-center justify-between gap-3">
+                          <Button.Label>{window.label}</Button.Label>
+                          <AppText
+                            className={
+                              isSelected
+                                ? 'text-primary-foreground'
+                                : 'text-foreground'
+                            }
+                          >
+                            {window.fee}
+                          </AppText>
+                        </View>
+                      </Button>
+                    );
+                  })}
+                </View>
+              </BottomSheet.Stack.Sheet>
+            </BottomSheet.Stack>
+          </BottomSheet.Portal>
+        </BottomSheet>
+      </View>
+    </View>
+  );
+};

--- a/src/components/bottom-sheet/bottom-sheet.constants.ts
+++ b/src/components/bottom-sheet/bottom-sheet.constants.ts
@@ -7,10 +7,9 @@ export const DISPLAY_NAME = {
   PORTAL: 'HeroUINative.BottomSheet.Portal',
   OVERLAY: 'HeroUINative.BottomSheet.Overlay',
   CONTENT: 'HeroUINative.BottomSheet.Content',
+  SHEET: 'HeroUINative.BottomSheet.Sheet',
+  SHEET_OVERLAY: 'HeroUINative.BottomSheet.Sheet.Overlay',
   CLOSE: 'HeroUINative.BottomSheet.Close',
   TITLE: 'HeroUINative.BottomSheet.Title',
   DESCRIPTION: 'HeroUINative.BottomSheet.Description',
-  STACK: 'HeroUINative.BottomSheet.Stack',
-  STACK_SHEET: 'HeroUINative.BottomSheet.Stack.Sheet',
-  STACK_SHEET_OVERLAY: 'HeroUINative.BottomSheet.Stack.Sheet.Overlay',
 };

--- a/src/components/bottom-sheet/bottom-sheet.constants.ts
+++ b/src/components/bottom-sheet/bottom-sheet.constants.ts
@@ -10,4 +10,7 @@ export const DISPLAY_NAME = {
   CLOSE: 'HeroUINative.BottomSheet.Close',
   TITLE: 'HeroUINative.BottomSheet.Title',
   DESCRIPTION: 'HeroUINative.BottomSheet.Description',
+  STACK: 'HeroUINative.BottomSheet.Stack',
+  STACK_SHEET: 'HeroUINative.BottomSheet.Stack.Sheet',
+  STACK_SHEET_OVERLAY: 'HeroUINative.BottomSheet.Stack.Sheet.Overlay',
 };

--- a/src/components/bottom-sheet/bottom-sheet.md
+++ b/src/components/bottom-sheet/bottom-sheet.md
@@ -33,32 +33,28 @@ import { BottomSheet } from 'heroui-native';
 - **BottomSheet.Title**: Bottom sheet title text with semantic heading role and accessibility linking.
 - **BottomSheet.Description**: Bottom sheet description text that provides additional context with accessibility linking.
 
-### Stacked Bottom Sheet Anatomy
+### Nested Bottom Sheet Anatomy
 
-Use `BottomSheet.Stack` instead of `BottomSheet.Content` when you need to present a second sheet on top of the first one.
+Use `BottomSheet.Sheet` inside `BottomSheet.Content` when you need to present a second sheet on top of the first one.
 
 ```tsx
 <BottomSheet>
   <BottomSheet.Trigger>...</BottomSheet.Trigger>
   <BottomSheet.Portal>
     <BottomSheet.Overlay />
-    <BottomSheet.Stack>
+    <BottomSheet.Content>
       {/* base sheet content */}
-      <BottomSheet.Stack.Sheet
-        isOpen={isSheetOpen}
-        onOpenChange={setIsSheetOpen}
-        backdropComponent={BottomSheet.Stack.Sheet.Overlay}
-      >
-        {/* stacked sheet content */}
-      </BottomSheet.Stack.Sheet>
-    </BottomSheet.Stack>
+      <BottomSheet.Sheet isOpen={isSheetOpen} onOpenChange={setIsSheetOpen}>
+        {/* nested sheet content */}
+      </BottomSheet.Sheet>
+    </BottomSheet.Content>
   </BottomSheet.Portal>
 </BottomSheet>
 ```
 
-- **BottomSheet.Stack**: Drop-in replacement for `BottomSheet.Content` that adds support for stacked sheets.
-- **BottomSheet.Stack.Sheet**: Controlled sheet rendered on top of the base sheet using `BottomSheetModal`.
-- **BottomSheet.Stack.Sheet.Overlay**: Backdrop component for stacked sheets. Pass it to the `backdropComponent` prop on `BottomSheet.Stack.Sheet`.
+- **BottomSheet.Content**: Main sheet container. Nested sheets can be declared inside it.
+- **BottomSheet.Sheet**: Controlled sheet rendered on top of the base sheet using `BottomSheetModal`.
+- **BottomSheet.Sheet.Overlay**: Backdrop component for nested sheets. It is used by default and can be passed explicitly when customizing `backdropComponent`.
 
 ## Usage
 
@@ -119,13 +115,13 @@ Bottom sheet with multiple snap points and scrollable content.
 </BottomSheet>
 ```
 
-### Stacked Bottom Sheets
+### Nested Bottom Sheets
 
 Present a second sheet on top of the main sheet without dismissing the original content underneath.
 
 ```tsx
 const [isOpen, setIsOpen] = useState(false);
-const [isDetailsOpen, setIsDetailsOpen] = useState(false);
+const [isDetailsOpen, setDetailsOpen] = useState(false);
 
 <BottomSheet isOpen={isOpen} onOpenChange={setIsOpen}>
   <BottomSheet.Trigger asChild>
@@ -133,29 +129,25 @@ const [isDetailsOpen, setIsDetailsOpen] = useState(false);
   </BottomSheet.Trigger>
   <BottomSheet.Portal>
     <BottomSheet.Overlay />
-    <BottomSheet.Stack>
+    <BottomSheet.Content>
       <BottomSheet.Title>Order summary</BottomSheet.Title>
       <BottomSheet.Description>
         Review the order, then open a second sheet to adjust one part of the
         flow.
       </BottomSheet.Description>
 
-      <Button variant="secondary" onPress={() => setIsDetailsOpen(true)}>
+      <Button variant="secondary" onPress={() => setDetailsOpen(true)}>
         Choose delivery window
       </Button>
 
-      <BottomSheet.Stack.Sheet
-        isOpen={isDetailsOpen}
-        onOpenChange={setIsDetailsOpen}
-        backdropComponent={BottomSheet.Stack.Sheet.Overlay}
-      >
+      <BottomSheet.Sheet isOpen={isDetailsOpen} onOpenChange={setDetailsOpen}>
         <BottomSheet.Title>Select a delivery window</BottomSheet.Title>
         <BottomSheet.Description>
           This sheet stays connected to the main sheet and closes when the main
           sheet closes.
         </BottomSheet.Description>
-      </BottomSheet.Stack.Sheet>
-    </BottomSheet.Stack>
+      </BottomSheet.Sheet>
+    </BottomSheet.Content>
   </BottomSheet.Portal>
 </BottomSheet>;
 ```
@@ -341,39 +333,44 @@ Animation configuration for bottom sheet overlay component. Can be:
 
 **Note**: You can use all components from [@gorhom/bottom-sheet](https://gorhom.dev/react-native-bottom-sheet/components/bottomsheetview) inside the content, such as `BottomSheetView`, `BottomSheetScrollView`, `BottomSheetFlatList`, etc.
 
-### BottomSheet.Stack
+### BottomSheet.Sheet
 
-`BottomSheet.Stack` accepts the same props as `BottomSheet.Content` and should be used when you want to render `BottomSheet.Stack.Sheet` inside the base sheet.
+| prop                        | type                                     | default  | description                                                                                                                                                   |
+| --------------------------- | ---------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `children`                  | `React.ReactNode`                        | -        | Stacked bottom sheet content                                                                                                                                  |
+| `isOpen`                    | `boolean`                                | -        | Controlled open state for the nested sheet                                                                                                                    |
+| `onOpenChange`              | `(open: boolean) => void`                | -        | Callback when the nested sheet open state changes                                                                                                             |
+| `onDismiss`                 | `() => void`                             | -        | Callback fired after the nested sheet dismiss animation finishes                                                                                              |
+| `stackBehavior`             | `'push' \| 'switch' \| 'replace'`        | `'push'` | Stacking behavior used by `BottomSheetModal`                                                                                                                  |
+| `contentContainerClassName` | `string`                                 | -        | Additional CSS classes for the content container                                                                                                              |
+| `contentContainerProps`     | `Omit<BottomSheetViewProps, 'children'>` | -        | Props for the content container                                                                                                                               |
+| `backgroundClassName`       | `string`                                 | -        | Additional CSS classes for the background                                                                                                                     |
+| `handleIndicatorClassName`  | `string`                                 | -        | Additional CSS classes for the handle indicator                                                                                                               |
+| `animation`                 | `AnimationDisabled`                      | -        | Animation configuration                                                                                                                                       |
+| `...BottomSheetModalProps`  | `Partial<BottomSheetModalProps>`         | -        | Supports [@gorhom/bottom-sheet modal props](https://gorhom.dev/react-native-bottom-sheet/modal/props), except props managed internally by `BottomSheet.Sheet` |
 
-### BottomSheet.Stack.Sheet
+**Note**: `BottomSheet.Sheet` is controlled. Keep its `isOpen` state in your component and update it through `onOpenChange`.
 
-| prop                        | type                                    | default  | description                                                                                             |
-| --------------------------- | --------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------- |
-| `children`                  | `React.ReactNode`                       | -        | Stacked bottom sheet content                                                                            |
-| `isOpen`                    | `boolean`                               | -        | Controlled open state for the stacked sheet                                                             |
-| `onOpenChange`              | `(open: boolean) => void`               | -        | Callback when the stacked sheet open state changes                                                      |
-| `onDismiss`                 | `() => void`                            | -        | Callback fired after the stacked sheet dismiss animation finishes                                       |
-| `stackBehavior`             | `'push' \| 'switch' \| 'replace'`       | `'push'` | Stacking behavior used by `BottomSheetModal`                                                            |
-| `contentContainerClassName` | `string`                                | -        | Additional CSS classes for the content container                                                        |
-| `contentContainerProps`     | `Omit<BottomSheetViewProps, 'children'>`| -        | Props for the content container                                                                         |
-| `backgroundClassName`       | `string`                                | -        | Additional CSS classes for the background                                                               |
-| `handleIndicatorClassName`  | `string`                                | -        | Additional CSS classes for the handle indicator                                                         |
-| `animation`                 | `AnimationDisabled`                     | -        | Animation configuration                                                                                 |
-| `...BottomSheetModalProps`  | `Partial<BottomSheetModalProps>`        | -        | Most [@gorhom/bottom-sheet modal props](https://gorhom.dev/react-native-bottom-sheet/modal/props) are supported |
+**Internally managed modal props**
 
-**Note**: `BottomSheet.Stack.Sheet` is controlled. Keep its `isOpen` state in your component and update it through `onOpenChange`.
+- `animatedIndex`: controlled internally to sync sheet progress with HeroUI animation state.
+- `children`: rendered through `BottomSheet.Sheet`'s own content container.
+- `containerComponent`: reserved for internal context wiring inside the modal portal.
+- `enableDismissOnClose`: always enabled so dismiss/unmount behavior stays consistent.
+- `gestureEventsHandlersHook`: reserved for internal drag-state tracking.
+- `onDismiss`: wrapped internally so `onOpenChange(false)` stays reliable before your `onDismiss` callback runs.
 
-### BottomSheet.Stack.Sheet.Overlay
+### BottomSheet.Sheet.Overlay
 
-| prop                    | type                     | default | description                                                                 |
-| ----------------------- | ------------------------ | ------- | --------------------------------------------------------------------------- |
-| `className`             | `string`                 | -       | Additional CSS classes for the overlay                                      |
-| `appearsOnIndex`        | `number`                 | `0`     | Snap point index where the overlay becomes visible                          |
-| `disappearsOnIndex`     | `number`                 | `-1`    | Snap point index where the overlay disappears                               |
-| `opacity`               | `number`                 | `1`     | Overlay opacity passed to `BottomSheetBackdrop`                             |
-| `pressBehavior`         | `BackdropPressBehavior`  | -       | Behavior to apply when the overlay is pressed                               |
-| `enableTouchThrough`    | `boolean`                | -       | Whether touches should pass through the overlay                             |
-| `...BottomSheetBackdropProps` | `BottomSheetBackdropProps` | -   | All standard `BottomSheetBackdrop` props are supported                      |
+| prop                          | type                       | default | description                                            |
+| ----------------------------- | -------------------------- | ------- | ------------------------------------------------------ |
+| `className`                   | `string`                   | -       | Additional CSS classes for the overlay                 |
+| `appearsOnIndex`              | `number`                   | `0`     | Snap point index where the overlay becomes visible     |
+| `disappearsOnIndex`           | `number`                   | `-1`    | Snap point index where the overlay disappears          |
+| `opacity`                     | `number`                   | `1`     | Overlay opacity passed to `BottomSheetBackdrop`        |
+| `pressBehavior`               | `BackdropPressBehavior`    | -       | Behavior to apply when the overlay is pressed          |
+| `enableTouchThrough`          | `boolean`                  | -       | Whether touches should pass through the overlay        |
+| `...BottomSheetBackdropProps` | `BottomSheetBackdropProps` | -       | All standard `BottomSheetBackdrop` props are supported |
 
 ### BottomSheet.Close
 

--- a/src/components/bottom-sheet/bottom-sheet.md
+++ b/src/components/bottom-sheet/bottom-sheet.md
@@ -33,6 +33,33 @@ import { BottomSheet } from 'heroui-native';
 - **BottomSheet.Title**: Bottom sheet title text with semantic heading role and accessibility linking.
 - **BottomSheet.Description**: Bottom sheet description text that provides additional context with accessibility linking.
 
+### Stacked Bottom Sheet Anatomy
+
+Use `BottomSheet.Stack` instead of `BottomSheet.Content` when you need to present a second sheet on top of the first one.
+
+```tsx
+<BottomSheet>
+  <BottomSheet.Trigger>...</BottomSheet.Trigger>
+  <BottomSheet.Portal>
+    <BottomSheet.Overlay />
+    <BottomSheet.Stack>
+      {/* base sheet content */}
+      <BottomSheet.Stack.Sheet
+        isOpen={isSheetOpen}
+        onOpenChange={setIsSheetOpen}
+        backdropComponent={BottomSheet.Stack.Sheet.Overlay}
+      >
+        {/* stacked sheet content */}
+      </BottomSheet.Stack.Sheet>
+    </BottomSheet.Stack>
+  </BottomSheet.Portal>
+</BottomSheet>
+```
+
+- **BottomSheet.Stack**: Drop-in replacement for `BottomSheet.Content` that adds support for stacked sheets.
+- **BottomSheet.Stack.Sheet**: Controlled sheet rendered on top of the base sheet using `BottomSheetModal`.
+- **BottomSheet.Stack.Sheet.Overlay**: Backdrop component for stacked sheets. Pass it to the `backdropComponent` prop on `BottomSheet.Stack.Sheet`.
+
 ## Usage
 
 ### Basic Bottom Sheet
@@ -90,6 +117,47 @@ Bottom sheet with multiple snap points and scrollable content.
     </BottomSheet.Content>
   </BottomSheet.Portal>
 </BottomSheet>
+```
+
+### Stacked Bottom Sheets
+
+Present a second sheet on top of the main sheet without dismissing the original content underneath.
+
+```tsx
+const [isOpen, setIsOpen] = useState(false);
+const [isDetailsOpen, setIsDetailsOpen] = useState(false);
+
+<BottomSheet isOpen={isOpen} onOpenChange={setIsOpen}>
+  <BottomSheet.Trigger asChild>
+    <Button>Open Bottom Sheet</Button>
+  </BottomSheet.Trigger>
+  <BottomSheet.Portal>
+    <BottomSheet.Overlay />
+    <BottomSheet.Stack>
+      <BottomSheet.Title>Order summary</BottomSheet.Title>
+      <BottomSheet.Description>
+        Review the order, then open a second sheet to adjust one part of the
+        flow.
+      </BottomSheet.Description>
+
+      <Button variant="secondary" onPress={() => setIsDetailsOpen(true)}>
+        Choose delivery window
+      </Button>
+
+      <BottomSheet.Stack.Sheet
+        isOpen={isDetailsOpen}
+        onOpenChange={setIsDetailsOpen}
+        backdropComponent={BottomSheet.Stack.Sheet.Overlay}
+      >
+        <BottomSheet.Title>Select a delivery window</BottomSheet.Title>
+        <BottomSheet.Description>
+          This sheet stays connected to the main sheet and closes when the main
+          sheet closes.
+        </BottomSheet.Description>
+      </BottomSheet.Stack.Sheet>
+    </BottomSheet.Stack>
+  </BottomSheet.Portal>
+</BottomSheet>;
 ```
 
 ### Custom Overlay
@@ -272,6 +340,40 @@ Animation configuration for bottom sheet overlay component. Can be:
 | `...GorhomBottomSheetProps` | `Partial<GorhomBottomSheetProps>`        | -       | All [@gorhom/bottom-sheet props](https://gorhom.dev/react-native-bottom-sheet/props) are supported |
 
 **Note**: You can use all components from [@gorhom/bottom-sheet](https://gorhom.dev/react-native-bottom-sheet/components/bottomsheetview) inside the content, such as `BottomSheetView`, `BottomSheetScrollView`, `BottomSheetFlatList`, etc.
+
+### BottomSheet.Stack
+
+`BottomSheet.Stack` accepts the same props as `BottomSheet.Content` and should be used when you want to render `BottomSheet.Stack.Sheet` inside the base sheet.
+
+### BottomSheet.Stack.Sheet
+
+| prop                        | type                                    | default  | description                                                                                             |
+| --------------------------- | --------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------- |
+| `children`                  | `React.ReactNode`                       | -        | Stacked bottom sheet content                                                                            |
+| `isOpen`                    | `boolean`                               | -        | Controlled open state for the stacked sheet                                                             |
+| `onOpenChange`              | `(open: boolean) => void`               | -        | Callback when the stacked sheet open state changes                                                      |
+| `onDismiss`                 | `() => void`                            | -        | Callback fired after the stacked sheet dismiss animation finishes                                       |
+| `stackBehavior`             | `'push' \| 'switch' \| 'replace'`       | `'push'` | Stacking behavior used by `BottomSheetModal`                                                            |
+| `contentContainerClassName` | `string`                                | -        | Additional CSS classes for the content container                                                        |
+| `contentContainerProps`     | `Omit<BottomSheetViewProps, 'children'>`| -        | Props for the content container                                                                         |
+| `backgroundClassName`       | `string`                                | -        | Additional CSS classes for the background                                                               |
+| `handleIndicatorClassName`  | `string`                                | -        | Additional CSS classes for the handle indicator                                                         |
+| `animation`                 | `AnimationDisabled`                     | -        | Animation configuration                                                                                 |
+| `...BottomSheetModalProps`  | `Partial<BottomSheetModalProps>`        | -        | Most [@gorhom/bottom-sheet modal props](https://gorhom.dev/react-native-bottom-sheet/modal/props) are supported |
+
+**Note**: `BottomSheet.Stack.Sheet` is controlled. Keep its `isOpen` state in your component and update it through `onOpenChange`.
+
+### BottomSheet.Stack.Sheet.Overlay
+
+| prop                    | type                     | default | description                                                                 |
+| ----------------------- | ------------------------ | ------- | --------------------------------------------------------------------------- |
+| `className`             | `string`                 | -       | Additional CSS classes for the overlay                                      |
+| `appearsOnIndex`        | `number`                 | `0`     | Snap point index where the overlay becomes visible                          |
+| `disappearsOnIndex`     | `number`                 | `-1`    | Snap point index where the overlay disappears                               |
+| `opacity`               | `number`                 | `1`     | Overlay opacity passed to `BottomSheetBackdrop`                             |
+| `pressBehavior`         | `BackdropPressBehavior`  | -       | Behavior to apply when the overlay is pressed                               |
+| `enableTouchThrough`    | `boolean`                | -       | Whether touches should pass through the overlay                             |
+| `...BottomSheetBackdropProps` | `BottomSheetBackdropProps` | -   | All standard `BottomSheetBackdrop` props are supported                      |
 
 ### BottomSheet.Close
 

--- a/src/components/bottom-sheet/bottom-sheet.tsx
+++ b/src/components/bottom-sheet/bottom-sheet.tsx
@@ -57,9 +57,8 @@ import type {
   BottomSheetOverlayProps,
   BottomSheetPortalProps,
   BottomSheetRootProps,
-  BottomSheetStackProps,
-  BottomSheetStackSheetOverlayProps,
-  BottomSheetStackSheetProps,
+  BottomSheetSheetOverlayProps,
+  BottomSheetSheetProps,
   BottomSheetTitleProps,
   BottomSheetTriggerProps,
 } from './bottom-sheet.types';
@@ -147,22 +146,30 @@ const BottomSheetPortal = ({
   const animationSettingsContext = useAnimationSettings();
   const animationContext = useBottomSheetAnimation();
 
+  const content = (
+    <AnimationSettingsProvider value={animationSettingsContext}>
+      <BottomSheetAnimationProvider value={animationContext}>
+        <FullWindowOverlay disableFullWindowOverlay={disableFullWindowOverlay}>
+          <Animated.View
+            style={StyleSheet.absoluteFill}
+            pointerEvents="box-none"
+          >
+            {children}
+          </Animated.View>
+        </FullWindowOverlay>
+      </BottomSheetAnimationProvider>
+    </AnimationSettingsProvider>
+  );
+
   return (
     <BottomSheetPrimitives.Portal {...props}>
-      <AnimationSettingsProvider value={animationSettingsContext}>
-        <BottomSheetAnimationProvider value={animationContext}>
-          <FullWindowOverlay
-            disableFullWindowOverlay={disableFullWindowOverlay}
-          >
-            <Animated.View
-              style={StyleSheet.absoluteFill}
-              pointerEvents="box-none"
-            >
-              {children}
-            </Animated.View>
-          </FullWindowOverlay>
-        </BottomSheetAnimationProvider>
-      </AnimationSettingsProvider>
+      {GorhomBottomSheetModalProvider ? (
+        <GorhomBottomSheetModalProvider>
+          {content}
+        </GorhomBottomSheetModalProvider>
+      ) : (
+        content
+      )}
     </BottomSheetPrimitives.Portal>
   );
 };
@@ -325,29 +332,15 @@ const BottomSheetDescription = forwardRef<RNText, BottomSheetDescriptionProps>(
 
 // --------------------------------------------------
 
-/** Drop-in replacement for BottomSheet.Content with stacked sheet support. */
-const BottomSheetStack = forwardRef<GorhomBottomSheet, BottomSheetStackProps>(
-  (props, ref) => {
-    if (!GorhomBottomSheetModalProvider) return null;
-    return (
-      <GorhomBottomSheetModalProvider>
-        <BottomSheetContent ref={ref} {...props} />
-      </GorhomBottomSheetModalProvider>
-    );
-  }
-);
-
-// --------------------------------------------------
-
 // Keep containerComponent type stable so the modal subtree does not remount.
 // This also lets us pass `isDragging` into portal-rendered content.
-type StackSheetContainerProps = { children: ReactNode };
-function makeStackSheetContainerComponent(
+type SheetContainerProps = { children: ReactNode };
+function makeSheetContainerComponent(
   isDragging: ReturnType<typeof usePopupRootAnimation>['isDragging']
-): ComponentType<StackSheetContainerProps> {
-  return function BottomSheetStackSheetContainer({
+): ComponentType<SheetContainerProps> {
+  return function BottomSheetSheetContainer({
     children: modalChildren,
-  }: StackSheetContainerProps) {
+  }: SheetContainerProps) {
     return (
       <BottomSheetIsDraggingProvider value={{ isDragging }}>
         {modalChildren}
@@ -358,8 +351,8 @@ function makeStackSheetContainerComponent(
 
 // --------------------------------------------------
 
-/** Sheet rendered on top of BottomSheet.Stack using BottomSheetModal. */
-const BottomSheetStackSheet = ({
+/** Sheet rendered on top of BottomSheet.Content using BottomSheetModal. */
+const BottomSheetSheet = ({
   children,
   isOpen,
   onOpenChange,
@@ -372,9 +365,10 @@ const BottomSheetStackSheet = ({
   animation,
   animationConfigs,
   backgroundStyle: backgroundStyleProp,
+  backdropComponent = BottomSheetSheetOverlay,
   enablePanDownToClose,
   ...restProps
-}: BottomSheetStackSheetProps) => {
+}: BottomSheetSheetProps) => {
   const modalRef = useRef<{
     dismiss: () => void;
     present: () => void;
@@ -429,7 +423,7 @@ const BottomSheetStackSheet = ({
     }
   }, [dismissModal, isOpen]);
 
-  // When the root bottom sheet closes (e.g. overlay tap), also close this stacked
+  // When the root bottom sheet closes (e.g., overlay tap), also close this nested
   // sheet. Gorhom does not automatically fire onDismiss on BottomSheetModal when its
   // parent BottomSheet collapses, so the consumer's state would otherwise remain open.
   const { isOpen: isRootOpen } = useBottomSheet();
@@ -452,9 +446,8 @@ const BottomSheetStackSheet = ({
   }, [dismissModal, isOpen]);
 
   const containerComponentRef =
-    useRef<ComponentType<StackSheetContainerProps> | null>(null);
-  containerComponentRef.current ??=
-    makeStackSheetContainerComponent(isDragging);
+    useRef<ComponentType<SheetContainerProps> | null>(null);
+  containerComponentRef.current ??= makeSheetContainerComponent(isDragging);
   const ContainerComponent = containerComponentRef.current;
 
   const contentBackgroundClassName = bottomSheetClassNames.contentBackground({
@@ -496,6 +489,7 @@ const BottomSheetStackSheet = ({
       handleIndicatorClassName={contentHandleIndicatorClassName}
       gestureEventsHandlersHook={useBottomSheetGestureHandlers}
       animationConfigs={mergedAnimationConfigs}
+      backdropComponent={backdropComponent}
       onDismiss={() => {
         prevIsOpenRef.current = false;
 
@@ -535,13 +529,13 @@ const BottomSheetStackSheet = ({
 // --------------------------------------------------
 
 /**
- * Backdrop for BottomSheet.Stack.Sheet.
- * Use as `backdropComponent={BottomSheet.Stack.Sheet.Overlay}`.
+ * Backdrop for BottomSheet.Sheet.
+ * Used by default, or pass as `backdropComponent={BottomSheet.Sheet.Overlay}`.
  */
-const BottomSheetStackSheetOverlay = ({
+const BottomSheetSheetOverlay = ({
   className,
   ...props
-}: BottomSheetStackSheetOverlayProps) => {
+}: BottomSheetSheetOverlayProps) => {
   if (!StyledGorhomBottomSheetBackdrop) return null;
 
   return (
@@ -565,9 +559,8 @@ BottomSheetContent.displayName = DISPLAY_NAME.CONTENT;
 BottomSheetClose.displayName = DISPLAY_NAME.CLOSE;
 BottomSheetTitle.displayName = DISPLAY_NAME.TITLE;
 BottomSheetDescription.displayName = DISPLAY_NAME.DESCRIPTION;
-BottomSheetStack.displayName = DISPLAY_NAME.STACK;
-BottomSheetStackSheet.displayName = DISPLAY_NAME.STACK_SHEET;
-BottomSheetStackSheetOverlay.displayName = DISPLAY_NAME.STACK_SHEET_OVERLAY;
+BottomSheetSheet.displayName = DISPLAY_NAME.SHEET;
+BottomSheetSheetOverlay.displayName = DISPLAY_NAME.SHEET_OVERLAY;
 
 /**
  * Compound BottomSheet component with sub-components
@@ -587,14 +580,11 @@ BottomSheetStackSheetOverlay.displayName = DISPLAY_NAME.STACK_SHEET_OVERLAY;
  * @component BottomSheet.Content - The bottom sheet content container.
  * Uses @gorhom/bottom-sheet for rendering. Contains the main bottom sheet UI elements.
  *
- * @component BottomSheet.Stack - Drop-in replacement for BottomSheet.Content that
- * enables stacking. Use BottomSheet.Stack.Sheet inside its content to push sheets.
+ * @component BottomSheet.Sheet - A sheet that stacks on top via BottomSheetModal.
+ * Use inside BottomSheet.Content when you need a nested sheet.
  *
- * @component BottomSheet.Stack.Sheet - A sheet that stacks on top via BottomSheetModal.
- * Must be rendered inside a BottomSheet.Stack.
- *
- * @component BottomSheet.Stack.Sheet.Overlay - Backdrop for a stacked sheet.
- * Pass as the `backdropComponent` prop on BottomSheet.Stack.Sheet.
+ * @component BottomSheet.Sheet.Overlay - Backdrop for a nested sheet.
+ * Applied by default and can also be passed to `backdropComponent`.
  *
  * @component BottomSheet.Close - Close button for the bottom sheet.
  * Can accept custom children or uses default close icon.
@@ -614,16 +604,10 @@ const BottomSheet = Object.assign(BottomSheetRoot, {
   Overlay: BottomSheetOverlay,
   /** @optional Main bottom sheet content container */
   Content: BottomSheetContent,
-  /** @optional Drop-in for Content that enables BottomSheet.Stack.Sheet */
-  Stack: Object.assign(BottomSheetStack, {
-    /** @optional Stacked sheet. Must be inside BottomSheet.Stack. */
-    Sheet: Object.assign(BottomSheetStackSheet, {
-      /**
-       * @optional Overlay for this stacked sheet.
-       * Pass as `backdropComponent={BottomSheet.Stack.Sheet.Overlay}`.
-       */
-      Overlay: BottomSheetStackSheetOverlay,
-    }),
+  /** @optional Nested sheet presented on top via BottomSheetModal. */
+  Sheet: Object.assign(BottomSheetSheet, {
+    /** @optional Overlay for this nested sheet. */
+    Overlay: BottomSheetSheetOverlay,
   }),
   /** @optional Close button for the bottom sheet */
   Close: BottomSheetClose,

--- a/src/components/bottom-sheet/bottom-sheet.tsx
+++ b/src/components/bottom-sheet/bottom-sheet.tsx
@@ -1,11 +1,24 @@
 import type GorhomBottomSheet from '@gorhom/bottom-sheet';
-import { forwardRef, useMemo } from 'react';
 import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type ComponentType,
+  type ReactNode,
+} from 'react';
+import {
+  BackHandler,
   StyleSheet,
   type GestureResponderEvent,
   type Text as RNText,
 } from 'react-native';
-import Animated, { useSharedValue } from 'react-native-reanimated';
+import Animated, {
+  ReduceMotion,
+  useSharedValue,
+} from 'react-native-reanimated';
+import { withUniwind } from 'uniwind';
 import {
   FullWindowOverlay,
   HeroText,
@@ -13,19 +26,24 @@ import {
 } from '../../helpers/internal/components';
 import {
   AnimationSettingsProvider,
+  BottomSheetIsDraggingProvider,
   useAnimationSettings,
 } from '../../helpers/internal/contexts';
 import {
+  useBottomSheetGestureHandlers,
+  usePopupBottomSheetContentAnimation,
   usePopupOverlayAnimation,
   usePopupRootAnimation,
 } from '../../helpers/internal/hooks';
 import type { PressableRef } from '../../helpers/internal/types';
+import GorhomBottomSheetPackage from '../../optional/gorhom-bottom-sheet';
 import * as BottomSheetPrimitives from '../../primitives/bottom-sheet';
 import * as BottomSheetPrimitivesTypes from '../../primitives/bottom-sheet/bottom-sheet.types';
 import { CloseButton } from '../close-button';
 import {
   BottomSheetAnimationProvider,
   useBottomSheetAnimation,
+  useBottomSheetContentAnimation,
 } from './bottom-sheet.animation';
 import { DISPLAY_NAME } from './bottom-sheet.constants';
 import {
@@ -39,6 +57,9 @@ import type {
   BottomSheetOverlayProps,
   BottomSheetPortalProps,
   BottomSheetRootProps,
+  BottomSheetStackProps,
+  BottomSheetStackSheetOverlayProps,
+  BottomSheetStackSheetProps,
   BottomSheetTitleProps,
   BottomSheetTriggerProps,
 } from './bottom-sheet.types';
@@ -48,6 +69,16 @@ const AnimatedOverlay = Animated.createAnimatedComponent(
 );
 
 const useBottomSheet = BottomSheetPrimitives.useRootContext;
+
+const GorhomBottomSheetModalProvider =
+  GorhomBottomSheetPackage?.BottomSheetModalProvider;
+const GorhomBottomSheetView = GorhomBottomSheetPackage?.BottomSheetView;
+const StyledGorhomBottomSheetBackdrop = withUniwind(
+  GorhomBottomSheetPackage?.BottomSheetBackdrop
+);
+const StyledGorhomBottomSheetModal = withUniwind(
+  GorhomBottomSheetPackage?.BottomSheetModal
+);
 
 // --------------------------------------------------
 
@@ -294,6 +325,238 @@ const BottomSheetDescription = forwardRef<RNText, BottomSheetDescriptionProps>(
 
 // --------------------------------------------------
 
+/** Drop-in replacement for BottomSheet.Content with stacked sheet support. */
+const BottomSheetStack = forwardRef<GorhomBottomSheet, BottomSheetStackProps>(
+  (props, ref) => {
+    if (!GorhomBottomSheetModalProvider) return null;
+    return (
+      <GorhomBottomSheetModalProvider>
+        <BottomSheetContent ref={ref} {...props} />
+      </GorhomBottomSheetModalProvider>
+    );
+  }
+);
+
+// --------------------------------------------------
+
+// Keep containerComponent type stable so the modal subtree does not remount.
+// This also lets us pass `isDragging` into portal-rendered content.
+type StackSheetContainerProps = { children: ReactNode };
+function makeStackSheetContainerComponent(
+  isDragging: ReturnType<typeof usePopupRootAnimation>['isDragging']
+): ComponentType<StackSheetContainerProps> {
+  return function BottomSheetStackSheetContainer({
+    children: modalChildren,
+  }: StackSheetContainerProps) {
+    return (
+      <BottomSheetIsDraggingProvider value={{ isDragging }}>
+        {modalChildren}
+      </BottomSheetIsDraggingProvider>
+    );
+  };
+}
+
+// --------------------------------------------------
+
+/** Sheet rendered on top of BottomSheet.Stack using BottomSheetModal. */
+const BottomSheetStackSheet = ({
+  children,
+  isOpen,
+  onOpenChange,
+  stackBehavior = 'push',
+  onDismiss,
+  backgroundClassName,
+  handleIndicatorClassName,
+  contentContainerClassName: contentContainerClassNameProp,
+  contentContainerProps,
+  animation,
+  animationConfigs,
+  backgroundStyle: backgroundStyleProp,
+  enablePanDownToClose,
+  ...restProps
+}: BottomSheetStackSheetProps) => {
+  const modalRef = useRef<{
+    dismiss: () => void;
+    present: () => void;
+  } | null>(null);
+  const prevIsOpenRef = useRef(false);
+  const skipNextDismissOpenChangeRef = useRef(false);
+
+  const { progress, isDragging, isAllAnimationsDisabled } =
+    usePopupRootAnimation({});
+
+  const { animatedIndex } = usePopupBottomSheetContentAnimation({
+    progress,
+    isDragging,
+  });
+
+  const { isAnimationDisabledValue } = useBottomSheetContentAnimation({
+    animation,
+  });
+
+  const mergedAnimationConfigs = useMemo(
+    () => ({
+      ...animationConfigs,
+      reduceMotion: isAnimationDisabledValue
+        ? ReduceMotion.Always
+        : animationConfigs?.reduceMotion,
+    }),
+    [animationConfigs, isAnimationDisabledValue]
+  );
+
+  const dismissModal = useCallback(
+    (shouldNotifyOpenChange: boolean) => {
+      skipNextDismissOpenChangeRef.current = true;
+
+      if (shouldNotifyOpenChange) {
+        onOpenChange(false);
+      }
+
+      modalRef.current?.dismiss();
+    },
+    [onOpenChange]
+  );
+
+  // Only present/dismiss on state transitions to mirror BottomSheet.Content
+  useEffect(() => {
+    const wasOpen = prevIsOpenRef.current;
+    prevIsOpenRef.current = isOpen;
+
+    if (isOpen && !wasOpen) {
+      modalRef.current?.present();
+    } else if (!isOpen && wasOpen) {
+      dismissModal(false);
+    }
+  }, [dismissModal, isOpen]);
+
+  // When the root bottom sheet closes (e.g. overlay tap), also close this stacked
+  // sheet. Gorhom does not automatically fire onDismiss on BottomSheetModal when its
+  // parent BottomSheet collapses, so the consumer's state would otherwise remain open.
+  const { isOpen: isRootOpen } = useBottomSheet();
+  useEffect(() => {
+    if (!isRootOpen && isOpen) {
+      dismissModal(true);
+    }
+  }, [dismissModal, isOpen, isRootOpen]);
+
+  // Android hardware back button closes this sheet, not the one beneath it.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handler = BackHandler.addEventListener('hardwareBackPress', () => {
+      dismissModal(true);
+      return true;
+    });
+
+    return () => handler.remove();
+  }, [dismissModal, isOpen]);
+
+  const containerComponentRef =
+    useRef<ComponentType<StackSheetContainerProps> | null>(null);
+  containerComponentRef.current ??=
+    makeStackSheetContainerComponent(isDragging);
+  const ContainerComponent = containerComponentRef.current;
+
+  const contentBackgroundClassName = bottomSheetClassNames.contentBackground({
+    className: backgroundClassName,
+  });
+  const contentHandleIndicatorClassName =
+    bottomSheetClassNames.contentHandleIndicator({
+      className: handleIndicatorClassName,
+    });
+  const contentContainerClassName = bottomSheetClassNames.contentContainer({
+    className: contentContainerClassNameProp,
+  });
+
+  const animContextValue = useMemo(
+    () => ({ progress, isDragging }),
+    [progress, isDragging]
+  );
+  const animSettingsValue = useMemo(
+    () => ({ isAllAnimationsDisabled }),
+    [isAllAnimationsDisabled]
+  );
+
+  if (!StyledGorhomBottomSheetModal || !GorhomBottomSheetView) {
+    return null;
+  }
+
+  return (
+    <StyledGorhomBottomSheetModal
+      ref={modalRef}
+      stackBehavior={stackBehavior}
+      enableDismissOnClose={true}
+      enablePanDownToClose={enablePanDownToClose ?? true}
+      animatedIndex={animatedIndex}
+      backgroundClassName={contentBackgroundClassName}
+      backgroundStyle={[
+        bottomSheetStyleSheet.contentContainer,
+        backgroundStyleProp,
+      ]}
+      handleIndicatorClassName={contentHandleIndicatorClassName}
+      gestureEventsHandlersHook={useBottomSheetGestureHandlers}
+      animationConfigs={mergedAnimationConfigs}
+      onDismiss={() => {
+        prevIsOpenRef.current = false;
+
+        if (skipNextDismissOpenChangeRef.current) {
+          skipNextDismissOpenChangeRef.current = false;
+        } else {
+          onOpenChange(false);
+        }
+        onDismiss?.();
+      }}
+      containerComponent={ContainerComponent}
+      {...restProps}
+    >
+      {/* Re-provide contexts inside the portal so nested subcomponents still work. */}
+      <AnimationSettingsProvider value={animSettingsValue}>
+        <BottomSheetAnimationProvider value={animContextValue}>
+          <BottomSheetPrimitives.Root
+            isOpen={isOpen}
+            onOpenChange={onOpenChange}
+            asChild
+          >
+            <BottomSheetPrimitives.Content asChild>
+              <GorhomBottomSheetView
+                className={contentContainerClassName}
+                {...contentContainerProps}
+              >
+                {children}
+              </GorhomBottomSheetView>
+            </BottomSheetPrimitives.Content>
+          </BottomSheetPrimitives.Root>
+        </BottomSheetAnimationProvider>
+      </AnimationSettingsProvider>
+    </StyledGorhomBottomSheetModal>
+  );
+};
+
+// --------------------------------------------------
+
+/**
+ * Backdrop for BottomSheet.Stack.Sheet.
+ * Use as `backdropComponent={BottomSheet.Stack.Sheet.Overlay}`.
+ */
+const BottomSheetStackSheetOverlay = ({
+  className,
+  ...props
+}: BottomSheetStackSheetOverlayProps) => {
+  if (!StyledGorhomBottomSheetBackdrop) return null;
+
+  return (
+    <StyledGorhomBottomSheetBackdrop
+      opacity={1}
+      {...props}
+      disappearsOnIndex={-1}
+      appearsOnIndex={0}
+      className={bottomSheetClassNames.overlay({ className })}
+    />
+  );
+};
+
+// --------------------------------------------------
+
 BottomSheetRoot.displayName = DISPLAY_NAME.ROOT;
 BottomSheetTrigger.displayName = DISPLAY_NAME.TRIGGER;
 BottomSheetPortal.displayName = DISPLAY_NAME.PORTAL;
@@ -302,6 +565,9 @@ BottomSheetContent.displayName = DISPLAY_NAME.CONTENT;
 BottomSheetClose.displayName = DISPLAY_NAME.CLOSE;
 BottomSheetTitle.displayName = DISPLAY_NAME.TITLE;
 BottomSheetDescription.displayName = DISPLAY_NAME.DESCRIPTION;
+BottomSheetStack.displayName = DISPLAY_NAME.STACK;
+BottomSheetStackSheet.displayName = DISPLAY_NAME.STACK_SHEET;
+BottomSheetStackSheetOverlay.displayName = DISPLAY_NAME.STACK_SHEET_OVERLAY;
 
 /**
  * Compound BottomSheet component with sub-components
@@ -321,6 +587,15 @@ BottomSheetDescription.displayName = DISPLAY_NAME.DESCRIPTION;
  * @component BottomSheet.Content - The bottom sheet content container.
  * Uses @gorhom/bottom-sheet for rendering. Contains the main bottom sheet UI elements.
  *
+ * @component BottomSheet.Stack - Drop-in replacement for BottomSheet.Content that
+ * enables stacking. Use BottomSheet.Stack.Sheet inside its content to push sheets.
+ *
+ * @component BottomSheet.Stack.Sheet - A sheet that stacks on top via BottomSheetModal.
+ * Must be rendered inside a BottomSheet.Stack.
+ *
+ * @component BottomSheet.Stack.Sheet.Overlay - Backdrop for a stacked sheet.
+ * Pass as the `backdropComponent` prop on BottomSheet.Stack.Sheet.
+ *
  * @component BottomSheet.Close - Close button for the bottom sheet.
  * Can accept custom children or uses default close icon.
  *
@@ -339,6 +614,17 @@ const BottomSheet = Object.assign(BottomSheetRoot, {
   Overlay: BottomSheetOverlay,
   /** @optional Main bottom sheet content container */
   Content: BottomSheetContent,
+  /** @optional Drop-in for Content that enables BottomSheet.Stack.Sheet */
+  Stack: Object.assign(BottomSheetStack, {
+    /** @optional Stacked sheet. Must be inside BottomSheet.Stack. */
+    Sheet: Object.assign(BottomSheetStackSheet, {
+      /**
+       * @optional Overlay for this stacked sheet.
+       * Pass as `backdropComponent={BottomSheet.Stack.Sheet.Overlay}`.
+       */
+      Overlay: BottomSheetStackSheetOverlay,
+    }),
+  }),
   /** @optional Close button for the bottom sheet */
   Close: BottomSheetClose,
   /** @optional Bottom sheet title text */

--- a/src/components/bottom-sheet/bottom-sheet.types.ts
+++ b/src/components/bottom-sheet/bottom-sheet.types.ts
@@ -144,17 +144,10 @@ export interface BottomSheetDescriptionProps extends TextProps {
 }
 
 /**
- * BottomSheet.Stack component props.
- * Drop-in replacement for BottomSheet.Content that enables stacking.
- * Accepts all the same props as BottomSheet.Content.
+ * BottomSheet.Sheet component props.
+ * Declarative wrapper around BottomSheetModal for nested sheets.
  */
-export type BottomSheetStackProps = BottomSheetContentProps;
-
-/**
- * BottomSheet.Stack.Sheet component props.
- * Declarative wrapper around BottomSheetModal for stacked sheets.
- */
-export interface BottomSheetStackSheetProps
+export interface BottomSheetSheetProps
   extends Omit<
       Partial<BottomSheetModalProps>,
       | 'animatedIndex'
@@ -166,7 +159,7 @@ export interface BottomSheetStackSheetProps
     >,
     BaseBottomSheetContentProps {
   /**
-   * Whether this stacked sheet is open.
+   * Whether this nested sheet is open.
    */
   isOpen: boolean;
   /**
@@ -180,15 +173,11 @@ export interface BottomSheetStackSheetProps
 }
 
 /**
- * BottomSheet.Stack.Sheet.Overlay component props.
- * Passed as `backdropComponent` on BottomSheet.Stack.Sheet.
- * Accepts an optional `className` to override the overlay colour.
+ * BottomSheet.Sheet.Overlay component props.
  */
-export interface BottomSheetStackSheetOverlayProps
-  extends BottomSheetBackdropProps {
+export interface BottomSheetSheetOverlayProps extends BottomSheetBackdropProps {
   /**
-   * Additional CSS class for the overlay.
-   * Defaults to the same `bg-black/10` used by BottomSheet.Overlay.
+   * Additional CSS class for the title
    */
   className?: string;
 }

--- a/src/components/bottom-sheet/bottom-sheet.types.ts
+++ b/src/components/bottom-sheet/bottom-sheet.types.ts
@@ -1,4 +1,8 @@
-import type { BottomSheetProps } from '@gorhom/bottom-sheet';
+import type {
+  BottomSheetBackdropProps,
+  BottomSheetModalProps,
+  BottomSheetProps,
+} from '@gorhom/bottom-sheet';
 import type { ReactNode } from 'react';
 import type { TextProps } from 'react-native';
 import type { SharedValue } from 'react-native-reanimated';
@@ -8,7 +12,7 @@ import type {
   PopupOverlayAnimation,
 } from '../../helpers/internal/types';
 import type * as BottomSheetPrimitivesTypes from '../../primitives/bottom-sheet/bottom-sheet.types';
-import type { CloseButtonProps } from '../close-button/close-button.types';
+import type { CloseButtonProps } from '../close-button';
 
 /**
  * Context value for bottom sheet animation state
@@ -140,11 +144,51 @@ export interface BottomSheetDescriptionProps extends TextProps {
 }
 
 /**
- * Return type for the useBottomSheetAnimation hook
+ * BottomSheet.Stack component props.
+ * Drop-in replacement for BottomSheet.Content that enables stacking.
+ * Accepts all the same props as BottomSheet.Content.
  */
-export interface UseBottomSheetAnimationReturn {
+export type BottomSheetStackProps = BottomSheetContentProps;
+
+/**
+ * BottomSheet.Stack.Sheet component props.
+ * Declarative wrapper around BottomSheetModal for stacked sheets.
+ */
+export interface BottomSheetStackSheetProps
+  extends Omit<
+      Partial<BottomSheetModalProps>,
+      | 'animatedIndex'
+      | 'children'
+      | 'containerComponent'
+      | 'enableDismissOnClose'
+      | 'gestureEventsHandlersHook'
+      | 'onDismiss'
+    >,
+    BaseBottomSheetContentProps {
   /**
-   * Animation progress shared value (0=idle, 1=open, 2=close)
+   * Whether this stacked sheet is open.
    */
-  progress: SharedValue<number>;
+  isOpen: boolean;
+  /**
+   * Called when the open state changes.
+   */
+  onOpenChange: (open: boolean) => void;
+  /**
+   * Called after the dismiss animation finishes.
+   */
+  onDismiss?: () => void;
+}
+
+/**
+ * BottomSheet.Stack.Sheet.Overlay component props.
+ * Passed as `backdropComponent` on BottomSheet.Stack.Sheet.
+ * Accepts an optional `className` to override the overlay colour.
+ */
+export interface BottomSheetStackSheetOverlayProps
+  extends BottomSheetBackdropProps {
+  /**
+   * Additional CSS class for the overlay.
+   * Defaults to the same `bg-black/10` used by BottomSheet.Overlay.
+   */
+  className?: string;
 }

--- a/src/components/bottom-sheet/index.ts
+++ b/src/components/bottom-sheet/index.ts
@@ -11,9 +11,8 @@ export type {
   BottomSheetOverlayProps,
   BottomSheetPortalProps,
   BottomSheetRootProps,
-  BottomSheetStackProps,
-  BottomSheetStackSheetOverlayProps,
-  BottomSheetStackSheetProps,
+  BottomSheetSheetOverlayProps,
+  BottomSheetSheetProps,
   BottomSheetTitleProps,
   BottomSheetTriggerProps,
 } from './bottom-sheet.types';

--- a/src/components/bottom-sheet/index.ts
+++ b/src/components/bottom-sheet/index.ts
@@ -11,6 +11,9 @@ export type {
   BottomSheetOverlayProps,
   BottomSheetPortalProps,
   BottomSheetRootProps,
+  BottomSheetStackProps,
+  BottomSheetStackSheetOverlayProps,
+  BottomSheetStackSheetProps,
   BottomSheetTitleProps,
   BottomSheetTriggerProps,
 } from './bottom-sheet.types';

--- a/src/primitives/bottom-sheet/bottom-sheet.tsx
+++ b/src/primitives/bottom-sheet/bottom-sheet.tsx
@@ -1,4 +1,4 @@
-import { createContext, forwardRef, useContext, useId } from 'react';
+import { createContext, forwardRef, useContext, useId, useMemo } from 'react';
 import {
   type GestureResponderEvent,
   Pressable,
@@ -52,14 +52,13 @@ const Root = forwardRef<RootRef, RootProps>(
 
     const Component = asChild ? Slot.View : View;
 
+    const value = useMemo(
+      () => ({ isOpen, onOpenChange, nativeID }),
+      [isOpen, nativeID, onOpenChange]
+    );
+
     return (
-      <BottomSheetContext.Provider
-        value={{
-          isOpen,
-          onOpenChange,
-          nativeID,
-        }}
-      >
+      <BottomSheetContext.Provider value={value}>
         <Component ref={ref} {...viewProps} />
       </BottomSheetContext.Provider>
     );
@@ -112,7 +111,7 @@ Trigger.displayName = 'HeroUINative.Primitive.BottomSheet.Trigger';
 /**
  * @warning when using a custom `<PortalHost />`, you might have to adjust the Content's offset to account for nav elements like headers.
  */
-function Portal({ hostName, children }: PortalProps) {
+function Portal({ hostName, children }: Readonly<PortalProps>) {
   const value = useRootContext();
 
   return (


### PR DESCRIPTION
## 📝 Description
Adds stacked bottom sheet support to the `BottomSheet` component by introducing a nested `BottomSheet.Sheet` component backed by `@gorhom/bottom-sheet` `BottomSheetModal`. This update also documents the new pattern and adds an example that demonstrates opening a secondary sheet on top of an existing bottom sheet.

## ⛳️ Current behavior (updates)
`BottomSheet` currently supports a single sheet flow only. There is no built-in API for presenting multiple sheets stacked above the root while preserving the underlying sheet state and content

**Key changes:**
 - Adds a declarative stacked sheet API using `BottomSheetModal` via `@gorhom/bottom-sheet`.
- Keeps nested sheet state in sync when the parent sheet closes.
- Handles Android hardware back presses by dismissing the topmost nested sheet first.
- Re-provides bottom sheet context inside the modal subtree so nested sheet content can still use the existing compound subcomponents.
- Exposes new types and display names for the nested sheet components.
- Adds docs and a stacked bottom sheet example to the demo app.

## 🚀 New behavior
`BottomSheet` now supports nested sheets through `BottomSheet.Sheet` and `BottomSheet.Sheet.Overlay`

## 💣 Is this a breaking change (Yes/No):
No

## 📝 Additional Information

<img width="413" height="871" alt="image" src="https://github.com/user-attachments/assets/d0ee2b38-ff0b-4c57-b966-96cfc5fdd915" />

<img width="416" height="874" alt="image" src="https://github.com/user-attachments/assets/42ca7418-1e4f-4968-8b95-e7225e2ba6ed" />
