### PR TITLE
feat(pressable-feedback, surface): add asChild slot pattern support

### DIFF
--- a/src/components/pressable-feedback/pressable-feedback.tsx
+++ b/src/components/pressable-feedback/pressable-feedback.tsx
@@ -10,6 +10,7 @@ import {
 import Animated from 'react-native-reanimated';
 import { AnimationSettingsProvider } from '../../helpers/internal/contexts';
 import type { PressableRef, ViewRef } from '../../helpers/internal/types';
+import * as Slot from '../../primitives/slot';
 import {
   PressableFeedbackRootAnimationProvider,
   usePressableFeedbackHighlightAnimation,
@@ -30,6 +31,7 @@ import type {
 } from './pressable-feedback.types';
 
 const AnimatedPressable = Animated.createAnimatedComponent(Pressable);
+const AnimatedSlotPressable = Animated.createAnimatedComponent(Slot.Pressable);
 
 // --------------------------------------------------
 
@@ -45,8 +47,11 @@ const PressableFeedback = forwardRef<PressableRef, PressableFeedbackProps>(
       onLayout,
       onPressIn,
       onPressOut,
+      asChild = false,
       ...restProps
     } = props;
+
+    const RootComponent = asChild ? AnimatedSlotPressable : AnimatedPressable;
 
     const {
       isPressed,
@@ -116,7 +121,7 @@ const PressableFeedback = forwardRef<PressableRef, PressableFeedbackProps>(
     return (
       <AnimationSettingsProvider value={animationSettingsContextValue}>
         <PressableFeedbackRootAnimationProvider value={animationContextValue}>
-          <AnimatedPressable
+          <RootComponent
             ref={ref}
             disabled={isDisabled}
             className={rootClassName}
@@ -127,7 +132,7 @@ const PressableFeedback = forwardRef<PressableRef, PressableFeedbackProps>(
             {...restProps}
           >
             {children}
-          </AnimatedPressable>
+          </RootComponent>
         </PressableFeedbackRootAnimationProvider>
       </AnimationSettingsProvider>
     );
@@ -314,7 +319,7 @@ PressableFeedbackRipple.displayName = DISPLAY_NAME.RIPPLE;
  * - Built-in scale animation enabled by default
  * - Composable compound parts: Scale, Highlight, Ripple
  * - Full gesture handling with press, long press, and disabled states
- * - Polymorphic via `asChild` prop (Slot pattern)
+ * - Polymorphic via `asChild` prop (AnimatedSlotPressable = Animated + Slot.Pressable)
  * - Used as foundation for interactive components like Button, Card, and Accordion
  *
  * @component PressableFeedback.Scale

--- a/src/components/pressable-feedback/pressable-feedback.types.ts
+++ b/src/components/pressable-feedback/pressable-feedback.types.ts
@@ -244,6 +244,12 @@ export interface PressableFeedbackProps
    * @default true
    */
   isAnimatedStyleActive?: boolean;
+  /**
+   * When `true`, merges press behavior and animated scale onto the single child (Slot pattern).
+   * The child must be one React element. Uses `Animated.createAnimatedComponent(Slot.Pressable)` internally.
+   * @default false
+   */
+  asChild?: boolean;
 }
 
 /**

--- a/src/components/surface/surface.tsx
+++ b/src/components/surface/surface.tsx
@@ -3,6 +3,7 @@ import { View } from 'react-native';
 import { AnimationSettingsProvider } from '../../helpers/internal/contexts';
 import type { ViewRef } from '../../helpers/internal/types';
 import { createContext } from '../../helpers/internal/utils';
+import * as Slot from '../../primitives/slot';
 import { useSurfaceRootAnimation } from './surface.animation';
 import { DISPLAY_NAME } from './surface.constants';
 import { surfaceClassNames, surfaceStyleSheet } from './surface.styles';
@@ -15,9 +16,19 @@ const [SurfaceProvider, useSurface] = createContext<SurfaceContextValue>({
 
 const Surface = forwardRef<ViewRef, SurfaceRootProps>(
   (
-    { children, variant = 'default', className, style, animation, ...props },
+    {
+      children,
+      variant = 'default',
+      className,
+      style,
+      animation,
+      asChild = false,
+      ...props
+    },
     ref
   ) => {
+    const RootComponent = asChild ? Slot.View : View;
+
     const rootClassName = surfaceClassNames.root({ variant, className });
 
     const { isAllAnimationsDisabled } = useSurfaceRootAnimation({
@@ -36,14 +47,14 @@ const Surface = forwardRef<ViewRef, SurfaceRootProps>(
     return (
       <AnimationSettingsProvider value={animationSettingsContextValue}>
         <SurfaceProvider value={contextValue}>
-          <View
+          <RootComponent
             ref={ref}
             className={rootClassName}
             style={[surfaceStyleSheet.root, style]}
             {...props}
           >
             {children}
-          </View>
+          </RootComponent>
         </SurfaceProvider>
       </AnimationSettingsProvider>
     );
@@ -58,6 +69,7 @@ Surface.displayName = DISPLAY_NAME.ROOT;
  * @component Surface - Container component that provides elevation and background styling.
  * Used as a base for other components like Card. Supports different visual variants
  * for various elevation levels and styling needs.
+ * - Polymorphic via `asChild` prop (Slot.View merges surface styling onto the child)
  *
  * @see Full documentation: https://heroui.com/docs/native/components/surface
  */

--- a/src/components/surface/surface.types.ts
+++ b/src/components/surface/surface.types.ts
@@ -33,6 +33,12 @@ export interface SurfaceRootProps extends ViewProps {
    * - `undefined`: Use default animations
    */
   animation?: AnimationRootDisableAll;
+  /**
+   * When `true`, merges surface styling onto the single child element (Slot pattern).
+   * The child must be one React element. Uses `Slot.View` internally.
+   * @default false
+   */
+  asChild?: boolean;
 }
 
 /**


### PR DESCRIPTION
Closes #357 

## 📝 Description

Adds `asChild` prop support to `PressableFeedback` and `Surface` components, enabling the Slot pattern for polymorphic rendering. When `asChild` is true, each component merges its behavior and styling onto a single child element instead of wrapping it in an additional DOM node.

## ⛳️ Current behavior (updates)

`PressableFeedback` always renders an `AnimatedPressable` wrapper and `Surface` always renders a `View` wrapper, with no way to merge their behavior/styling onto an existing child element.

## 🚀 New behavior

- **PressableFeedback**: New `asChild` prop (default `false`). When `true`, uses `Animated.createAnimatedComponent(Slot.Pressable)` to merge press handling and animated styles onto the child element.
- **Surface**: New `asChild` prop (default `false`). When `true`, uses `Slot.View` to merge surface styling (elevation, background, className) onto the child element.
- Both components include full TypeScript types and JSDoc documentation for the new prop.

## 💣 Is this a breaking change (Yes/No):

**No** - The `asChild` prop defaults to `false`, preserving existing behavior. No migration required.

## 📝 Additional Information

Both implementations follow the established Slot primitive pattern already used in the codebase. The child must be a single React element when `asChild` is enabled.