### PR TITLE
chore: refine button, chip, and input styles

### DIFF
--- a/src/components/button/button.styles.ts
+++ b/src/components/button/button.styles.ts
@@ -34,9 +34,9 @@ const root = tv({
       ['danger-soft']: 'bg-danger-soft border-0',
     },
     size: {
-      sm: 'h-[36px] px-3.5 gap-1.5 rounded-3xl',
-      md: 'h-[48px] px-4 gap-2 rounded-3xl',
-      lg: 'h-[56px] px-5 gap-2.5 rounded-4xl',
+      sm: 'h-10 px-3.5 gap-1.5 rounded-3xl',
+      md: 'h-12 px-4 gap-2 rounded-3xl',
+      lg: 'h-14 px-5 gap-2.5 rounded-4xl',
     },
     isIconOnly: {
       true: 'p-0 aspect-square',

--- a/src/components/chip/chip.styles.ts
+++ b/src/components/chip/chip.styles.ts
@@ -55,7 +55,7 @@ const root = tv({
     {
       variant: 'soft',
       color: 'accent',
-      className: 'bg-accent/15',
+      className: 'bg-accent-soft',
     },
     {
       variant: 'soft',
@@ -65,17 +65,17 @@ const root = tv({
     {
       variant: 'soft',
       color: 'success',
-      className: 'bg-success/15',
+      className: 'bg-success-soft',
     },
     {
       variant: 'soft',
       color: 'warning',
-      className: 'bg-warning/15',
+      className: 'bg-warning-soft',
     },
     {
       variant: 'soft',
       color: 'danger',
-      className: 'bg-danger/15',
+      className: 'bg-danger-soft',
     },
   ],
   defaultVariants: {

--- a/src/components/chip/chip.styles.ts
+++ b/src/components/chip/chip.styles.ts
@@ -13,8 +13,8 @@ const root = tv({
     },
     size: {
       sm: 'px-2 py-0.5 rounded-xl',
-      md: 'px-3 py-[3px] rounded-2xl',
-      lg: 'px-4 py-1 rounded-3xl',
+      md: 'px-3 py-1 rounded-2xl',
+      lg: 'px-4 py-1.5 rounded-3xl',
     },
     color: {
       accent: '',

--- a/src/components/input/input.styles.ts
+++ b/src/components/input/input.styles.ts
@@ -6,7 +6,8 @@ const input = tv({
   base: 'py-3.5 px-3 rounded-2xl text-foreground font-normal border-[1.5px] focus:border-accent',
   variants: {
     variant: {
-      primary: 'bg-field border-field ios:shadow-field android:shadow-sm',
+      primary:
+        'bg-field border-field-border ios:shadow-field android:shadow-sm',
       secondary: 'bg-default border-default',
     },
     isInvalid: {

--- a/src/components/input/input.styles.ts
+++ b/src/components/input/input.styles.ts
@@ -3,7 +3,7 @@ import { tv } from 'tailwind-variants';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const input = tv({
-  base: 'py-3.5 px-3 rounded-2xl text-foreground font-normal border-[1.5px] focus:border-accent',
+  base: 'min-h-12 px-3 rounded-2xl text-foreground font-normal border-[1.5px] focus:border-accent',
   variants: {
     variant: {
       primary:


### PR DESCRIPTION
## 📝 Description

Refines sizing and color styles across `Button`, `Chip`, and `Input` to standardize on Tailwind utility classes and semantic soft color tokens. Also fixes the primary `Input` border color to use the proper `field-border` token instead of `field`.

## ⛳️ Current behavior (updates)

Button sizes use arbitrary pixel values, chip soft variants rely on opacity-based backgrounds, and the primary input uses `border-field` (incorrect token) with `py-3.5` for vertical sizing.

## 🚀 New behavior

- `Button` sizes now use Tailwind height utilities (`h-10`, `h-12`, `h-14`) instead of arbitrary px values; `sm` height adjusted from 36px to 40px.
- `Chip` `md`/`lg` vertical padding refined (`py-[3px]` → `py-1`, `py-1` → `py-1.5`) for better visual balance.
- `Chip` soft variants now use semantic `bg-{color}-soft` tokens instead of `bg-{color}/15` opacity backgrounds.
- `Input` switches from `py-3.5` to `min-h-12` for consistent height behavior across content.
- `Input` primary variant border now correctly uses `border-field-border`.

## 💣 Is this a breaking change (Yes/No):

**No** - Visual refinements only; no API changes. Minor pixel-level differences in `Button` `sm` size (+4px) and `Chip` `md`/`lg` paddings.

## 📝 Additional Information

Changes are limited to style tokens in `button.styles.ts`, `chip.styles.ts`, and `input.styles.ts`. Recommend visual regression review across themes to confirm the new soft tokens render as expected on light and dark modes.