### PR TITLE
fix(tabs): rtl indicator animation issue

### DIFF
--- a/example/app.json
+++ b/example/app.json
@@ -43,7 +43,8 @@
           },
           "imageWidth": 200
         }
-      ]
+      ],
+      "expo-localization"
     ],
     "extra": {
       "router": {

--- a/example/package.json
+++ b/example/package.json
@@ -29,6 +29,7 @@
     "expo-image": "~3.0.11",
     "expo-linear-gradient": "~15.0.8",
     "expo-linking": "~8.0.11",
+    "expo-localization": "~17.0.8",
     "expo-router": "~6.0.21",
     "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",

--- a/src/components/tabs/tabs.animation.ts
+++ b/src/components/tabs/tabs.animation.ts
@@ -126,6 +126,15 @@ export function useTabsIndicatorAnimation(options: {
     });
 
     if (!hasMeasured.value) {
+      if (isRTL && listWidth === 0) {
+        return {
+          width: 0,
+          height: 0,
+          transform: [{ translateX: 0 }],
+          opacity: 0,
+        };
+      }
+
       hasMeasured.value = true;
       return {
         width: activeMeasurements.width,
@@ -190,6 +199,7 @@ function getIndicatorTranslateX({
   tabWidth: number;
   tabX: number;
 }) {
+  'worklet';
   if (!(isRTL && listWidth > 0)) {
     return tabX;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7884,6 +7884,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-localization@npm:~17.0.8":
+  version: 17.0.8
+  resolution: "expo-localization@npm:17.0.8"
+  dependencies:
+    rtl-detect: ^1.0.2
+  peerDependencies:
+    expo: "*"
+    react: "*"
+  checksum: 70ddc37ec97392c7c2b783135695a2b06e5b38c7397989a0986632e91e75b36a87579267322910ac5edf53975440ad17b62f270206ce246df5a30881e4933aa5
+  languageName: node
+  linkType: hard
+
 "expo-manifests@npm:~1.0.10":
   version: 1.0.10
   resolution: "expo-manifests@npm:1.0.10"
@@ -9010,6 +9022,7 @@ __metadata:
     expo-image: ~3.0.11
     expo-linear-gradient: ~15.0.8
     expo-linking: ~8.0.11
+    expo-localization: ~17.0.8
     expo-router: ~6.0.21
     expo-splash-screen: ~31.0.13
     expo-status-bar: ~3.0.9
@@ -13983,6 +13996,13 @@ __metadata:
   bin:
     rimraf: bin.js
   checksum: 87f4164e396f0171b0a3386cc1877a817f572148ee13a7e113b238e48e8a9f2f31d009a92ec38a591ff1567d9662c6b67fd8818a2dbbaed74bc26a87a2a4a9a0
+  languageName: node
+  linkType: hard
+
+"rtl-detect@npm:^1.0.2":
+  version: 1.1.2
+  resolution: "rtl-detect@npm:1.1.2"
+  checksum: 4a43a1e5df0617eb86d5485640b318787d12b86acf53d840a3b2ff701ee941e95479d4e9ae97e907569ec763d1c47218cb87639bc87bcdad60a85747e5270cf0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 📝 Description

Fixes an RTL indicator animation issue in the `Tabs` component where the indicator would briefly render at the wrong position before the list width was measured. Also marks the `getIndicatorTranslateX` helper as a Reanimated worklet so it can safely run on the UI thread.

## ⛳️ Current behavior (updates)

In RTL layouts, the tabs indicator could flash at an incorrect position on first render because `listWidth` had not yet been measured when the initial style was computed.

## 🚀 New behavior

- Indicator is hidden (zero size, zero opacity) on the first render in RTL mode until `listWidth` is measured.
- `getIndicatorTranslateX` is now a proper Reanimated worklet, ensuring it executes on the UI thread without warnings.
- Example app adds `expo-localization` to enable RTL testing scenarios.

## 💣 Is this a breaking change (Yes/No):

**No** - This is a non-breaking bug fix; the public API of `Tabs` is unchanged.

## 📝 Additional Information

Verified the fix in the example app by toggling RTL via `expo-localization` and confirming the indicator no longer flickers on initial mount. Only the example app gains a new dependency; the library itself has no new runtime dependencies.