### PR TITLE
fix(text-field, search-field): remove side padding on child components

### DIFF
--- a/src/components/search-field/search-field.tsx
+++ b/src/components/search-field/search-field.tsx
@@ -60,7 +60,7 @@ const SearchFieldRoot = forwardRef<ViewRef, SearchFieldProps>((props, ref) => {
   );
 
   const formFieldContextValue = useMemo(
-    () => ({ isDisabled, isInvalid, isRequired, hasFieldPadding: true }),
+    () => ({ isDisabled, isInvalid, isRequired, hasFieldPadding: false }),
     [isDisabled, isInvalid, isRequired]
   );
 

--- a/src/components/text-field/text-field.tsx
+++ b/src/components/text-field/text-field.tsx
@@ -42,7 +42,7 @@ const TextFieldRoot = forwardRef<ViewRef, TextFieldRootProps>((props, ref) => {
   );
 
   const formFieldContextValue = useMemo(
-    () => ({ isDisabled, isInvalid, isRequired, hasFieldPadding: true }),
+    () => ({ isDisabled, isInvalid, isRequired, hasFieldPadding: false }),
     [isDisabled, isInvalid, isRequired]
   );
 


### PR DESCRIPTION
## 📝 Description

Disables the `hasFieldPadding` flag on `TextField` and `SearchField` so that nested `Label`, `Description`, and `FieldError` components no longer receive the extra `px-1.5` horizontal padding. This aligns these fields with the rest of the form-field family (`ControlField`, `RadioGroup`, `TagGroup`), which already set `hasFieldPadding: false`.

## ⛳️ Current behavior (updates)

`TextField` and `SearchField` propagated `hasFieldPadding: true` through `FormFieldContext`, causing child components to render with additional horizontal padding that misaligned them from the field container's edges.

## 🚀 New behavior

- `TextField` now provides `hasFieldPadding: false` to its form field context
- `SearchField` now provides `hasFieldPadding: false` to its form field context
- `Label`, `Description`, and `FieldError` rendered inside these fields no longer apply the extra `px-1.5` side padding
- Visual alignment is now consistent across all form field containers

## 💣 Is this a breaking change (Yes/No):

**No** - This is a visual fix that only adjusts internal padding behavior. Public APIs and prop signatures are unchanged.

## 📝 Additional Information

The change is isolated to two `useMemo` values providing `FormFieldContext`. Consumers that previously relied on the unintended inner padding can restore spacing by adding `className="px-1.5"` to the affected child components.