### PR TITLE
refactor(avatar): make alt prop optional with default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </p>
 
 <p align="center">
-  v1.0.2
+  v1.0.3
 </p>
 
 ## Getting Started

--- a/example/src/app/(home)/components/avatar.tsx
+++ b/example/src/app/(home)/components/avatar.tsx
@@ -11,7 +11,7 @@ const SizesContent = () => {
   return (
     <View className="flex-1 px-5 items-center justify-center">
       <View className="flex-row items-center justify-center gap-4">
-        <Avatar size="sm" alt="Small Avatar">
+        <Avatar size="sm">
           <Avatar.Image
             source={{
               uri: 'https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/avatars/blue.jpg',
@@ -19,7 +19,7 @@ const SizesContent = () => {
           />
           <Avatar.Fallback />
         </Avatar>
-        <Avatar size="md" alt="Medium Avatar">
+        <Avatar size="md">
           <Avatar.Image
             source={{
               uri: 'https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/avatars/purple.jpg',
@@ -27,7 +27,7 @@ const SizesContent = () => {
           />
           <Avatar.Fallback>MD</Avatar.Fallback>
         </Avatar>
-        <Avatar size="lg" alt="Large Avatar">
+        <Avatar size="lg">
           <Avatar.Image
             source={{
               uri: 'https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/avatars/red.jpg',
@@ -46,23 +46,23 @@ const DefaultTextFallbackContent = () => {
   return (
     <View className="flex-1 px-5 items-center justify-center">
       <View className="flex-row items-center justify-center gap-3">
-        <Avatar color="accent" alt="Accent">
+        <Avatar color="accent">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback>AC</Avatar.Fallback>
         </Avatar>
-        <Avatar color="default" alt="Default">
+        <Avatar color="default">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback>DF</Avatar.Fallback>
         </Avatar>
-        <Avatar color="success" alt="Success">
+        <Avatar color="success">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback>SC</Avatar.Fallback>
         </Avatar>
-        <Avatar color="warning" alt="Warning">
+        <Avatar color="warning">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback>WR</Avatar.Fallback>
         </Avatar>
-        <Avatar color="danger" alt="Danger">
+        <Avatar color="danger">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback>DG</Avatar.Fallback>
         </Avatar>
@@ -77,23 +77,23 @@ const SoftTextFallbackContent = () => {
   return (
     <View className="flex-1 px-5 items-center justify-center">
       <View className="flex-row items-center justify-center gap-3">
-        <Avatar variant="soft" color="accent" alt="Accent">
+        <Avatar variant="soft" color="accent">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback>AC</Avatar.Fallback>
         </Avatar>
-        <Avatar variant="soft" color="default" alt="Default">
+        <Avatar variant="soft" color="default">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback>DF</Avatar.Fallback>
         </Avatar>
-        <Avatar variant="soft" color="success" alt="Success">
+        <Avatar variant="soft" color="success">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback>SC</Avatar.Fallback>
         </Avatar>
-        <Avatar variant="soft" color="warning" alt="Warning">
+        <Avatar variant="soft" color="warning">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback>WR</Avatar.Fallback>
         </Avatar>
-        <Avatar variant="soft" color="danger" alt="Danger">
+        <Avatar variant="soft" color="danger">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback>DG</Avatar.Fallback>
         </Avatar>
@@ -108,23 +108,23 @@ const DefaultIconFallbackContent = () => {
   return (
     <View className="flex-1 px-5 items-center justify-center">
       <View className="flex-row items-center justify-center gap-3">
-        <Avatar color="accent" alt="Accent">
+        <Avatar color="accent">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback />
         </Avatar>
-        <Avatar color="default" alt="Default">
+        <Avatar color="default">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback />
         </Avatar>
-        <Avatar color="success" alt="Success">
+        <Avatar color="success">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback />
         </Avatar>
-        <Avatar color="warning" alt="Warning">
+        <Avatar color="warning">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback />
         </Avatar>
-        <Avatar color="danger" alt="Danger">
+        <Avatar color="danger">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback />
         </Avatar>
@@ -139,23 +139,23 @@ const SoftIconFallbackContent = () => {
   return (
     <View className="flex-1 px-5 items-center justify-center">
       <View className="flex-row items-center justify-center gap-3">
-        <Avatar variant="soft" color="accent" alt="Accent">
+        <Avatar variant="soft" color="accent">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback />
         </Avatar>
-        <Avatar variant="soft" color="default" alt="Default">
+        <Avatar variant="soft" color="default">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback />
         </Avatar>
-        <Avatar variant="soft" color="success" alt="Success">
+        <Avatar variant="soft" color="success">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback />
         </Avatar>
-        <Avatar variant="soft" color="warning" alt="Warning">
+        <Avatar variant="soft" color="warning">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback />
         </Avatar>
-        <Avatar variant="soft" color="danger" alt="Danger">
+        <Avatar variant="soft" color="danger">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback />
         </Avatar>
@@ -173,7 +173,7 @@ const CustomFallbackContent = () => {
         <Avatar alt="John Doe">
           <Avatar.Fallback>🎉</Avatar.Fallback>
         </Avatar>
-        <Avatar alt="Custom">
+        <Avatar>
           <Avatar.Fallback>
             <LinearGradient
               colors={['#ec4899', '#a855f7']}
@@ -191,7 +191,7 @@ const CustomFallbackContent = () => {
             </LinearGradient>
           </Avatar.Fallback>
         </Avatar>
-        <Avatar alt="User">
+        <Avatar>
           <Avatar.Fallback>
             <PersonFillIcon colorClassName="accent-muted" />
           </Avatar.Fallback>
@@ -276,7 +276,7 @@ const AvatarGroupContent = () => {
             </Avatar.Fallback>
           </Avatar>
         ))}
-        <Avatar className="border-background border-2 -ml-4" alt="More">
+        <Avatar className="border-background border-2 -ml-4">
           <Avatar.Fallback>+2</Avatar.Fallback>
         </Avatar>
       </View>
@@ -290,7 +290,7 @@ const CustomStylesContent = () => {
   return (
     <View className="flex-1 px-5 items-center justify-center">
       <View className="flex-row items-center justify-center gap-4">
-        <Avatar className="h-16 w-16" alt="Extra Large">
+        <Avatar className="h-16 w-16">
           <Avatar.Image
             source={{
               uri: 'https://img.heroui.chat/image/avatar?w=400&h=400&u=3',
@@ -298,7 +298,7 @@ const CustomStylesContent = () => {
           />
           <Avatar.Fallback>XL</Avatar.Fallback>
         </Avatar>
-        <Avatar className="rounded-lg" alt="Square Avatar">
+        <Avatar className="rounded-lg">
           <Avatar.Image
             source={{
               uri: 'https://img.heroui.chat/image/avatar?w=400&h=400&u=5',
@@ -306,7 +306,7 @@ const CustomStylesContent = () => {
           />
           <Avatar.Fallback className="rounded-lg">SQ</Avatar.Fallback>
         </Avatar>
-        <Avatar className="p-[2.5px]" size="lg" alt="Gradient Border">
+        <Avatar className="p-[2.5px]" size="lg">
           <LinearGradient
             colors={['#ec4899', '#f59e0b']}
             start={{ x: 0, y: 0 }}
@@ -322,7 +322,7 @@ const CustomStylesContent = () => {
           <Avatar.Fallback className="border-none">GB</Avatar.Fallback>
         </Avatar>
         <View className="relative">
-          <Avatar size="lg" alt="Online User">
+          <Avatar size="lg">
             <Avatar.Image
               source={{
                 uri: 'https://img.heroui.chat/image/avatar?w=400&h=400&u=23',

--- a/example/src/app/(home)/components/skeleton.tsx
+++ b/example/src/app/(home)/components/skeleton.tsx
@@ -80,7 +80,7 @@ const CardSkeletonContent = () => {
               <Card.Header>
                 <View className="flex-row items-center gap-3 mb-4">
                   <SkeletonGroup.Item className="size-10 rounded-full">
-                    <Avatar size="sm" alt="Avatar">
+                    <Avatar size="sm">
                       <Avatar.Image
                         source={{
                           uri: 'https://img.heroui.chat/image/avatar?w=400&h=400&u=4',
@@ -284,7 +284,7 @@ const CircularSkeletonsContent = () => {
               className="flex-row gap-4 items-end justify-center"
             >
               <SkeletonGroup.Item className="size-10 rounded-full">
-                <Avatar size="sm" alt="Avatar">
+                <Avatar size="sm">
                   <Avatar.Image
                     source={{
                       uri: 'https://img.heroui.chat/image/avatar?w=400&h=400&u=3',
@@ -295,7 +295,7 @@ const CircularSkeletonsContent = () => {
               </SkeletonGroup.Item>
 
               <SkeletonGroup.Item className="size-12 rounded-full">
-                <Avatar size="md" alt="Avatar">
+                <Avatar size="md">
                   <Avatar.Image
                     source={{
                       uri: 'https://img.heroui.chat/image/avatar?w=400&h=400&u=5',
@@ -306,7 +306,7 @@ const CircularSkeletonsContent = () => {
               </SkeletonGroup.Item>
 
               <SkeletonGroup.Item className="size-16 rounded-full">
-                <Avatar size="lg" alt="Avatar">
+                <Avatar size="lg">
                   <Avatar.Image
                     source={{
                       uri: 'https://img.heroui.chat/image/avatar?w=400&h=400&u=20',

--- a/example/src/app/(home)/index.tsx
+++ b/example/src/app/(home)/index.tsx
@@ -161,7 +161,7 @@ export default function App() {
   return (
     <ScreenScrollView>
       <AppText className="text-muted text-base text-center my-4">
-        v1.0.2
+        v1.0.3
       </AppText>
       <View className="gap-6">
         {cards.map((card, index) => (

--- a/src/components/avatar/avatar.md
+++ b/src/components/avatar/avatar.md
@@ -261,7 +261,7 @@ You can find more examples in the [GitHub repository](<https://github.com/heroui
 | `color`        | `'default' \| 'accent' \| 'success' \| 'warning' \| 'danger'` | `'accent'`  | Color variant of the avatar                                                               |
 | `className`    | `string`                                                      | -           | Additional CSS classes to apply                                                           |
 | `animation`    | `"disable-all"` \| `undefined`                                | `undefined` | Animation configuration. Use `"disable-all"` to disable all animations including children |
-| `alt`          | `string`                                                      | -           | Alternative text description for accessibility                                            |
+| `alt`          | `string`                                                      | `'Avatar'`  | Alternative text description for accessibility                                            |
 | `...ViewProps` | `ViewProps`                                                   | -           | All standard React Native View props are supported                                        |
 
 ### Avatar.Image

--- a/src/primitives/avatar/avatar.tsx
+++ b/src/primitives/avatar/avatar.tsx
@@ -39,7 +39,7 @@ export function useRootContext() {
 // --------------------------------------------------
 
 const Root = forwardRef<RootRef, RootProps>(
-  ({ asChild, alt, ...viewProps }, ref) => {
+  ({ asChild, alt = 'Avatar', ...viewProps }, ref) => {
     const [status, setStatus] = useState<AvatarStatus>('error');
 
     const Component = asChild ? Slot.View : View;

--- a/src/primitives/avatar/avatar.types.ts
+++ b/src/primitives/avatar/avatar.types.ts
@@ -18,8 +18,11 @@ type AvatarStatus = 'loading' | 'loaded' | 'error';
  * Extends SlottableViewProps to support the asChild pattern.
  */
 type RootProps = SlottableViewProps & {
-  /** Alternative text description for the avatar, used for accessibility */
-  alt: string;
+  /**
+   * Alternative text description for the avatar, used for accessibility.
+   * @default 'Avatar'
+   */
+  alt?: string;
 };
 
 /**


### PR DESCRIPTION
## 📝 Description

Makes the `alt` prop optional on the `Avatar` component, defaulting to `'Avatar'` when not provided. This reduces boilerplate in common use cases while preserving accessibility support.

## ⛳️ Current behavior (updates)

The `Avatar` component requires consumers to explicitly pass an `alt` prop, forcing redundant labels even for purely decorative or contextually obvious avatars.

## 🚀 New behavior

- `alt` prop on `Avatar` is now optional and defaults to `'Avatar'`
- Updated `RootProps` type with `alt?: string` and JSDoc `@default 'Avatar'`
- Cleaned up example screens to remove unnecessary `alt` props
- Updated `avatar.md` API table to reflect the new default

## 💣 Is this a breaking change (Yes/No):

**No** - Existing code passing `alt` continues to work unchanged; the prop simply gains a sensible default when omitted.

## 📝 Additional Information

Verified by running the example app's avatar and skeleton screens, where `alt` props were removed without any regression. No new dependencies were introduced.