### PR TITLE
feat: add Text component with semantic type prop and sub-components

### DIFF
--- a/example/src/app/(home)/components/text.tsx
+++ b/example/src/app/(home)/components/text.tsx
@@ -1,0 +1,140 @@
+import { Text } from 'heroui-native';
+import { View } from 'react-native';
+import type { UsageVariant } from '../../../components/component-presentation/types';
+import { UsageVariantFlatList } from '../../../components/component-presentation/usage-variant-flatlist';
+
+const TypesContent = () => {
+  return (
+    <View className="flex-1 justify-center px-5 gap-4">
+      <Text type="h1">Heading 1</Text>
+      <Text type="h2">Heading 2</Text>
+      <Text type="h3">Heading 3</Text>
+      <Text type="h4">Heading 4</Text>
+      <Text type="h5">Heading 5</Text>
+      <Text type="h6">Heading 6</Text>
+      <Text type="body">Body text</Text>
+      <Text type="body-sm">Small body text</Text>
+      <Text type="body-xs">Extra-small body text</Text>
+      <Text type="code">const x = 42;</Text>
+    </View>
+  );
+};
+
+// ------------------------------------------------------------------------------
+
+const HeadingsContent = () => {
+  return (
+    <View className="flex-1 justify-center px-5 gap-4">
+      <Text.Heading type="h1">Page Title</Text.Heading>
+      <Text.Heading type="h2">Section Title</Text.Heading>
+      <Text.Heading type="h3">Subsection</Text.Heading>
+      <Text.Heading type="h4">Group Title</Text.Heading>
+      <Text.Heading type="h5">Label Heading</Text.Heading>
+      <Text.Heading type="h6">Small Heading</Text.Heading>
+    </View>
+  );
+};
+
+// ------------------------------------------------------------------------------
+
+const ParagraphsContent = () => {
+  return (
+    <View className="flex-1 justify-center px-5 gap-4">
+      <Text.Paragraph>
+        This is a default body paragraph. It uses the base font size and normal
+        weight for comfortable reading.
+      </Text.Paragraph>
+      <Text.Paragraph type="body-sm">
+        This is a smaller paragraph, useful for captions, footnotes, or
+        secondary descriptions.
+      </Text.Paragraph>
+      <Text.Paragraph type="body-xs">
+        Extra-small text for disclaimers or fine print.
+      </Text.Paragraph>
+    </View>
+  );
+};
+
+// ------------------------------------------------------------------------------
+
+const CodeContent = () => {
+  return (
+    <View className="flex-1 justify-center px-5 gap-4">
+      <Text.Code>npm install heroui-native</Text.Code>
+      <Text.Code>{'const greeting = "Hello, world!";'}</Text.Code>
+      <Text.Code>{'export default function App() { }'}</Text.Code>
+    </View>
+  );
+};
+
+// ------------------------------------------------------------------------------
+
+const ProseContent = () => {
+  return (
+    <View className="flex-1 justify-center px-5 gap-4">
+      <Text.Prose>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+      </Text.Prose>
+    </View>
+  );
+};
+
+// ------------------------------------------------------------------------------
+
+const CustomStylingContent = () => {
+  return (
+    <View className="flex-1 justify-center px-5 gap-4">
+      <Text type="h1" className="text-accent">
+        Accent Heading
+      </Text>
+      <Text type="body" className="text-muted">
+        Muted body text
+      </Text>
+      <Text type="body-sm" className="text-danger">
+        Danger small text
+      </Text>
+    </View>
+  );
+};
+
+// ------------------------------------------------------------------------------
+
+const TEXT_VARIANTS: UsageVariant[] = [
+  {
+    value: 'types',
+    label: 'Types',
+    content: <TypesContent />,
+  },
+  {
+    value: 'headings',
+    label: 'Headings',
+    content: <HeadingsContent />,
+  },
+  {
+    value: 'paragraphs',
+    label: 'Paragraphs',
+    content: <ParagraphsContent />,
+  },
+  {
+    value: 'code',
+    label: 'Code',
+    content: <CodeContent />,
+  },
+  {
+    value: 'prose',
+    label: 'Prose',
+    content: <ProseContent />,
+  },
+  {
+    value: 'custom',
+    label: 'Custom Styling',
+    content: <CustomStylingContent />,
+  },
+];
+
+export default function TextScreen() {
+  return <UsageVariantFlatList data={TEXT_VARIANTS} />;
+}

--- a/example/src/app/(home)/components/text.tsx
+++ b/example/src/app/(home)/components/text.tsx
@@ -49,7 +49,7 @@ const ParagraphsContent = () => {
         secondary descriptions.
       </Text.Paragraph>
       <Text.Paragraph type="body-xs">
-        Extra-small text for disclaimers or fine print.
+        Extra-small text for disclaimers or fine print. lore
       </Text.Paragraph>
     </View>
   );
@@ -63,24 +63,6 @@ const CodeContent = () => {
       <Text.Code>npm install heroui-native</Text.Code>
       <Text.Code>{'const greeting = "Hello, world!";'}</Text.Code>
       <Text.Code>{'export default function App() { }'}</Text.Code>
-    </View>
-  );
-};
-
-// ------------------------------------------------------------------------------
-
-const CustomStylingContent = () => {
-  return (
-    <View className="flex-1 justify-center px-5 gap-4">
-      <Text type="h1" className="text-accent">
-        Accent Heading
-      </Text>
-      <Text type="body" className="text-muted">
-        Muted body text
-      </Text>
-      <Text type="body-sm" className="text-danger">
-        Danger small text
-      </Text>
     </View>
   );
 };
@@ -107,11 +89,6 @@ const TEXT_VARIANTS: UsageVariant[] = [
     value: 'code',
     label: 'Code',
     content: <CodeContent />,
-  },
-  {
-    value: 'custom',
-    label: 'Custom Styling',
-    content: <CustomStylingContent />,
   },
 ];
 

--- a/example/src/app/(home)/components/text.tsx
+++ b/example/src/app/(home)/components/text.tsx
@@ -69,21 +69,6 @@ const CodeContent = () => {
 
 // ------------------------------------------------------------------------------
 
-const ProseContent = () => {
-  return (
-    <View className="flex-1 justify-center px-5 gap-4">
-      <Text.Prose>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-        commodo consequat.
-      </Text.Prose>
-    </View>
-  );
-};
-
-// ------------------------------------------------------------------------------
-
 const CustomStylingContent = () => {
   return (
     <View className="flex-1 justify-center px-5 gap-4">
@@ -122,11 +107,6 @@ const TEXT_VARIANTS: UsageVariant[] = [
     value: 'code',
     label: 'Code',
     content: <CodeContent />,
-  },
-  {
-    value: 'prose',
-    label: 'Prose',
-    content: <ProseContent />,
   },
   {
     value: 'custom',

--- a/example/src/helpers/data/components.ts
+++ b/example/src/helpers/data/components.ts
@@ -146,6 +146,10 @@ export const COMPONENTS: ComponentItem[] = [
     path: 'tag-group',
   },
   {
+    title: 'Text',
+    path: 'text',
+  },
+  {
     title: 'TextArea',
     path: 'text-area',
   },

--- a/src/__tests__/text.test.tsx
+++ b/src/__tests__/text.test.tsx
@@ -1,23 +1,6 @@
-import { Text } from '../components/text';
-
-describe('Text', () => {
-  it('should export Text component', () => {
-    expect(Text).toBeDefined();
-  });
-
-  it('should have Heading sub-component', () => {
-    expect(Text.Heading).toBeDefined();
-  });
-
-  it('should have Paragraph sub-component', () => {
-    expect(Text.Paragraph).toBeDefined();
-  });
-
-  it('should have Code sub-component', () => {
-    expect(Text.Code).toBeDefined();
-  });
-
-  it('should have Prose sub-component', () => {
-    expect(Text.Prose).toBeDefined();
-  });
-});
+it.todo('Text: renders with default body type');
+it.todo('Text: applies correct className for each type variant');
+it.todo('Text.Heading: sets accessibilityRole header');
+it.todo('Text.Paragraph: defaults to body type');
+it.todo('Text.Code: applies monospace font family');
+it.todo('Text.Prose: renders body text');

--- a/src/__tests__/text.test.tsx
+++ b/src/__tests__/text.test.tsx
@@ -1,0 +1,23 @@
+import { Text } from '../components/text';
+
+describe('Text', () => {
+  it('should export Text component', () => {
+    expect(Text).toBeDefined();
+  });
+
+  it('should have Heading sub-component', () => {
+    expect(Text.Heading).toBeDefined();
+  });
+
+  it('should have Paragraph sub-component', () => {
+    expect(Text.Paragraph).toBeDefined();
+  });
+
+  it('should have Code sub-component', () => {
+    expect(Text.Code).toBeDefined();
+  });
+
+  it('should have Prose sub-component', () => {
+    expect(Text.Prose).toBeDefined();
+  });
+});

--- a/src/__tests__/text.test.tsx
+++ b/src/__tests__/text.test.tsx
@@ -1,6 +1,0 @@
-it.todo('Text: renders with default body type');
-it.todo('Text: applies correct className for each type variant');
-it.todo('Text.Heading: sets accessibilityRole header');
-it.todo('Text.Paragraph: defaults to body type');
-it.todo('Text.Code: applies monospace font family');
-it.todo('Text.Prose: renders body text');

--- a/src/components/text/index.ts
+++ b/src/components/text/index.ts
@@ -1,0 +1,10 @@
+export { default as Text } from './text';
+export { textClassNames } from './text.styles';
+export type {
+  TextCodeProps,
+  TextHeadingProps,
+  TextParagraphProps,
+  TextProseProps,
+  TextRootProps,
+  TextType,
+} from './text.types';

--- a/src/components/text/index.ts
+++ b/src/components/text/index.ts
@@ -1,9 +1,12 @@
 export { default as Text } from './text';
 export { textClassNames } from './text.styles';
 export type {
+  TextAlign,
   TextCodeProps,
+  TextColor,
   TextHeadingProps,
   TextParagraphProps,
   TextRootProps,
   TextType,
+  TextWeight,
 } from './text.types';

--- a/src/components/text/index.ts
+++ b/src/components/text/index.ts
@@ -4,7 +4,6 @@ export type {
   TextCodeProps,
   TextHeadingProps,
   TextParagraphProps,
-  TextProseProps,
   TextRootProps,
   TextType,
 } from './text.types';

--- a/src/components/text/text.constants.ts
+++ b/src/components/text/text.constants.ts
@@ -1,0 +1,17 @@
+/**
+ * Display names for Text components
+ */
+export const DISPLAY_NAME = {
+  TEXT_ROOT: 'HeroUINative.Text',
+  TEXT_HEADING: 'HeroUINative.Text.Heading',
+  TEXT_PARAGRAPH: 'HeroUINative.Text.Paragraph',
+  TEXT_CODE: 'HeroUINative.Text.Code',
+  TEXT_PROSE: 'HeroUINative.Text.Prose',
+} as const;
+
+/**
+ * Monospaced font family fallback for the Code sub-component.
+ * Platform-specific monospace defaults are handled by RN when this value
+ * is used as `fontFamily`.
+ */
+export const CODE_FONT_FAMILY = 'monospace';

--- a/src/components/text/text.constants.ts
+++ b/src/components/text/text.constants.ts
@@ -9,8 +9,9 @@ export const DISPLAY_NAME = {
 } as const;
 
 /**
- * Monospaced font family fallback for the Code sub-component.
- * Platform-specific monospace defaults are handled by RN when this value
- * is used as `fontFamily`.
+ * Monospaced font family used by `Text.Code` on Android and web.
+ *
+ * iOS uses `'Menlo'` directly; the platform branch lives in
+ * `styleSheet.code` in `text.styles.ts`.
  */
 export const CODE_FONT_FAMILY = 'monospace';

--- a/src/components/text/text.constants.ts
+++ b/src/components/text/text.constants.ts
@@ -6,7 +6,6 @@ export const DISPLAY_NAME = {
   TEXT_HEADING: 'HeroUINative.Text.Heading',
   TEXT_PARAGRAPH: 'HeroUINative.Text.Paragraph',
   TEXT_CODE: 'HeroUINative.Text.Code',
-  TEXT_PROSE: 'HeroUINative.Text.Prose',
 } as const;
 
 /**

--- a/src/components/text/text.md
+++ b/src/components/text/text.md
@@ -1,0 +1,177 @@
+# Text
+
+Primitive typography component for rendering styled text with semantic type variants.
+
+## Import
+
+```tsx
+import { Text } from 'heroui-native';
+```
+
+## Anatomy
+
+```tsx
+<Text>...</Text>
+
+{/* Sub-components */}
+<Text.Heading>...</Text.Heading>
+<Text.Paragraph>...</Text.Paragraph>
+<Text.Code>...</Text.Code>
+<Text.Prose>...</Text.Prose>
+```
+
+- **Text**: Root text element. The `type` prop selects a semantic typography preset (heading, body, or code).
+- **Text.Heading**: Convenience wrapper restricted to heading types (`h1`–`h6`). Adds `accessibilityRole="header"` automatically.
+- **Text.Paragraph**: Convenience wrapper restricted to body types (`body`, `body-sm`, `body-xs`).
+- **Text.Code**: Renders monospaced text using a platform-appropriate monospace font family.
+- **Text.Prose**: Minimal wrapper for longer body text passages. Currently equivalent to `body` type.
+
+## Usage
+
+### Basic Usage
+
+The Text component renders body text by default.
+
+```tsx
+<Text>Hello, world!</Text>
+```
+
+### Type Variants
+
+Use the `type` prop to select a semantic typography preset.
+
+```tsx
+<Text type="h1">Heading 1</Text>
+<Text type="h2">Heading 2</Text>
+<Text type="h3">Heading 3</Text>
+<Text type="h4">Heading 4</Text>
+<Text type="h5">Heading 5</Text>
+<Text type="h6">Heading 6</Text>
+<Text type="body">Body text</Text>
+<Text type="body-sm">Small body text</Text>
+<Text type="body-xs">Extra-small body text</Text>
+<Text type="code">Code snippet</Text>
+```
+
+### Headings
+
+Use `Text.Heading` for heading text with automatic header accessibility role.
+
+```tsx
+<Text.Heading type="h1">Page Title</Text.Heading>
+<Text.Heading type="h2">Section Title</Text.Heading>
+<Text.Heading type="h3">Subsection Title</Text.Heading>
+```
+
+### Paragraphs
+
+Use `Text.Paragraph` for body text.
+
+```tsx
+<Text.Paragraph>
+  This is a paragraph of body text with the default size.
+</Text.Paragraph>
+<Text.Paragraph type="body-sm">
+  This is smaller body text.
+</Text.Paragraph>
+```
+
+### Code
+
+Use `Text.Code` for inline code snippets with monospaced font.
+
+```tsx
+<Text.Code>console.log('hello')</Text.Code>
+```
+
+### Prose
+
+Use `Text.Prose` for longer passages of body text.
+
+```tsx
+<Text.Prose>
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
+  tempor incididunt ut labore et dolore magna aliqua.
+</Text.Prose>
+```
+
+### Custom Styling
+
+Override or extend styles with the `className` prop.
+
+```tsx
+<Text type="h1" className="text-accent">Colored Heading</Text>
+<Text type="body" className="text-muted">Muted body text</Text>
+```
+
+## Example
+
+```tsx
+import { Text } from 'heroui-native';
+import { View } from 'react-native';
+
+export default function TextExample() {
+  return (
+    <View className="flex-1 justify-center px-5 gap-4">
+      <Text.Heading type="h1">Welcome</Text.Heading>
+      <Text.Heading type="h3">Getting Started</Text.Heading>
+      <Text.Paragraph>
+        This is a body paragraph rendered with the Text component.
+      </Text.Paragraph>
+      <Text.Paragraph type="body-sm">
+        Smaller supporting text for captions or footnotes.
+      </Text.Paragraph>
+      <Text.Code>npm install heroui-native</Text.Code>
+    </View>
+  );
+}
+```
+
+You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/text.tsx>).
+
+## API Reference
+
+### Text
+
+Text extends all standard React Native `TextProps` with additional typography props.
+
+| prop           | type                                                                                            | default  | description                                         |
+| -------------- | ----------------------------------------------------------------------------------------------- | -------- | --------------------------------------------------- |
+| `type`         | `'h1' \| 'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6' \| 'body' \| 'body-sm' \| 'body-xs' \| 'code'` | `'body'` | Semantic typography variant                         |
+| `children`     | `React.ReactNode`                                                                               | -        | Content to render                                   |
+| `className`    | `string`                                                                                        | -        | Additional CSS classes                              |
+| `...TextProps` | `TextProps`                                                                                     | -        | All standard React Native Text props are supported  |
+
+### Text.Heading
+
+| prop           | type                                                  | default | description                                        |
+| -------------- | ----------------------------------------------------- | ------- | -------------------------------------------------- |
+| `type`         | `'h1' \| 'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6'`      | `'h1'`  | Heading level                                      |
+| `children`     | `React.ReactNode`                                     | -       | Content to render                                  |
+| `className`    | `string`                                              | -       | Additional CSS classes                             |
+| `...TextProps` | `TextProps`                                            | -       | All standard React Native Text props are supported |
+
+### Text.Paragraph
+
+| prop           | type                                       | default  | description                                        |
+| -------------- | ------------------------------------------ | -------- | -------------------------------------------------- |
+| `type`         | `'body' \| 'body-sm' \| 'body-xs'`         | `'body'` | Paragraph text size                                |
+| `children`     | `React.ReactNode`                          | -        | Content to render                                  |
+| `className`    | `string`                                   | -        | Additional CSS classes                             |
+| `...TextProps` | `TextProps`                                | -        | All standard React Native Text props are supported |
+
+### Text.Code
+
+| prop           | type              | default | description                                        |
+| -------------- | ----------------- | ------- | -------------------------------------------------- |
+| `children`     | `React.ReactNode` | -       | Content to render                                  |
+| `className`    | `string`          | -       | Additional CSS classes                             |
+| `...TextProps` | `TextProps`       | -       | All standard React Native Text props are supported |
+
+### Text.Prose
+
+| prop           | type              | default | description                                        |
+| -------------- | ----------------- | ------- | -------------------------------------------------- |
+| `children`     | `React.ReactNode` | -       | Content to render                                  |
+| `className`    | `string`          | -       | Additional CSS classes                             |
+| `...TextProps` | `TextProps`       | -       | All standard React Native Text props are supported |

--- a/src/components/text/text.md
+++ b/src/components/text/text.md
@@ -19,10 +19,10 @@ import { Text } from 'heroui-native';
 <Text.Code>...</Text.Code>
 ```
 
-- **Text**: Root text element. The `type` prop selects a semantic typography preset (heading, body, or code).
+- **Text**: Root text element. Selects a typography preset via `type` and exposes orthogonal `align`, `color`, `weight`, and `truncate` props.
 - **Text.Heading**: Convenience wrapper restricted to heading types (`h1`–`h6`). Adds `accessibilityRole="header"` automatically.
 - **Text.Paragraph**: Convenience wrapper restricted to body types (`body`, `body-sm`, `body-xs`).
-- **Text.Code**: Renders monospaced text using a platform-appropriate monospace font family.
+- **Text.Code**: Chip-styled inline monospaced text. Uses a platform-appropriate monospace font family.
 
 ## Usage
 
@@ -76,19 +76,64 @@ Use `Text.Paragraph` for body text.
 
 ### Code
 
-Use `Text.Code` for inline code snippets with monospaced font.
+Use `Text.Code` (or equivalently `<Text type="code">`) for inline code snippets. Both render a chip-styled, monospaced inline element with a subtle background, rounded corners, and a `self-start` layout so it does not stretch in flex containers. The platform monospace `fontFamily` is applied at the `Text` root, so the two forms are interchangeable.
 
 ```tsx
 <Text.Code>console.log('hello')</Text.Code>
+<Text type="code">console.log('hello')</Text>
 ```
 
-### Custom Styling
+### Alignment
 
-Override or extend styles with the `className` prop.
+Use the `align` prop to control horizontal alignment. `start` and `end` are RTL-aware (they flip under right-to-left layouts).
 
 ```tsx
-<Text type="h1" className="text-accent">Colored Heading</Text>
-<Text type="body" className="text-muted">Muted body text</Text>
+<Text align="start">Start-aligned</Text>
+<Text align="center">Center-aligned</Text>
+<Text align="end">End-aligned</Text>
+<Text align="justify">Justified text spreads across the line.</Text>
+```
+
+> **Note:** `text-justify` is iOS-only on React Native; Android falls back to left alignment.
+
+### Color
+
+Use the `color` prop to apply a semantic foreground color preset.
+
+```tsx
+<Text color="default">Default foreground</Text>
+<Text color="muted">Muted secondary text</Text>
+```
+
+For other theme colors, pass the corresponding utility through `className` (e.g. `className="text-accent"`, `className="text-danger"`).
+
+### Weight
+
+Use the `weight` prop to override the font weight implied by `type`. The override merges via `tailwind-merge`, so it always wins over the type variant's default weight.
+
+```tsx
+<Text type="h1" weight="bold">Bold H1</Text>
+<Text weight="medium">Medium body</Text>
+<Text weight="semibold">Semibold body</Text>
+```
+
+### Truncation
+
+Use the `truncate` boolean prop to limit the text to a single line with an ellipsis. It is mapped to React Native's `numberOfLines={1}`. An explicit `numberOfLines` prop, if provided, takes precedence.
+
+```tsx
+<Text truncate>
+  A long line of text that will be cut off with an ellipsis when it overflows
+  the container.
+</Text>;
+
+{
+  /* Multi-line truncation via the underlying RN prop */
+}
+<Text numberOfLines={2}>
+  Two-line truncation works through React Native's standard `numberOfLines`
+  prop.
+</Text>;
 ```
 
 ## Example
@@ -105,7 +150,7 @@ export default function TextExample() {
       <Text.Paragraph>
         This is a body paragraph rendered with the Text component.
       </Text.Paragraph>
-      <Text.Paragraph type="body-sm">
+      <Text.Paragraph color="muted" type="body-sm">
         Smaller supporting text for captions or footnotes.
       </Text.Paragraph>
       <Text.Code>npm install heroui-native</Text.Code>
@@ -120,37 +165,47 @@ You can find more examples in the [GitHub repository](<https://github.com/heroui
 
 ### Text
 
-Text extends all standard React Native `TextProps` with additional typography props.
+`Text` extends all standard React Native `TextProps` with additional typography props.
 
-| prop           | type                                                                                            | default  | description                                         |
-| -------------- | ----------------------------------------------------------------------------------------------- | -------- | --------------------------------------------------- |
-| `type`         | `'h1' \| 'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6' \| 'body' \| 'body-sm' \| 'body-xs' \| 'code'` | `'body'` | Semantic typography variant                         |
-| `children`     | `React.ReactNode`                                                                               | -        | Content to render                                   |
-| `className`    | `string`                                                                                        | -        | Additional CSS classes                              |
-| `...TextProps` | `TextProps`                                                                                     | -        | All standard React Native Text props are supported  |
+| prop           | type                                                                                         | default     | description                                                                                                                    |
+| -------------- | -------------------------------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `type`         | `'h1' \| 'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6' \| 'body' \| 'body-sm' \| 'body-xs' \| 'code'` | `'body'`    | Semantic typography variant (size, default weight, line-height)                                                                |
+| `align`        | `'start' \| 'center' \| 'end' \| 'justify'`                                                  | `'start'`   | Horizontal alignment. `start` and `end` are RTL-aware. `justify` is iOS-only.                                                  |
+| `color`        | `'default' \| 'muted'`                                                                       | `'default'` | Semantic foreground color preset                                                                                               |
+| `weight`       | `'normal' \| 'medium' \| 'semibold' \| 'bold'`                                               | -           | Font weight override. When set, overrides the weight implied by `type`.                                                        |
+| `truncate`     | `boolean`                                                                                    | `false`     | Truncates the text to a single line with an ellipsis (sets `numberOfLines={1}`). An explicit `numberOfLines` takes precedence. |
+| `children`     | `React.ReactNode`                                                                            | -           | Content to render                                                                                                              |
+| `className`    | `string`                                                                                     | -           | Additional CSS classes                                                                                                         |
+| `...TextProps` | `TextProps`                                                                                  | -           | All standard React Native `Text` props are supported                                                                           |
 
 ### Text.Heading
 
-| prop           | type                                                  | default | description                                        |
-| -------------- | ----------------------------------------------------- | ------- | -------------------------------------------------- |
-| `type`         | `'h1' \| 'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6'`      | `'h1'`  | Heading level                                      |
-| `children`     | `React.ReactNode`                                     | -       | Content to render                                  |
-| `className`    | `string`                                              | -       | Additional CSS classes                             |
-| `...TextProps` | `TextProps`                                            | -       | All standard React Native Text props are supported |
+Inherits all `Text` root props (`align`, `color`, `weight`, `truncate`, `className`, and React Native `TextProps`). Sets `accessibilityRole="header"` automatically and narrows `type` to heading variants.
+
+| prop           | type                                           | default | description                                          |
+| -------------- | ---------------------------------------------- | ------- | ---------------------------------------------------- |
+| `type`         | `'h1' \| 'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6'` | `'h1'`  | Heading level                                        |
+| `children`     | `React.ReactNode`                              | -       | Content to render                                    |
+| `className`    | `string`                                       | -       | Additional CSS classes                               |
+| `...TextProps` | `TextProps`                                    | -       | All standard React Native `Text` props are supported |
 
 ### Text.Paragraph
 
-| prop           | type                                       | default  | description                                        |
-| -------------- | ------------------------------------------ | -------- | -------------------------------------------------- |
-| `type`         | `'body' \| 'body-sm' \| 'body-xs'`         | `'body'` | Paragraph text size                                |
-| `children`     | `React.ReactNode`                          | -        | Content to render                                  |
-| `className`    | `string`                                   | -        | Additional CSS classes                             |
-| `...TextProps` | `TextProps`                                | -        | All standard React Native Text props are supported |
+Inherits all `Text` root props (`align`, `color`, `weight`, `truncate`, `className`, and React Native `TextProps`). Narrows `type` to body variants.
+
+| prop           | type                               | default  | description                                          |
+| -------------- | ---------------------------------- | -------- | ---------------------------------------------------- |
+| `type`         | `'body' \| 'body-sm' \| 'body-xs'` | `'body'` | Paragraph text size                                  |
+| `children`     | `React.ReactNode`                  | -        | Content to render                                    |
+| `className`    | `string`                           | -        | Additional CSS classes                               |
+| `...TextProps` | `TextProps`                        | -        | All standard React Native `Text` props are supported |
 
 ### Text.Code
 
-| prop           | type              | default | description                                        |
-| -------------- | ----------------- | ------- | -------------------------------------------------- |
-| `children`     | `React.ReactNode` | -       | Content to render                                  |
-| `className`    | `string`          | -       | Additional CSS classes                             |
-| `...TextProps` | `TextProps`       | -       | All standard React Native Text props are supported |
+Inherits all `Text` root props (`align`, `color`, `weight`, `truncate`, `className`, `style`, and React Native `TextProps`). Thin wrapper that forces `type="code"`; the platform monospace `fontFamily` is merged in at the `Text` root, so `<Text type="code">` and `<Text.Code>` render identically.
+
+| prop           | type              | default | description                                          |
+| -------------- | ----------------- | ------- | ---------------------------------------------------- |
+| `children`     | `React.ReactNode` | -       | Content to render                                    |
+| `className`    | `string`          | -       | Additional CSS classes                               |
+| `...TextProps` | `TextProps`       | -       | All standard React Native `Text` props are supported |

--- a/src/components/text/text.md
+++ b/src/components/text/text.md
@@ -17,14 +17,12 @@ import { Text } from 'heroui-native';
 <Text.Heading>...</Text.Heading>
 <Text.Paragraph>...</Text.Paragraph>
 <Text.Code>...</Text.Code>
-<Text.Prose>...</Text.Prose>
 ```
 
 - **Text**: Root text element. The `type` prop selects a semantic typography preset (heading, body, or code).
 - **Text.Heading**: Convenience wrapper restricted to heading types (`h1`–`h6`). Adds `accessibilityRole="header"` automatically.
 - **Text.Paragraph**: Convenience wrapper restricted to body types (`body`, `body-sm`, `body-xs`).
 - **Text.Code**: Renders monospaced text using a platform-appropriate monospace font family.
-- **Text.Prose**: Minimal wrapper for longer body text passages. Currently equivalent to `body` type.
 
 ## Usage
 
@@ -82,17 +80,6 @@ Use `Text.Code` for inline code snippets with monospaced font.
 
 ```tsx
 <Text.Code>console.log('hello')</Text.Code>
-```
-
-### Prose
-
-Use `Text.Prose` for longer passages of body text.
-
-```tsx
-<Text.Prose>
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
-  tempor incididunt ut labore et dolore magna aliqua.
-</Text.Prose>
 ```
 
 ### Custom Styling
@@ -161,14 +148,6 @@ Text extends all standard React Native `TextProps` with additional typography pr
 | `...TextProps` | `TextProps`                                | -        | All standard React Native Text props are supported |
 
 ### Text.Code
-
-| prop           | type              | default | description                                        |
-| -------------- | ----------------- | ------- | -------------------------------------------------- |
-| `children`     | `React.ReactNode` | -       | Content to render                                  |
-| `className`    | `string`          | -       | Additional CSS classes                             |
-| `...TextProps` | `TextProps`       | -       | All standard React Native Text props are supported |
-
-### Text.Prose
 
 | prop           | type              | default | description                                        |
 | -------------- | ----------------- | ------- | -------------------------------------------------- |

--- a/src/components/text/text.styles.ts
+++ b/src/components/text/text.styles.ts
@@ -1,0 +1,42 @@
+import { tv } from 'tailwind-variants';
+import { combineStyles } from '../../helpers/internal/utils';
+
+/**
+ * Typography style map driven by Tailwind utility classes.
+ *
+ * Token mapping rationale (derived from existing native component usage):
+ *   h1  → text-3xl  font-bold       (largest heading)
+ *   h2  → text-2xl  font-bold
+ *   h3  → text-xl   font-semibold
+ *   h4  → text-lg   font-semibold
+ *   h5  → text-base font-semibold
+ *   h6  → text-sm   font-semibold
+ *   body    → text-base font-normal  (default running text, matches HeroText)
+ *   body-sm → text-sm   font-normal
+ *   body-xs → text-xs   font-normal
+ *   code    → text-sm   font-normal  (monospaced via fontFamily style)
+ */
+const root = tv({
+  base: 'text-foreground',
+  variants: {
+    type: {
+      'h1': 'text-3xl font-bold',
+      'h2': 'text-2xl font-bold',
+      'h3': 'text-xl font-semibold',
+      'h4': 'text-lg font-semibold',
+      'h5': 'text-base font-semibold',
+      'h6': 'text-sm font-semibold',
+      'body': 'text-base font-normal',
+      'body-sm': 'text-sm font-normal',
+      'body-xs': 'text-xs font-normal',
+      'code': 'text-sm font-normal',
+    },
+  },
+  defaultVariants: {
+    type: 'body',
+  },
+});
+
+export const textClassNames = combineStyles({
+  root,
+});

--- a/src/components/text/text.styles.ts
+++ b/src/components/text/text.styles.ts
@@ -1,42 +1,57 @@
+import { Platform, StyleSheet } from 'react-native';
 import { tv } from 'tailwind-variants';
 import { combineStyles } from '../../helpers/internal/utils';
+import { CODE_FONT_FAMILY } from './text.constants';
 
-/**
- * Typography style map driven by Tailwind utility classes.
- *
- * Token mapping rationale (derived from existing native component usage):
- *   h1  → text-3xl  font-bold       (largest heading)
- *   h2  → text-2xl  font-bold
- *   h3  → text-xl   font-semibold
- *   h4  → text-lg   font-semibold
- *   h5  → text-base font-semibold
- *   h6  → text-sm   font-semibold
- *   body    → text-base font-normal  (default running text, matches HeroText)
- *   body-sm → text-sm   font-normal
- *   body-xs → text-xs   font-normal
- *   code    → text-sm   font-normal  (monospaced via fontFamily style)
- */
 const root = tv({
-  base: 'text-foreground',
+  base: 'font-normal',
   variants: {
     type: {
-      'h1': 'text-3xl font-bold',
-      'h2': 'text-2xl font-bold',
-      'h3': 'text-xl font-semibold',
-      'h4': 'text-lg font-semibold',
-      'h5': 'text-base font-semibold',
-      'h6': 'text-sm font-semibold',
-      'body': 'text-base font-normal',
-      'body-sm': 'text-sm font-normal',
-      'body-xs': 'text-xs font-normal',
-      'code': 'text-sm font-normal',
+      'h1': 'text-4xl font-semibold tracking-tight',
+      'h2': 'text-3xl font-semibold tracking-tight',
+      'h3': 'text-2xl font-semibold tracking-tight',
+      'h4': 'text-xl font-semibold tracking-tight',
+      'h5': 'text-lg font-semibold tracking-tight',
+      'h6': 'text-base font-semibold tracking-tight',
+      'body': 'text-base leading-7',
+      'body-sm': 'text-sm leading-6',
+      'body-xs': 'text-xs leading-5',
+      'code': 'self-start text-sm rounded-md bg-default px-1.5 py-0.5',
+    },
+    align: {
+      start: 'text-left rtl:text-right',
+      center: 'text-center',
+      end: 'text-right rtl:text-left',
+      justify: 'text-justify',
+    },
+    color: {
+      default: 'text-foreground',
+      muted: 'text-muted',
+    },
+    weight: {
+      normal: 'font-normal',
+      medium: 'font-medium',
+      semibold: 'font-semibold',
+      bold: 'font-bold',
     },
   },
   defaultVariants: {
     type: 'body',
+    align: 'start',
+    color: 'default',
   },
 });
 
 export const textClassNames = combineStyles({
   root,
+});
+
+export const styleSheet = StyleSheet.create({
+  code: {
+    fontFamily: Platform.select({
+      ios: 'Menlo',
+      android: CODE_FONT_FAMILY,
+      default: CODE_FONT_FAMILY,
+    }),
+  },
 });

--- a/src/components/text/text.tsx
+++ b/src/components/text/text.tsx
@@ -1,0 +1,122 @@
+import { forwardRef, useMemo } from 'react';
+import { Platform, StyleSheet } from 'react-native';
+import { HeroText } from '../../helpers/internal/components';
+import type { TextRef } from '../../helpers/internal/types';
+import { CODE_FONT_FAMILY, DISPLAY_NAME } from './text.constants';
+import { textClassNames } from './text.styles';
+import type {
+  TextCodeProps,
+  TextHeadingProps,
+  TextParagraphProps,
+  TextProseProps,
+  TextRootProps,
+} from './text.types';
+
+// --------------------------------------------------
+
+const TextRoot = forwardRef<TextRef, TextRootProps>((props, ref) => {
+  const { children, type = 'body', className, ...restProps } = props;
+
+  const rootClassName = textClassNames.root({ type, className });
+
+  return (
+    <HeroText ref={ref} className={rootClassName} {...restProps}>
+      {children}
+    </HeroText>
+  );
+});
+
+// --------------------------------------------------
+
+const TextHeading = forwardRef<TextRef, TextHeadingProps>((props, ref) => {
+  const { type = 'h1', accessibilityRole = 'header', ...restProps } = props;
+  return (
+    <TextRoot
+      ref={ref}
+      type={type}
+      accessibilityRole={accessibilityRole}
+      {...restProps}
+    />
+  );
+});
+
+// --------------------------------------------------
+
+const TextParagraph = forwardRef<TextRef, TextParagraphProps>((props, ref) => {
+  const { type = 'body', ...restProps } = props;
+  return <TextRoot ref={ref} type={type} {...restProps} />;
+});
+
+// --------------------------------------------------
+
+const TextCode = forwardRef<TextRef, TextCodeProps>((props, ref) => {
+  const { style, ...restProps } = props;
+
+  const mergedStyle = useMemo(
+    () =>
+      Array.isArray(style) ? [styles.code, ...style] : [styles.code, style],
+    [style]
+  );
+
+  return <TextRoot ref={ref} type="code" style={mergedStyle} {...restProps} />;
+});
+
+// --------------------------------------------------
+
+const TextProse = forwardRef<TextRef, TextProseProps>((props, ref) => {
+  return <TextRoot ref={ref} type="body" {...props} />;
+});
+
+// --------------------------------------------------
+
+TextRoot.displayName = DISPLAY_NAME.TEXT_ROOT;
+TextHeading.displayName = DISPLAY_NAME.TEXT_HEADING;
+TextParagraph.displayName = DISPLAY_NAME.TEXT_PARAGRAPH;
+TextCode.displayName = DISPLAY_NAME.TEXT_CODE;
+TextProse.displayName = DISPLAY_NAME.TEXT_PROSE;
+
+/**
+ * Compound Text component with semantic sub-components.
+ *
+ * @component Text - Generic text element with a `type` prop for semantic
+ * typography variants (headings, body, code). Maps each type to native
+ * typography tokens via Tailwind utility classes.
+ *
+ * @component Text.Heading - Convenience wrapper restricted to heading types
+ * (`h1`–`h6`). Sets `accessibilityRole="header"` automatically.
+ *
+ * @component Text.Paragraph - Convenience wrapper restricted to body types
+ * (`body`, `body-sm`, `body-xs`).
+ *
+ * @component Text.Code - Renders monospaced text using the `code` type and
+ * applies a platform monospace font family.
+ *
+ * @component Text.Prose - Minimal body-text wrapper intended for longer
+ * prose passages. Currently equivalent to `body` type.
+ *
+ * @see Full documentation: https://heroui.com/docs/native/components/text
+ */
+const CompoundText = Object.assign(TextRoot, {
+  /** Heading text – renders h1-h6 with header accessibility role */
+  Heading: TextHeading,
+  /** Paragraph text – renders body / body-sm / body-xs */
+  Paragraph: TextParagraph,
+  /** Code text – monospaced font with code styling */
+  Code: TextCode,
+  /** Prose text – long-form body content */
+  Prose: TextProse,
+});
+
+export default CompoundText;
+
+// --------------------------------------------------
+
+const styles = StyleSheet.create({
+  code: {
+    fontFamily: Platform.select({
+      ios: 'Menlo',
+      android: CODE_FONT_FAMILY,
+      default: CODE_FONT_FAMILY,
+    }),
+  },
+});

--- a/src/components/text/text.tsx
+++ b/src/components/text/text.tsx
@@ -8,7 +8,6 @@ import type {
   TextCodeProps,
   TextHeadingProps,
   TextParagraphProps,
-  TextProseProps,
   TextRootProps,
 } from './text.types';
 
@@ -63,17 +62,10 @@ const TextCode = forwardRef<TextRef, TextCodeProps>((props, ref) => {
 
 // --------------------------------------------------
 
-const TextProse = forwardRef<TextRef, TextProseProps>((props, ref) => {
-  return <TextRoot ref={ref} type="body" {...props} />;
-});
-
-// --------------------------------------------------
-
 TextRoot.displayName = DISPLAY_NAME.TEXT_ROOT;
 TextHeading.displayName = DISPLAY_NAME.TEXT_HEADING;
 TextParagraph.displayName = DISPLAY_NAME.TEXT_PARAGRAPH;
 TextCode.displayName = DISPLAY_NAME.TEXT_CODE;
-TextProse.displayName = DISPLAY_NAME.TEXT_PROSE;
 
 /**
  * Compound Text component with semantic sub-components.
@@ -91,9 +83,6 @@ TextProse.displayName = DISPLAY_NAME.TEXT_PROSE;
  * @component Text.Code - Renders monospaced text using the `code` type and
  * applies a platform monospace font family.
  *
- * @component Text.Prose - Minimal body-text wrapper intended for longer
- * prose passages. Currently equivalent to `body` type.
- *
  * @see Full documentation: https://heroui.com/docs/native/components/text
  */
 const CompoundText = Object.assign(TextRoot, {
@@ -103,8 +92,6 @@ const CompoundText = Object.assign(TextRoot, {
   Paragraph: TextParagraph,
   /** Code text – monospaced font with code styling */
   Code: TextCode,
-  /** Prose text – long-form body content */
-  Prose: TextProse,
 });
 
 export default CompoundText;

--- a/src/components/text/text.tsx
+++ b/src/components/text/text.tsx
@@ -1,9 +1,8 @@
-import { forwardRef, useMemo } from 'react';
-import { Platform, StyleSheet } from 'react-native';
+import { forwardRef } from 'react';
 import { HeroText } from '../../helpers/internal/components';
 import type { TextRef } from '../../helpers/internal/types';
-import { CODE_FONT_FAMILY, DISPLAY_NAME } from './text.constants';
-import { textClassNames } from './text.styles';
+import { DISPLAY_NAME } from './text.constants';
+import { styleSheet, textClassNames } from './text.styles';
 import type {
   TextCodeProps,
   TextHeadingProps,
@@ -14,12 +13,38 @@ import type {
 // --------------------------------------------------
 
 const TextRoot = forwardRef<TextRef, TextRootProps>((props, ref) => {
-  const { children, type = 'body', className, ...restProps } = props;
+  const {
+    children,
+    type = 'body',
+    align = 'start',
+    color = 'default',
+    weight,
+    truncate = false,
+    numberOfLines,
+    style,
+    className,
+    ...restProps
+  } = props;
 
-  const rootClassName = textClassNames.root({ type, className });
+  const rootClassName = textClassNames.root({
+    type,
+    align,
+    color,
+    weight,
+    className,
+  });
+
+  const resolvedNumberOfLines = numberOfLines ?? (truncate ? 1 : undefined);
+  const resolvedStyle = type === 'code' ? [styleSheet.code, style] : style;
 
   return (
-    <HeroText ref={ref} className={rootClassName} {...restProps}>
+    <HeroText
+      ref={ref}
+      className={rootClassName}
+      numberOfLines={resolvedNumberOfLines}
+      style={resolvedStyle}
+      {...restProps}
+    >
       {children}
     </HeroText>
   );
@@ -49,15 +74,7 @@ const TextParagraph = forwardRef<TextRef, TextParagraphProps>((props, ref) => {
 // --------------------------------------------------
 
 const TextCode = forwardRef<TextRef, TextCodeProps>((props, ref) => {
-  const { style, ...restProps } = props;
-
-  const mergedStyle = useMemo(
-    () =>
-      Array.isArray(style) ? [styles.code, ...style] : [styles.code, style],
-    [style]
-  );
-
-  return <TextRoot ref={ref} type="code" style={mergedStyle} {...restProps} />;
+  return <TextRoot ref={ref} type="code" {...props} />;
 });
 
 // --------------------------------------------------
@@ -70,9 +87,13 @@ TextCode.displayName = DISPLAY_NAME.TEXT_CODE;
 /**
  * Compound Text component with semantic sub-components.
  *
- * @component Text - Generic text element with a `type` prop for semantic
- * typography variants (headings, body, code). Maps each type to native
- * typography tokens via Tailwind utility classes.
+ * @component Text - Root text element. Selects a typography preset via
+ * `type` and exposes orthogonal `align`, `color`, `weight`, and `truncate`
+ * props. `truncate` is implemented via React Native's `numberOfLines={1}`;
+ * an explicit `numberOfLines` prop, if provided, takes precedence. When
+ * `type="code"`, the platform-appropriate monospace `fontFamily` from
+ * `styleSheet.code` is merged into `style` (since the project's NativeWind
+ * theme has no `font-mono` token).
  *
  * @component Text.Heading - Convenience wrapper restricted to heading types
  * (`h1`–`h6`). Sets `accessibilityRole="header"` automatically.
@@ -80,8 +101,9 @@ TextCode.displayName = DISPLAY_NAME.TEXT_CODE;
  * @component Text.Paragraph - Convenience wrapper restricted to body types
  * (`body`, `body-sm`, `body-xs`).
  *
- * @component Text.Code - Renders monospaced text using the `code` type and
- * applies a platform monospace font family.
+ * @component Text.Code - Chip-styled inline monospaced text. Thin wrapper
+ * that forces `type="code"`; the monospace `fontFamily` is applied at the
+ * root.
  *
  * @see Full documentation: https://heroui.com/docs/native/components/text
  */
@@ -90,20 +112,8 @@ const CompoundText = Object.assign(TextRoot, {
   Heading: TextHeading,
   /** Paragraph text – renders body / body-sm / body-xs */
   Paragraph: TextParagraph,
-  /** Code text – monospaced font with code styling */
+  /** Code text – chip-styled inline monospaced text */
   Code: TextCode,
 });
 
 export default CompoundText;
-
-// --------------------------------------------------
-
-const styles = StyleSheet.create({
-  code: {
-    fontFamily: Platform.select({
-      ios: 'Menlo',
-      android: CODE_FONT_FAMILY,
-      default: CODE_FONT_FAMILY,
-    }),
-  },
-});

--- a/src/components/text/text.types.ts
+++ b/src/components/text/text.types.ts
@@ -1,0 +1,71 @@
+import type { TextProps as RNTextProps } from 'react-native';
+
+/**
+ * Semantic type variants for the Text component.
+ *
+ * Heading types (`h1`–`h6`) map to decreasing font sizes with bold/semibold weight.
+ * Body types (`body`, `body-sm`, `body-xs`) map to regular-weight running text.
+ * `code` maps to a monospaced style.
+ */
+export type TextType =
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'h5'
+  | 'h6'
+  | 'body'
+  | 'body-sm'
+  | 'body-xs'
+  | 'code';
+
+/**
+ * Props for the Text component root
+ */
+export interface TextRootProps extends RNTextProps {
+  /**
+   * Semantic type that determines typography styling (size, weight, line-height).
+   * @default 'body'
+   */
+  type?: TextType;
+  /**
+   * Additional CSS classes
+   */
+  className?: string;
+  /**
+   * Content to render
+   */
+  children?: React.ReactNode;
+}
+
+/**
+ * Props for Text.Heading sub-component
+ */
+export interface TextHeadingProps extends Omit<TextRootProps, 'type'> {
+  /**
+   * Heading level, restricted to heading types
+   * @default 'h1'
+   */
+  type?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+}
+
+/**
+ * Props for Text.Paragraph sub-component
+ */
+export interface TextParagraphProps extends Omit<TextRootProps, 'type'> {
+  /**
+   * Paragraph type, restricted to body types
+   * @default 'body'
+   */
+  type?: 'body' | 'body-sm' | 'body-xs';
+}
+
+/**
+ * Props for Text.Code sub-component
+ */
+export interface TextCodeProps extends Omit<TextRootProps, 'type'> {}
+
+/**
+ * Props for Text.Prose sub-component (multi-line body text wrapper)
+ */
+export interface TextProseProps extends Omit<TextRootProps, 'type'> {}

--- a/src/components/text/text.types.ts
+++ b/src/components/text/text.types.ts
@@ -64,8 +64,3 @@ export interface TextParagraphProps extends Omit<TextRootProps, 'type'> {
  * Props for Text.Code sub-component
  */
 export interface TextCodeProps extends Omit<TextRootProps, 'type'> {}
-
-/**
- * Props for Text.Prose sub-component (multi-line body text wrapper)
- */
-export interface TextProseProps extends Omit<TextRootProps, 'type'> {}

--- a/src/components/text/text.types.ts
+++ b/src/components/text/text.types.ts
@@ -3,9 +3,9 @@ import type { TextProps as RNTextProps } from 'react-native';
 /**
  * Semantic type variants for the Text component.
  *
- * Heading types (`h1`–`h6`) map to decreasing font sizes with bold/semibold weight.
- * Body types (`body`, `body-sm`, `body-xs`) map to regular-weight running text.
- * `code` maps to a monospaced style.
+ * Heading types (`h1`–`h6`) map to decreasing font sizes with semibold weight.
+ * Body types (`body`, `body-sm`, `body-xs`) map to running text with explicit
+ * line-heights. `code` maps to a chip-like monospaced style.
  */
 export type TextType =
   | 'h1'
@@ -20,6 +20,25 @@ export type TextType =
   | 'code';
 
 /**
+ * Horizontal text alignment.
+ *
+ * `start` and `end` are RTL-aware (flip to right/left under RTL).
+ *
+ * @note `justify` is iOS-only on React Native; Android falls back to left.
+ */
+export type TextAlign = 'start' | 'center' | 'end' | 'justify';
+
+/**
+ * Semantic foreground color preset.
+ */
+export type TextColor = 'default' | 'muted';
+
+/**
+ * Font weight override, applied independently of the `type` variant.
+ */
+export type TextWeight = 'normal' | 'medium' | 'semibold' | 'bold';
+
+/**
  * Props for the Text component root
  */
 export interface TextRootProps extends RNTextProps {
@@ -28,6 +47,26 @@ export interface TextRootProps extends RNTextProps {
    * @default 'body'
    */
   type?: TextType;
+  /**
+   * Horizontal alignment. RTL-aware for `start` and `end`.
+   * @default 'start'
+   */
+  align?: TextAlign;
+  /**
+   * Semantic foreground color preset.
+   * @default 'default'
+   */
+  color?: TextColor;
+  /**
+   * Font weight override. When set, overrides the weight implied by `type`.
+   */
+  weight?: TextWeight;
+  /**
+   * Truncates the text to a single line with an ellipsis.
+   *
+   * @default false
+   */
+  truncate?: boolean;
   /**
    * Additional CSS classes
    */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,6 +36,7 @@ export * from './components/surface';
 export * from './components/switch';
 export * from './components/tabs';
 export * from './components/tag-group';
+export * from './components/text';
 export * from './components/text-area';
 export * from './components/text-field';
 export * from './components/toast';


### PR DESCRIPTION
## 📝 Description

Adds a new `Text` typography primitive to HeroUI Native with a compound API exposing `Text.Heading`, `Text.Paragraph`, and `Text.Code` sub-components. The root component selects a semantic typography preset via `type` and exposes orthogonal `align`, `color`, `weight`, and `truncate` props built on top of `tailwind-variants`.

## ⛳️ Current behavior (updates)

There is no built-in typography primitive in HeroUI Native, so consumers had to compose React Native's `Text` with custom styles for headings, body copy, and inline code.

## 🚀 New behavior

- New `Text` component with semantic `type` variants (`h1`–`h6`, `body`, `body-sm`, `body-xs`, `code`).
- Sub-components: `Text.Heading` (auto-sets `accessibilityRole="header"`), `Text.Paragraph`, and `Text.Code` (chip-styled inline monospaced text).
- Orthogonal props: `align` (RTL-aware `start`/`end`, plus `center`/`justify`), `color` (`default` | `muted`), `weight` override, and `truncate` (maps to `numberOfLines={1}`).
- Platform-appropriate monospace `fontFamily` for `code` (Menlo on iOS, `monospace` elsewhere).
- Component documentation (`text.md`), example screen, and registration in the public exports and example app navigation.

## 💣 Is this a breaking change (Yes/No):

**No** - The change is purely additive: a new component module and a new export from `src/index.tsx`. No existing APIs are modified.

## 📝 Additional Information

The component is built on the internal `HeroText` primitive and reuses `combineStyles` and `tailwind-variants` for styling, so it integrates with the existing theming system without new dependencies. An explicit `numberOfLines` prop always takes precedence over `truncate`, and `weight` overrides any weight implied by `type` via `tailwind-merge`.