### PR TITLE
feat: export useGlobalAnimationSettings hook from public API

### DIFF
--- a/src/helpers/external/hooks/index.ts
+++ b/src/helpers/external/hooks/index.ts
@@ -1,3 +1,4 @@
+export { useGlobalAnimationSettings } from '../../../providers/animation-settings/index';
 export { useTextComponent } from '../../../providers/text-component/index';
 export * from './use-bottom-sheet-aware-handlers';
 export * from './use-is-on-surface';


### PR DESCRIPTION
## 📝 Description

Exports the `useGlobalAnimationSettings` hook from the public-facing external hooks barrel file, making it accessible to consumers of the library. Previously, the hook was only available through the internal `animation-settings` provider module.

## ⛳️ Current behavior (updates)

The `useGlobalAnimationSettings` hook exists in `src/providers/animation-settings/` but is not re-exported from `src/helpers/external/hooks/index.ts`, so library consumers cannot import it from the public hooks API.

## 🚀 New behavior

- `useGlobalAnimationSettings` is now exported from the external hooks barrel (`src/helpers/external/hooks/index.ts`)
- Consumers can import the hook alongside other public hooks like `useTextComponent`, `useIsOnSurface`, and `useThemeColor`

## 💣 Is this a breaking change (Yes/No):

**No** - This is a purely additive change that exposes an existing hook through the public API. No existing imports or behaviors are affected.

## 📝 Additional Information

Single-line addition to the external hooks barrel file. No new dependencies or logic changes involved — this is strictly a build/export surface change.