### PR TITLE
fix(description): remove horizontal padding (px) from Description component

### DIFF
--- a/src/components/description/description.styles.ts
+++ b/src/components/description/description.styles.ts
@@ -4,9 +4,6 @@ import { combineStyles } from '../../helpers/internal/utils';
 const root = tv({
   base: 'text-sm text-muted',
   variants: {
-    isInsideField: {
-      true: 'px-1.5',
-    },
     isInvalid: {
       true: 'text-danger',
     },

--- a/src/components/description/description.tsx
+++ b/src/components/description/description.tsx
@@ -36,12 +36,9 @@ const Description = forwardRef<TextRef, DescriptionProps>((props, ref) => {
       ? localIsDisabled
       : (formField?.isDisabled ?? false);
 
-  const isInsideField = formField?.hasFieldPadding ?? false;
-
   const rootClassName = descriptionClassNames.root({
     isInvalid,
     isDisabled,
-    isInsideField,
     className,
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes HHTA-751

## 📝 Description

Remove the horizontal padding (`px-1.5`) applied to the Description component when inside a form field. The ticket states: "Remove padding x applied for description components in the native OSS project".

## ⛳️ Current behavior (updates)

The Description component applies `px-1.5` (horizontal padding) via the `isInsideField` variant when the component is rendered inside a form field context (i.e., when `formField.hasFieldPadding` is `true`).

## 🚀 New behavior

The Description component no longer applies any horizontal padding. The `isInsideField` variant and its associated logic have been removed from:
- `src/components/description/description.styles.ts` — removed the `isInsideField` variant (`px-1.5`)
- `src/components/description/description.tsx` — removed the `isInsideField` variable and its usage in `rootClassName`

## 💣 Is this a breaking change (Yes/No):

No. This is a visual-only change that removes unintended padding. Users who relied on the built-in `px-1.5` padding can add it back via the `className` prop.

## 📝 Additional Information

### Validation

```
$ yarn typecheck
✅ TypeScript check passed successfully! 🎉

$ yarn lint
(no errors, exit code 0)
```

Both validation gates pass cleanly. The pre-commit hooks (lint + types) also ran and passed during commit.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6542e11a-0eb4-4b9b-bf27-325959dd333d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6542e11a-0eb4-4b9b-bf27-325959dd333d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

