### PR TITLE
fix(styles): respect disabled modifier

### DIFF
--- a/src/components/button/button.styles.ts
+++ b/src/components/button/button.styles.ts
@@ -42,7 +42,7 @@ const root = tv({
       true: 'p-0 aspect-square',
     },
     isDisabled: {
-      true: 'opacity-disabled pointer-events-none',
+      true: 'disabled:opacity-disabled disabled:pointer-events-none',
     },
   },
   defaultVariants: {

--- a/src/components/checkbox/checkbox.styles.ts
+++ b/src/components/checkbox/checkbox.styles.ts
@@ -33,7 +33,7 @@ const root = tv({
       false: '',
     },
     isDisabled: {
-      true: 'opacity-disabled pointer-events-none',
+      true: 'disabled:opacity-disabled disabled:pointer-events-none',
       false: '',
     },
     isInvalid: {

--- a/src/components/input/input.styles.ts
+++ b/src/components/input/input.styles.ts
@@ -14,7 +14,7 @@ const input = tv({
       false: '',
     },
     isDisabled: {
-      true: 'opacity-disabled',
+      true: 'disabled:opacity-disabled',
       false: '',
     },
   },

--- a/src/components/menu/menu.styles.ts
+++ b/src/components/menu/menu.styles.ts
@@ -66,7 +66,7 @@ const item = tv({
   base: 'flex-row items-center gap-2.5 px-2.5 py-2 rounded-2xl',
   variants: {
     isDisabled: {
-      true: 'opacity-disabled pointer-events-none',
+      true: 'disabled:opacity-disabled disabled:pointer-events-none',
     },
     isOutsideSubMenuOnOpen: {
       true: 'opacity-40 pointer-events-none',

--- a/src/components/switch/switch.styles.ts
+++ b/src/components/switch/switch.styles.ts
@@ -27,7 +27,7 @@ const root = tv({
   base: 'w-[48px] h-[24px] rounded-full justify-center overflow-hidden',
   variants: {
     isDisabled: {
-      true: 'opacity-disabled pointer-events-none',
+      true: 'disabled:opacity-disabled disabled:pointer-events-none',
       false: '',
     },
   },

--- a/src/components/tabs/tabs.styles.ts
+++ b/src/components/tabs/tabs.styles.ts
@@ -50,7 +50,7 @@ const trigger = tv({
   base: 'flex-row items-center justify-center px-3 py-1.5 gap-1.5',
   variants: {
     isDisabled: {
-      true: 'opacity-disabled pointer-events-none',
+      true: 'disabled:opacity-disabled disabled:pointer-events-none',
       false: '',
     },
   },

--- a/src/components/tag-group/tag-group.styles.ts
+++ b/src/components/tag-group/tag-group.styles.ts
@@ -26,7 +26,7 @@ const tag = tv({
       true: 'bg-accent-soft',
     },
     isDisabled: {
-      true: 'opacity-disabled pointer-events-none',
+      true: 'disabled:opacity-disabled disabled:pointer-events-none',
     },
   },
   defaultVariants: {


### PR DESCRIPTION
Closes #356 

## 📝 Description

Updates disabled state styling across 7 components to use the `disabled:` modifier prefix instead of applying styles unconditionally. This ensures disabled styles (opacity and pointer-events) are only applied when the component is in an actual disabled state, respecting the native disabled modifier from Uniwind.

## ⛳️ Current behavior (updates)

Disabled variant styles (`opacity-disabled`, `pointer-events-none`) are applied unconditionally when `isDisabled` is true, without using the `disabled:` pseudo-state modifier. This can cause styling conflicts when the disabled state is toggled dynamically.

## 🚀 New behavior

- All `isDisabled` variant classes now use the `disabled:` modifier prefix (e.g., `disabled:opacity-disabled disabled:pointer-events-none`)
- Affected components: **Button**, **Checkbox**, **Input**, **Menu**, **Switch**, **Tabs**, **TagGroup**
- Ensures disabled styles are properly scoped to the disabled pseudo-state

## 💣 Is this a breaking change (Yes/No):

**No** - This is a styling fix that corrects how disabled states are applied. Components continue to accept the same props and APIs.

## 📝 Additional Information

This is a targeted fix across all components that implement an `isDisabled` variant in their style definitions. The change is consistent across all 7 affected style files, replacing raw utility classes with their `disabled:` modifier equivalents.