### PR TITLE
fix(button): android dynamic variant style issue

### DIFF
--- a/src/components/button/button.styles.ts
+++ b/src/components/button/button.styles.ts
@@ -25,13 +25,13 @@ const root = tv({
   base: 'flex-row items-center justify-center',
   variants: {
     variant: {
-      primary: 'bg-accent',
-      secondary: 'bg-default',
-      tertiary: 'bg-default',
+      primary: 'bg-accent border-0',
+      secondary: 'bg-default border-0',
+      tertiary: 'bg-default border-0',
       outline: 'bg-transparent border border-border',
-      ghost: 'bg-transparent',
-      danger: 'bg-danger',
-      ['danger-soft']: 'bg-danger-soft',
+      ghost: 'bg-transparent border-0',
+      danger: 'bg-danger border-0',
+      ['danger-soft']: 'bg-danger-soft border-0',
     },
     size: {
       sm: 'h-[36px] px-3.5 gap-1.5 rounded-3xl',


### PR DESCRIPTION
Closes #363 

## 📝 Description
This PR fixes the Button outline variant issue on Android where the border would sometimes persist when switching to another variant via a conditional prop.

## ⛳️ Current behavior (updates)
On the Android platform, React Native sometimes retains the borderWidth property when a component transitions from a state WITH a border (like the outline variant) to a state WITHOUT any border-related classes (like primary or secondary). This causes an unwanted border to remain visible even after the variant has changed.

## 🚀 New behavior
Added explicit border-0 classes to all button variants except outline. This ensures that borderWidth is explicitly reset to 0 whenever the button variant changes, preventing the persistent border bug on Android.

## 💣 Is this a breaking change (Yes/No):
No, just a styling fix.
