### PR TITLE
fix: align tabs indicator in RTL

### DIFF
--- a/src/components/tabs/tabs.animation.ts
+++ b/src/components/tabs/tabs.animation.ts
@@ -1,3 +1,4 @@
+import { I18nManager } from 'react-native';
 import {
   useAnimatedStyle,
   useSharedValue,
@@ -22,6 +23,8 @@ import type {
   TabsIndicatorAnimation,
   TabsSeparatorAnimation,
 } from './tabs.types';
+
+const isRTL = I18nManager.isRTL;
 
 // --------------------------------------------------
 
@@ -54,7 +57,7 @@ export function useTabsIndicatorAnimation(options: {
 
   // Get active measurements from tabs context
   const { value } = TabsPrimitives.useRootContext();
-  const { measurements } = useTabsMeasurements();
+  const { listWidth, measurements } = useTabsMeasurements();
   const activeMeasurements = measurements[value];
 
   // Read from global animation context (always available in compound parts)
@@ -116,12 +119,18 @@ export function useTabsIndicatorAnimation(options: {
       };
     }
 
+    const translateX = getIndicatorTranslateX({
+      listWidth,
+      tabWidth: activeMeasurements.width,
+      tabX: activeMeasurements.x,
+    });
+
     if (!hasMeasured.value) {
       hasMeasured.value = true;
       return {
         width: activeMeasurements.width,
         height: activeMeasurements.height,
-        transform: [{ translateX: activeMeasurements.x }],
+        transform: [{ translateX }],
         opacity: 1,
       };
     }
@@ -131,7 +140,7 @@ export function useTabsIndicatorAnimation(options: {
       return {
         width: activeMeasurements.width,
         height: activeMeasurements.height,
-        transform: [{ translateX: activeMeasurements.x }],
+        transform: [{ translateX }],
         opacity: 1,
       };
     }
@@ -149,8 +158,8 @@ export function useTabsIndicatorAnimation(options: {
 
     const translateXAnimation =
       translateXConfig.type === 'timing'
-        ? withTiming(activeMeasurements.x, translateXConfig.timingConfig)
-        : withSpring(activeMeasurements.x, translateXConfig.springConfig);
+        ? withTiming(translateX, translateXConfig.timingConfig)
+        : withSpring(translateX, translateXConfig.springConfig);
 
     return {
       width: widthAnimation,
@@ -161,6 +170,7 @@ export function useTabsIndicatorAnimation(options: {
   }, [
     activeMeasurements,
     isAnimationDisabledValue,
+    listWidth,
     widthConfig,
     heightConfig,
     translateXConfig,
@@ -169,6 +179,22 @@ export function useTabsIndicatorAnimation(options: {
   return {
     rContainerStyle,
   };
+}
+
+function getIndicatorTranslateX({
+  listWidth,
+  tabWidth,
+  tabX,
+}: {
+  listWidth: number;
+  tabWidth: number;
+  tabX: number;
+}) {
+  if (!(isRTL && listWidth > 0)) {
+    return tabX;
+  }
+
+  return tabX - (listWidth - tabWidth);
 }
 
 // --------------------------------------------------

--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -63,6 +63,7 @@ const TabsRoot = forwardRef<TabsPrimitivesTypes.RootRef, TabsProps>(
     const [measurements, setMeasurementsState] = useState<
       Record<string, ItemMeasurements>
     >({});
+    const [listWidth, setListWidth] = useState(0);
     const [isScrollView, setIsScrollView] = useState(false);
 
     const setMeasurements = useCallback(
@@ -92,6 +93,8 @@ const TabsRoot = forwardRef<TabsPrimitivesTypes.RootRef, TabsProps>(
           value={{
             measurements,
             setMeasurements,
+            listWidth,
+            setListWidth,
             variant,
             isScrollView,
             setIsScrollView,
@@ -116,19 +119,28 @@ const TabsRoot = forwardRef<TabsPrimitivesTypes.RootRef, TabsProps>(
 
 const TabsList = forwardRef<TabsPrimitivesTypes.ListRef, TabsListProps>(
   (props, ref) => {
-    const { children, className, style, ...restProps } = props;
+    const { children, className, style, onLayout, ...restProps } = props;
 
-    const { variant, setIsScrollView } = useTabsMeasurements();
+    const { variant, setIsScrollView, setListWidth } = useTabsMeasurements();
 
-    const handleLayout = useCallback(() => {
-      const childrenArray = Children.toArray(children);
-      const hasScrollView =
-        childrenArray.length === 1 &&
-        isValidElement(childrenArray[0]) &&
-        (childrenArray[0].type as any)?.displayName ===
-          DISPLAY_NAME.SCROLL_VIEW;
-      setIsScrollView(hasScrollView);
-    }, [children, setIsScrollView]);
+    const handleLayout = useCallback(
+      (event: LayoutChangeEvent) => {
+        onLayout?.(event);
+
+        const childrenArray = Children.toArray(children);
+        const hasScrollView =
+          childrenArray.length === 1 &&
+          isValidElement(childrenArray[0]) &&
+          (childrenArray[0].type as any)?.displayName ===
+            DISPLAY_NAME.SCROLL_VIEW;
+        setIsScrollView(hasScrollView);
+
+        if (!hasScrollView) {
+          setListWidth(event.nativeEvent.layout.width);
+        }
+      },
+      [children, onLayout, setIsScrollView, setListWidth]
+    );
 
     const listClassName = tabsClassNames.list({ variant, className });
 
@@ -154,13 +166,14 @@ const TabsScrollView = forwardRef<ScrollView, TabsScrollViewProps>(
       children,
       className,
       contentContainerClassName,
+      onContentSizeChange,
       showsHorizontalScrollIndicator = false,
       scrollAlign = 'center',
       ...restProps
     } = props;
 
     const { value } = useTabs();
-    const { measurements, variant } = useTabsMeasurements();
+    const { measurements, setListWidth, variant } = useTabsMeasurements();
     const { width: screenWidth } = useWindowDimensions();
 
     const scrollViewClassName = tabsClassNames.scrollView({
@@ -174,6 +187,14 @@ const TabsScrollView = forwardRef<ScrollView, TabsScrollViewProps>(
       });
 
     const scrollRef = useRef<ScrollView>(null);
+
+    const handleContentSizeChange = useCallback(
+      (width: number, height: number) => {
+        setListWidth(width);
+        onContentSizeChange?.(width, height);
+      },
+      [onContentSizeChange, setListWidth]
+    );
 
     useEffect(() => {
       if (scrollAlign === 'none' || !measurements[value]) return;
@@ -210,6 +231,7 @@ const TabsScrollView = forwardRef<ScrollView, TabsScrollViewProps>(
         showsHorizontalScrollIndicator={showsHorizontalScrollIndicator}
         className={scrollViewClassName}
         contentContainerClassName={contentContainerClassNameValue}
+        onContentSizeChange={handleContentSizeChange}
         {...restProps}
       >
         {children}

--- a/src/components/tabs/tabs.types.ts
+++ b/src/components/tabs/tabs.types.ts
@@ -335,6 +335,8 @@ export type ItemMeasurements = {
 export type MeasurementsContextValue = {
   measurements: Record<string, ItemMeasurements>;
   setMeasurements: (key: string, measurements: ItemMeasurements) => void;
+  listWidth: number;
+  setListWidth: (width: number) => void;
   variant: 'primary' | 'secondary';
   isScrollView: boolean;
   setIsScrollView: (isScrollView: boolean) => void;


### PR DESCRIPTION
## Summary
- Track the rendered tabs list width in measurements context.
- Use that width to mirror the indicator translateX when React Native is running in RTL.
- Populate the width from `Tabs.List` for fixed tabs and from `Tabs.ScrollView` content size for scrollable tabs.

## Test plan
- `corepack yarn lint`
- `corepack yarn typecheck`
- Manual local check recommended: run the example app with `I18nManager.forceRTL(true)` and verify both fixed tabs and `Tabs.ScrollView` indicator placement.