### PR TITLE
fix(select): unify trigger indicator render branches

### DIFF
--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -213,19 +213,6 @@ const SelectTriggerIndicator = forwardRef<ViewRef, SelectTriggerIndicatorProps>(
       ? [rContainerStyle, style]
       : style;
 
-    if (children) {
-      return (
-        <AnimatedTriggerIndicator
-          ref={ref}
-          className={triggerIndicatorClassName}
-          style={style}
-          {...restProps}
-        >
-          {children}
-        </AnimatedTriggerIndicator>
-      );
-    }
-
     return (
       <AnimatedTriggerIndicator
         ref={ref}
@@ -233,10 +220,12 @@ const SelectTriggerIndicator = forwardRef<ViewRef, SelectTriggerIndicatorProps>(
         style={triggerIndicatorStyle}
         {...restProps}
       >
-        <ChevronDownIcon
-          size={iconProps?.size ?? DEFAULT_ICON_SIZE}
-          color={iconProps?.color ?? themeColorForeground}
-        />
+        {children ?? (
+          <ChevronDownIcon
+            size={iconProps?.size ?? DEFAULT_ICON_SIZE}
+            color={iconProps?.color ?? themeColorForeground}
+          />
+        )}
       </AnimatedTriggerIndicator>
     );
   }


### PR DESCRIPTION
## 📝 Description

Fixes `Select.TriggerIndicator` so the open/close rotation animation is applied even when custom `children` are provided. Previously the component took a separate render branch for custom children that bypassed the animated style.

## ⛳️ Current behavior (updates)

When passing custom `children` to `Select.TriggerIndicator`, the animated rotation transform (`rContainerStyle`) was not applied, so the indicator did not rotate on open/close.

## 🚀 New behavior

- Custom `children` now receive the same animated container style as the default icon.
- `ChevronDownIcon` is rendered as a fallback via `children ?? <ChevronDownIcon />`.
- Single, unified render path for `SelectTriggerIndicator`.

## 💣 Is this a breaking change (Yes/No):

**No** - Public API is unchanged; only the internal rendering branch was consolidated.

## 📝 Additional Information

Manually verified that the trigger indicator rotates correctly with both the default icon and custom children. No new dependencies or performance impact.