### PR TITLE
feat(theme): add backdrop style variable for overlay components

### DIFF
--- a/docs/colors.md
+++ b/docs/colors.md
@@ -47,7 +47,7 @@ These colors define the main background layers and their foreground text colors:
 --surface-foreground: var(--foreground);
 --overlay: var(--white);
 --overlay-foreground: var(--foreground);
---overlay-backdrop: oklch(0% 0 0 / 10%);
+--backdrop: oklch(0% 0 0 / 20%);
 
 /* Dark theme */
 --background: oklch(12% 0.005 285.823);
@@ -56,7 +56,7 @@ These colors define the main background layers and their foreground text colors:
 --surface-foreground: var(--foreground);
 --overlay: oklch(0.2103 0.0059 285.89);
 --overlay-foreground: var(--foreground);
---overlay-backdrop: oklch(0% 0 0 / 10%);
+--backdrop: oklch(0% 0 0 / 20%);
 ```
 
 ### Primary Colors

--- a/docs/theming.md
+++ b/docs/theming.md
@@ -96,7 +96,7 @@ Create multiple themes using Uniwind's variant system. For complete custom theme
       /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) */
       --overlay: oklch(0.998 0.003 230);
       --overlay-foreground: oklch(0.3 0.045 230);
-      --overlay-backdrop: oklch(0% 0 0 / 10%);
+      --backdrop: oklch(0% 0 0 / 20%);
 
       --muted: oklch(0.55 0.035 230);
 
@@ -163,7 +163,7 @@ Create multiple themes using Uniwind's variant system. For complete custom theme
       /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) */
       --overlay: oklch(0.23 0.045 230);
       --overlay-foreground: oklch(0.9 0.015 230);
-      --overlay-backdrop: oklch(0% 0 0 / 10%);
+      --backdrop: oklch(0% 0 0 / 20%);
 
       --muted: oklch(0.5 0.04 230);
 
@@ -347,7 +347,11 @@ We use Tailwind's `@theme` directive to automatically create calculated variable
 
   --color-surface: var(--surface);
   --color-surface-foreground: var(--surface-foreground);
-  --color-surface-hover: color-mix(in oklab, var(--surface) 92%, var(--surface-foreground) 8%);
+  --color-surface-hover: color-mix(
+    in oklab,
+    var(--surface) 92%,
+    var(--surface-foreground) 8%
+  );
 
   --color-surface-secondary: var(--surface-secondary);
   --color-surface-secondary-foreground: var(--surface-secondary-foreground);
@@ -357,7 +361,7 @@ We use Tailwind's `@theme` directive to automatically create calculated variable
 
   --color-overlay: var(--overlay);
   --color-overlay-foreground: var(--overlay-foreground);
-  --color-overlay-backdrop: var(--overlay-backdrop);
+  --color-backdrop: var(--backdrop);
 
   --color-muted: var(--muted);
 
@@ -401,48 +405,120 @@ We use Tailwind's `@theme` directive to automatically create calculated variable
   /* Colors */
 
   /* --- background shades --- */
-  --color-background-secondary: color-mix(in oklab, var(--background) 96%, var(--foreground) 4%);
-  --color-background-tertiary: color-mix(in oklab, var(--background) 92%, var(--foreground) 8%);
+  --color-background-secondary: color-mix(
+    in oklab,
+    var(--background) 96%,
+    var(--foreground) 4%
+  );
+  --color-background-tertiary: color-mix(
+    in oklab,
+    var(--background) 92%,
+    var(--foreground) 8%
+  );
   --color-background-inverse: var(--foreground);
 
   /* ------------------------- */
-  --color-default-hover: color-mix(in oklab, var(--default) 96%, var(--default-foreground) 4%);
-  --color-accent-hover: color-mix(in oklab, var(--accent) 90%, var(--accent-foreground) 10%);
-  --color-success-hover: color-mix(in oklab, var(--success) 90%, var(--success-foreground) 10%);
-  --color-warning-hover: color-mix(in oklab, var(--warning) 90%, var(--warning-foreground) 10%);
-  --color-danger-hover: color-mix(in oklab, var(--danger) 90%, var(--danger-foreground) 10%);
+  --color-default-hover: color-mix(
+    in oklab,
+    var(--default) 96%,
+    var(--default-foreground) 4%
+  );
+  --color-accent-hover: color-mix(
+    in oklab,
+    var(--accent) 90%,
+    var(--accent-foreground) 10%
+  );
+  --color-success-hover: color-mix(
+    in oklab,
+    var(--success) 90%,
+    var(--success-foreground) 10%
+  );
+  --color-warning-hover: color-mix(
+    in oklab,
+    var(--warning) 90%,
+    var(--warning-foreground) 10%
+  );
+  --color-danger-hover: color-mix(
+    in oklab,
+    var(--danger) 90%,
+    var(--danger-foreground) 10%
+  );
 
-  /* Form Field Colors */ 
-  --color-field-hover: color-mix(in oklab, var(--field-background, var(--default)) 90%, var(--field-foreground, var(--foreground)) 2%);
+  /* Form Field Colors */
+  --color-field-hover: color-mix(
+    in oklab,
+    var(--field-background, var(--default)) 90%,
+    var(--field-foreground, var(--foreground)) 2%
+  );
   --color-field-focus: var(--field-background, var(--default));
-  --color-field-border-hover: color-mix(in oklab, var(--field-border, var(--border)) 88%, var(--field-foreground, var(--foreground)) 10%);
-  --color-field-border-focus: color-mix(in oklab, var(--field-border, var(--border)) 74%, var(--field-foreground, var(--foreground)) 22%);
+  --color-field-border-hover: color-mix(
+    in oklab,
+    var(--field-border, var(--border)) 88%,
+    var(--field-foreground, var(--foreground)) 10%
+  );
+  --color-field-border-focus: color-mix(
+    in oklab,
+    var(--field-border, var(--border)) 74%,
+    var(--field-foreground, var(--foreground)) 22%
+  );
 
   /* Soft Colors */
   --color-accent-soft: color-mix(in oklab, var(--accent) 15%, transparent);
   --color-accent-soft-foreground: var(--accent);
-  --color-accent-soft-hover: color-mix(in oklab, var(--accent) 20%, transparent);
+  --color-accent-soft-hover: color-mix(
+    in oklab,
+    var(--accent) 20%,
+    transparent
+  );
 
   --color-danger-soft: color-mix(in oklab, var(--danger) 15%, transparent);
   --color-danger-soft-foreground: var(--danger);
-  --color-danger-soft-hover: color-mix(in oklab, var(--danger) 20%, transparent);
+  --color-danger-soft-hover: color-mix(
+    in oklab,
+    var(--danger) 20%,
+    transparent
+  );
 
   --color-warning-soft: color-mix(in oklab, var(--warning) 15%, transparent);
   --color-warning-soft-foreground: var(--warning);
-  --color-warning-soft-hover: color-mix(in oklab, var(--warning) 20%, transparent);
+  --color-warning-soft-hover: color-mix(
+    in oklab,
+    var(--warning) 20%,
+    transparent
+  );
 
   --color-success-soft: color-mix(in oklab, var(--success) 15%, transparent);
   --color-success-soft-foreground: var(--success);
-  --color-success-soft-hover: color-mix(in oklab, var(--success) 20%, transparent);
+  --color-success-soft-hover: color-mix(
+    in oklab,
+    var(--success) 20%,
+    transparent
+  );
 
   /* Separator Colors - Levels */
-  --color-separator-secondary: color-mix(in oklab, var(--surface) 85%, var(--surface-foreground) 15%);
-  --color-separator-tertiary: color-mix(in oklab, var(--surface) 81%, var(--surface-foreground) 19%);
+  --color-separator-secondary: color-mix(
+    in oklab,
+    var(--surface) 85%,
+    var(--surface-foreground) 15%
+  );
+  --color-separator-tertiary: color-mix(
+    in oklab,
+    var(--surface) 81%,
+    var(--surface-foreground) 19%
+  );
 
   /* Border Colors - Levels (progressive contrast: default → secondary → tertiary) */
   /* Light mode: lighter → darker | Dark mode: darker → lighter */
-  --color-border-secondary: color-mix(in oklab, var(--surface) 78%, var(--surface-foreground) 22%);
-  --color-border-tertiary: color-mix(in oklab, var(--surface) 66%, var(--surface-foreground) 34%);
+  --color-border-secondary: color-mix(
+    in oklab,
+    var(--surface) 78%,
+    var(--surface-foreground) 22%
+  );
+  --color-border-tertiary: color-mix(
+    in oklab,
+    var(--surface) 66%,
+    var(--surface-foreground) 34%
+  );
 
   /* Radius and default sizes - defaults can change by just changing the --radius */
   --radius-xs: calc(var(--radius) * 0.25); /* 0.125rem (2px) */

--- a/example/themes/alpha.css
+++ b/example/themes/alpha.css
@@ -25,6 +25,7 @@
       /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) */
       --overlay: var(--white);
       --overlay-foreground: var(--foreground);
+      --backdrop: oklch(0% 0 0 / 20%);
 
       --muted: var(--color-neutral-500);
 
@@ -97,6 +98,7 @@
       /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) */
       --overlay: var(--color-neutral-800);
       --overlay-foreground: var(--foreground);
+      --backdrop: oklch(0% 0 0 / 20%);
 
       --muted: var(--color-neutral-400);
 

--- a/example/themes/lavander.css
+++ b/example/themes/lavander.css
@@ -25,6 +25,7 @@
       /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) */
       --overlay: oklch(100.00% 0.0045 305.00);
       --overlay-foreground: oklch(21.03% 0.0059 305.00);
+      --backdrop: oklch(0% 0 0 / 20%);
 
       --muted: oklch(55.17% 0.0302 305.00);
 
@@ -93,6 +94,7 @@
       /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) */
       --overlay: oklch(21.03% 0.0302 305.00);
       --overlay-foreground: oklch(99.11% 0.0000 0.00);
+      --backdrop: oklch(0% 0 0 / 20%);
 
       --muted: oklch(70.50% 0.0302 305.00);
 

--- a/example/themes/mint.css
+++ b/example/themes/mint.css
@@ -25,6 +25,7 @@
       /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) */
       --overlay: oklch(100.00% 0.0036 155.00);
       --overlay-foreground: oklch(21.03% 0.0059 155.00);
+      --backdrop: oklch(0% 0 0 / 20%);
 
       --muted: oklch(55.17% 0.0242 155.00);
 
@@ -98,6 +99,7 @@
       /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) */
       --overlay: oklch(21.03% 0.0242 155.00);
       --overlay-foreground: oklch(99.11% 0.0000 0.00);
+      --backdrop: oklch(0% 0 0 / 20%);
 
       --muted: oklch(70.50% 0.0242 155.00);
 

--- a/example/themes/sky.css
+++ b/example/themes/sky.css
@@ -25,6 +25,7 @@
       /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) */
       --overlay: oklch(100.00% 0.0014 225.00);
       --overlay-foreground: oklch(21.03% 0.0059 225.00);
+      --backdrop: oklch(0% 0 0 / 20%);
 
       --muted: oklch(55.17% 0.0096 225.00);
 
@@ -98,6 +99,7 @@
       /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) */
       --overlay: oklch(21.03% 0.0096 225.00);
       --overlay-foreground: oklch(99.11% 0.0000 0.00);
+      --backdrop: oklch(0% 0 0 / 20%);
 
       --muted: oklch(70.50% 0.0096 225.00);
 

--- a/src/components/bottom-sheet/bottom-sheet.styles.ts
+++ b/src/components/bottom-sheet/bottom-sheet.styles.ts
@@ -22,7 +22,7 @@ import { combineStyles } from '../../helpers/internal/utils';
  * set `isAnimatedStyleActive={false}` on `BottomSheet.Overlay`.
  */
 const overlay = tv({
-  base: 'absolute inset-0 bg-overlay-backdrop',
+  base: 'absolute inset-0 bg-backdrop',
 });
 
 const contentContainer = tv({

--- a/src/components/dialog/dialog.styles.ts
+++ b/src/components/dialog/dialog.styles.ts
@@ -26,7 +26,7 @@ const portal = tv({
  * set `isAnimatedStyleActive={false}` on `Dialog.Overlay`.
  */
 const overlay = tv({
-  base: 'absolute inset-0 bg-overlay-backdrop',
+  base: 'absolute inset-0 bg-backdrop',
 });
 
 /**

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -14,7 +14,7 @@
 
   --color-overlay: var(--overlay);
   --color-overlay-foreground: var(--overlay-foreground);
-  --color-overlay-backdrop: var(--overlay-backdrop);
+  --color-backdrop: var(--backdrop);
 
   --color-muted: var(--muted);
 
@@ -69,7 +69,7 @@
   --color-warning-hover: color-mix(in oklab, var(--warning) 90%, var(--warning-foreground) 10%);
   --color-danger-hover: color-mix(in oklab, var(--danger) 90%, var(--danger-foreground) 10%);
 
-  /* Form Field Colors */ 
+  /* Form Field Colors */
   --color-field-hover: color-mix(in oklab, var(--field-background, var(--default)) 90%, var(--field-foreground, var(--foreground)) 2%);
   --color-field-focus: var(--field-background, var(--default));
   --color-field-border-hover: color-mix(in oklab, var(--field-border, var(--border)) 88%, var(--field-foreground, var(--foreground)) 10%);

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -37,7 +37,7 @@
       /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) */
       --overlay: var(--white);
       --overlay-foreground: var(--foreground);
-      --overlay-backdrop: oklch(0% 0 0 / 10%);
+      --backdrop: oklch(0% 0 0 / 20%);
 
       --muted: oklch(0.5517 0.0138 285.94);
 
@@ -103,7 +103,7 @@
       /* Overlay: Used for floating/overlay components (dialogs, popovers, modals, menus) - lighter for contrast */
       --overlay: oklch(0.2103 0.0059 285.89);
       --overlay-foreground: var(--foreground);
-      --overlay-backdrop: oklch(0% 0 0 / 10%);
+      --backdrop: oklch(0% 0 0 / 20%);
 
       --muted: oklch(70.5% 0.015 286.067);
 


### PR DESCRIPTION
## 📝 Description

Adds a new `--backdrop` top-level style variable to the theme system, providing a dedicated color token for the dimming layer behind overlay components (dialogs, bottom sheets). The default value is set to `oklch(0% 0 0 / 20%)` for a subtle but visible backdrop effect.

## ⛳️ Current behavior (updates)

There was no dedicated top-level backdrop-style variable.

## 🚀 New behavior

- New `--backdrop` style variable available at the theme root level with a default 20% opacity
- Corresponding Tailwind utility `bg-backdrop` available for use in component styles
- `--backdrop` is included in all built-in themes (default, alpha, lavander, mint, sky) for both light and dark modes
- Dialog and Bottom Sheet overlay components now use the new `bg-backdrop` utility
- Documentation updated with the new variable in both the colors and theming guides

## 💣 Is this a breaking change (Yes/No):

**No** — It's new style variable which doesn't touch users

## 📝 Additional Information

The variable was promoted out of the overlay namespace to allow broader reuse across components that need a backdrop/scrim layer. The opacity increase from 10% to 20% improves visual hierarchy when overlays are open.