### PR TITLE
fix(toast): sync animated total with toasts.length to fix stale-closure race

### DIFF
--- a/example/src/app/(home)/components/toast.tsx
+++ b/example/src/app/(home)/components/toast.tsx
@@ -83,8 +83,8 @@ const DefaultVariantsContent = () => {
         onPress={() =>
           toast.show({
             variant: 'success',
-            label: 'You have upgraded your plan',
-            description: 'You can continue using HeroUI Chat',
+            label: 'Plan upgraded',
+            description: 'You can continue using HeroUI Chat and more',
             icon: (
               <View className="mt-0.5">
                 <ShieldCheckIcon size={20} colorClassName="accent-success" />
@@ -102,8 +102,8 @@ const DefaultVariantsContent = () => {
         onPress={() =>
           toast.show({
             variant: 'warning',
-            label: 'You have no credits left',
-            description: 'Upgrade to a paid plan to continue',
+            label: 'No credits left',
+            description: 'Upgrade to a paid plan to continue using HeroUI Chat',
             icon: (
               <View className="mt-0.5">
                 <ShieldExclamationIcon
@@ -160,8 +160,8 @@ const PlacementVariantsContent = () => {
     toast.show({
       variant: 'success',
       placement: 'top',
-      label: 'You have upgraded your plan',
-      description: 'You can continue using HeroUI Chat',
+      label: 'Plan upgraded',
+      description: 'You can continue using HeroUI Chat and more',
       icon: (
         <View className="mt-0.5">
           <ShieldCheckIcon size={20} colorClassName="accent-success" />
@@ -175,8 +175,8 @@ const PlacementVariantsContent = () => {
     toast.show({
       variant: 'warning',
       placement: 'bottom',
-      label: 'You have no credits left',
-      description: 'Upgrade to a paid plan to continue',
+      label: 'No credits left',
+      description: 'Upgrade to a paid plan to continue using HeroUI Chat',
       icon: (
         <View className="mt-0.5">
           <ShieldExclamationIcon size={20} colorClassName="accent-warning" />
@@ -272,7 +272,7 @@ const DifferentContentSizesContent = () => {
         onPress={() =>
           toast.show({
             variant: 'success',
-            label: 'Backup completed successfully',
+            label: 'Backup completed',
             description:
               'All your files have been backed up to the cloud. You can now access them from any device. The backup includes 1,234 files totaling 2.5 GB. Your data is safe and secure. The next backup will run automatically in 24 hours.',
             actionLabel: 'Close',
@@ -366,7 +366,7 @@ const FromNativeModalContent = () => {
     <View className="flex-1 items-center justify-center px-5 gap-5">
       <Button
         variant="secondary"
-        onPress={() => router.push('components/toast-native-modal')}
+        onPress={() => router.push('/components/toast-native-modal')}
       >
         Open modal
       </Button>

--- a/src/providers/toast/provider.tsx
+++ b/src/providers/toast/provider.tsx
@@ -2,6 +2,7 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useReducer,
   useRef,
@@ -140,6 +141,16 @@ export function ToastProvider({
 
   const total = useSharedValue<number>(0);
 
+  /**
+   * Derive total from toasts.length so the animated opacity/scale/translateY
+   * interpolations always use the real count.  Manual increment/decrement
+   * was prone to drift when hide + show ran in the same tick or when
+   * auto-dismiss raced with a manual hide (stale-closure mismatch).
+   */
+  useEffect(() => {
+    total.set(toasts.length);
+  }, [toasts.length, total]);
+
   const idCounter = useRef(0);
   const timeoutRefs = useRef<Map<string, NodeJS.Timeout>>(new Map());
   const hideRef = useRef<((ids?: string | string[] | 'all') => void) | null>(
@@ -183,8 +194,6 @@ export function ToastProvider({
             delete result[lastToast.id];
             return result;
           });
-
-          total.set((value) => value - 1);
         }
       } else if (ids === 'all') {
         // Clear all timeouts
@@ -201,7 +210,6 @@ export function ToastProvider({
         });
         dispatch({ type: 'HIDE_ALL' });
         heights.set({});
-        total.set(0);
       } else {
         // Hide specific toast(s) - call onHide for each toast before hiding
         const idsArray = Array.isArray(ids) ? ids : [ids];
@@ -240,12 +248,10 @@ export function ToastProvider({
             }
             return result;
           });
-
-          total.set((value) => value - removedCount);
         }
       }
     },
-    [total, heights, toasts]
+    [heights, toasts]
   );
 
   // Keep hide ref up to date
@@ -319,8 +325,6 @@ export function ToastProvider({
         },
       });
 
-      total.set((value) => value + 1);
-
       if (normalizedOptions.onShow) {
         normalizedOptions.onShow();
       }
@@ -351,7 +355,7 @@ export function ToastProvider({
 
       return id;
     },
-    [total, toasts, globalConfig]
+    [toasts, globalConfig]
   );
 
   const contextValue = useMemo<ToasterContextValue>(


### PR DESCRIPTION
Closes #359 

## 📝 Description

Fixes a race condition in the toast provider where the `total` SharedValue could drift out of sync with the actual toast count. The manual increment/decrement approach was prone to stale-closure mismatches when hide and show ran in the same tick or when auto-dismiss raced with a manual hide. Also fixes a missing leading slash in the example app's router navigation.

## ⛳️ Current behavior (updates)

The `total` SharedValue was manually incremented on `show()` and decremented on `hide()`, which caused opacity/scale/translateY interpolations to use an incorrect count when concurrent show/hide operations occurred.

## 🚀 New behavior

- `total` is now derived from `toasts.length` via a `useEffect`, ensuring animated interpolations always reflect the real toast count
- Removed all manual `total.set(value => value + 1)` and `total.set(value => value - 1)` calls from show/hide logic
- Removed `total` from the `useCallback` dependency arrays of `show` and `hide`
- Fixed router path from `'components/toast-native-modal'` to `'/components/toast-native-modal'` in the example app
- Shortened example toast label strings for brevity

## 💣 Is this a breaking change (Yes/No):

**No** - This is an internal implementation fix. The toast provider API remains unchanged.

## 📝 Additional Information

The root cause was a stale-closure mismatch: when auto-dismiss fired, the `hide` callback captured an outdated `total` value, leading to negative or inflated counts that broke opacity and transform animations. Deriving from React state (`toasts.length`) eliminates the entire class of desync bugs.