### PR TITLE
fix(scroll-shadow): respect child's `inverted` prop

### DIFF
--- a/src/components/scroll-shadow/scroll-shadow.tsx
+++ b/src/components/scroll-shadow/scroll-shadow.tsx
@@ -85,6 +85,13 @@ const ScrollShadowRoot = forwardRef<View, ScrollShadowProps>((props, ref) => {
   const orientation =
     orientationProp || (childHorizontal ? 'horizontal' : 'vertical');
 
+  const inverted =
+    children?.props &&
+    typeof children?.props === 'object' &&
+    'inverted' in children.props
+      ? children.props.inverted
+      : false;
+
   // Get all animation logic from root hook
   const {
     contentSize,
@@ -99,6 +106,11 @@ const ScrollShadowRoot = forwardRef<View, ScrollShadowProps>((props, ref) => {
     visibility,
     isEnabled,
   });
+
+  // When inverted, swap which animated style drives each visual edge so that
+  // shadows appear at the correct edge from the user's perspective.
+  const topEdgeShadowStyle = inverted ? bottomShadowStyle : topShadowStyle;
+  const bottomEdgeShadowStyle = inverted ? topShadowStyle : bottomShadowStyle;
 
   const onContentSizeChange = (w: number, h: number) => {
     const contentDimension = orientation === 'vertical' ? h : w;
@@ -180,7 +192,7 @@ const ScrollShadowRoot = forwardRef<View, ScrollShadowProps>((props, ref) => {
           style={[
             scrollShadowStyleSheet.topShadow,
             { height: size },
-            topShadowStyle,
+            topEdgeShadowStyle,
           ]}
         >
           <LinearGradientComponent
@@ -194,7 +206,7 @@ const ScrollShadowRoot = forwardRef<View, ScrollShadowProps>((props, ref) => {
           style={[
             scrollShadowStyleSheet.leftShadow,
             { width: size },
-            topShadowStyle,
+            topEdgeShadowStyle,
           ]}
         >
           <LinearGradientComponent
@@ -213,7 +225,7 @@ const ScrollShadowRoot = forwardRef<View, ScrollShadowProps>((props, ref) => {
           style={[
             scrollShadowStyleSheet.bottomShadow,
             { height: size },
-            bottomShadowStyle,
+            bottomEdgeShadowStyle,
           ]}
         >
           <LinearGradientComponent
@@ -227,7 +239,7 @@ const ScrollShadowRoot = forwardRef<View, ScrollShadowProps>((props, ref) => {
           style={[
             scrollShadowStyleSheet.rightShadow,
             { width: size },
-            bottomShadowStyle,
+            bottomEdgeShadowStyle,
           ]}
         >
           <LinearGradientComponent


### PR DESCRIPTION
  Closes #393

  ## 📝 Description

  `ScrollShadow` did not respect the `inverted` prop of its scrollable
  child (e.g. `<FlatList inverted>`), causing the gradient shadows to
  appear on the wrong visual edges.

  ## ⛳️ Current behavior (updates)

  When wrapping an inverted list, shadows render at the top edge while
  content exists below, and remain absent at the bottom even though
  there is more content to scroll. From the user's perspective, this
  points to the wrong direction.

  ## 🚀 New behavior

  `ScrollShadowRoot` now reads `inverted` from the child component's
  props (mirroring the existing `childHorizontal` auto-detection
  pattern) and swaps which animated style drives each visual edge so
  shadows render at the correct side.

  If maintainers prefer, I can also add an explicit `inverted` prop on
  `ScrollShadow` itself with override semantics (matching how
  `orientationProp` overrides `childHorizontal`). Kept it minimal for
  now to match the scope of the bug.

  ## 💣 Is this a breaking change (Yes/No):

  No. The behavior only changes when the child has `inverted={true}`,
  which previously rendered incorrectly.

  ## 📝 Additional Information

  - `yarn typecheck`, `yarn lint`, `yarn test` all pass.
  - Verified locally via `patch-package` in a production app using
    `<ScrollShadow><FlashList inverted ... /></ScrollShadow>`.
  - I noticed @vvv-sss is assigned to the issue — if you have a fix
    in progress, happy to defer or rebase on top of yours.
