### PR TITLE
style(input, select): refine input border width and select trigger padding

### DIFF
--- a/src/components/input/input.styles.ts
+++ b/src/components/input/input.styles.ts
@@ -3,7 +3,7 @@ import { tv } from 'tailwind-variants';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const input = tv({
-  base: 'py-3.5 px-3 rounded-2xl text-foreground font-normal border-2 focus:border-accent',
+  base: 'py-3.5 px-3 rounded-2xl text-foreground font-normal border-[1.5px] focus:border-accent',
   variants: {
     variant: {
       primary: 'bg-field border-field ios:shadow-field android:shadow-sm',

--- a/src/components/select/select.styles.ts
+++ b/src/components/select/select.styles.ts
@@ -7,7 +7,7 @@ const trigger = tv({
   variants: {
     variant: {
       default:
-        'flex-row items-center justify-between gap-3 py-3.5 px-4 rounded-2xl bg-surface shadow-surface',
+        'flex-row items-center justify-between gap-3 py-3 px-4 rounded-2xl bg-surface shadow-surface',
       unstyled: '',
     },
     isDisabled: {


### PR DESCRIPTION
## 📝 Description

Refines the visual styling of the Input and Select components by reducing the Input border width and adjusting the Select trigger vertical padding for a cleaner, more balanced appearance.

## ⛳️ Current behavior (updates)

The Input component uses a `border-2` (2px) border width, and the Select trigger uses `py-3.5` vertical padding.

## 🚀 New behavior

- **Input**: Border width reduced from `border-2` to `border-[1.5px]` for a subtler, less heavy border appearance
- **Select**: Trigger vertical padding reduced from `py-3.5` to `py-3` for tighter, more compact spacing

## 💣 Is this a breaking change (Yes/No):

**No** - These are minor visual refinements to existing styles with no API or behavioral changes.

## 📝 Additional Information

Purely cosmetic adjustments. No new dependencies or logic changes. Visual regression testing recommended to confirm the updated styles render as expected across iOS and Android.