### PR TITLE
1.0.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 </p>
 
 <p align="center">
-  v1.0.2
+  v1.0.3
 </p>
 
 ## Getting Started

--- a/docs/components.md
+++ b/docs/components.md
@@ -38,6 +38,7 @@
 | Switch            | [switch.md](../src/components/switch/switch.md)                                     |
 | Tabs              | [tabs.md](../src/components/tabs/tabs.md)                                           |
 | TagGroup          | [tag-group.md](../src/components/tag-group/tag-group.md)                            |
+| Text              | [text.md](../src/components/text/text.md)                                           |
 | TextArea          | [text-area.md](../src/components/text-area/text-area.md)                            |
 | TextField         | [text-field.md](../src/components/text-field/text-field.md)                         |
 | Toast             | [toast.md](../src/components/toast/toast.md)                                        |

--- a/example/app.json
+++ b/example/app.json
@@ -43,7 +43,8 @@
           },
           "imageWidth": 200
         }
-      ]
+      ],
+      "expo-localization"
     ],
     "extra": {
       "router": {

--- a/example/package.json
+++ b/example/package.json
@@ -29,6 +29,7 @@
     "expo-image": "~3.0.11",
     "expo-linear-gradient": "~15.0.8",
     "expo-linking": "~8.0.11",
+    "expo-localization": "~17.0.8",
     "expo-router": "~6.0.21",
     "expo-splash-screen": "~31.0.13",
     "expo-status-bar": "~3.0.9",

--- a/example/src/app/(home)/components/avatar.tsx
+++ b/example/src/app/(home)/components/avatar.tsx
@@ -11,7 +11,7 @@ const SizesContent = () => {
   return (
     <View className="flex-1 px-5 items-center justify-center">
       <View className="flex-row items-center justify-center gap-4">
-        <Avatar size="sm" alt="Small Avatar">
+        <Avatar size="sm">
           <Avatar.Image
             source={{
               uri: 'https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/avatars/blue.jpg',
@@ -19,7 +19,7 @@ const SizesContent = () => {
           />
           <Avatar.Fallback />
         </Avatar>
-        <Avatar size="md" alt="Medium Avatar">
+        <Avatar size="md">
           <Avatar.Image
             source={{
               uri: 'https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/avatars/purple.jpg',
@@ -27,7 +27,7 @@ const SizesContent = () => {
           />
           <Avatar.Fallback>MD</Avatar.Fallback>
         </Avatar>
-        <Avatar size="lg" alt="Large Avatar">
+        <Avatar size="lg">
           <Avatar.Image
             source={{
               uri: 'https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/avatars/red.jpg',
@@ -46,23 +46,23 @@ const DefaultTextFallbackContent = () => {
   return (
     <View className="flex-1 px-5 items-center justify-center">
       <View className="flex-row items-center justify-center gap-3">
-        <Avatar color="accent" alt="Accent">
+        <Avatar color="accent">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback>AC</Avatar.Fallback>
         </Avatar>
-        <Avatar color="default" alt="Default">
+        <Avatar color="default">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback>DF</Avatar.Fallback>
         </Avatar>
-        <Avatar color="success" alt="Success">
+        <Avatar color="success">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback>SC</Avatar.Fallback>
         </Avatar>
-        <Avatar color="warning" alt="Warning">
+        <Avatar color="warning">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback>WR</Avatar.Fallback>
         </Avatar>
-        <Avatar color="danger" alt="Danger">
+        <Avatar color="danger">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback>DG</Avatar.Fallback>
         </Avatar>
@@ -77,23 +77,23 @@ const SoftTextFallbackContent = () => {
   return (
     <View className="flex-1 px-5 items-center justify-center">
       <View className="flex-row items-center justify-center gap-3">
-        <Avatar variant="soft" color="accent" alt="Accent">
+        <Avatar variant="soft" color="accent">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback>AC</Avatar.Fallback>
         </Avatar>
-        <Avatar variant="soft" color="default" alt="Default">
+        <Avatar variant="soft" color="default">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback>DF</Avatar.Fallback>
         </Avatar>
-        <Avatar variant="soft" color="success" alt="Success">
+        <Avatar variant="soft" color="success">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback>SC</Avatar.Fallback>
         </Avatar>
-        <Avatar variant="soft" color="warning" alt="Warning">
+        <Avatar variant="soft" color="warning">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback>WR</Avatar.Fallback>
         </Avatar>
-        <Avatar variant="soft" color="danger" alt="Danger">
+        <Avatar variant="soft" color="danger">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback>DG</Avatar.Fallback>
         </Avatar>
@@ -108,23 +108,23 @@ const DefaultIconFallbackContent = () => {
   return (
     <View className="flex-1 px-5 items-center justify-center">
       <View className="flex-row items-center justify-center gap-3">
-        <Avatar color="accent" alt="Accent">
+        <Avatar color="accent">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback />
         </Avatar>
-        <Avatar color="default" alt="Default">
+        <Avatar color="default">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback />
         </Avatar>
-        <Avatar color="success" alt="Success">
+        <Avatar color="success">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback />
         </Avatar>
-        <Avatar color="warning" alt="Warning">
+        <Avatar color="warning">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback />
         </Avatar>
-        <Avatar color="danger" alt="Danger">
+        <Avatar color="danger">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback />
         </Avatar>
@@ -139,23 +139,23 @@ const SoftIconFallbackContent = () => {
   return (
     <View className="flex-1 px-5 items-center justify-center">
       <View className="flex-row items-center justify-center gap-3">
-        <Avatar variant="soft" color="accent" alt="Accent">
+        <Avatar variant="soft" color="accent">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback />
         </Avatar>
-        <Avatar variant="soft" color="default" alt="Default">
+        <Avatar variant="soft" color="default">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback />
         </Avatar>
-        <Avatar variant="soft" color="success" alt="Success">
+        <Avatar variant="soft" color="success">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback />
         </Avatar>
-        <Avatar variant="soft" color="warning" alt="Warning">
+        <Avatar variant="soft" color="warning">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback />
         </Avatar>
-        <Avatar variant="soft" color="danger" alt="Danger">
+        <Avatar variant="soft" color="danger">
           <Avatar.Image source={undefined} />
           <Avatar.Fallback />
         </Avatar>
@@ -173,7 +173,7 @@ const CustomFallbackContent = () => {
         <Avatar alt="John Doe">
           <Avatar.Fallback>🎉</Avatar.Fallback>
         </Avatar>
-        <Avatar alt="Custom">
+        <Avatar>
           <Avatar.Fallback>
             <LinearGradient
               colors={['#ec4899', '#a855f7']}
@@ -191,7 +191,7 @@ const CustomFallbackContent = () => {
             </LinearGradient>
           </Avatar.Fallback>
         </Avatar>
-        <Avatar alt="User">
+        <Avatar>
           <Avatar.Fallback>
             <PersonFillIcon colorClassName="accent-muted" />
           </Avatar.Fallback>
@@ -276,7 +276,7 @@ const AvatarGroupContent = () => {
             </Avatar.Fallback>
           </Avatar>
         ))}
-        <Avatar className="border-background border-2 -ml-4" alt="More">
+        <Avatar className="border-background border-2 -ml-4">
           <Avatar.Fallback>+2</Avatar.Fallback>
         </Avatar>
       </View>
@@ -290,7 +290,7 @@ const CustomStylesContent = () => {
   return (
     <View className="flex-1 px-5 items-center justify-center">
       <View className="flex-row items-center justify-center gap-4">
-        <Avatar className="h-16 w-16" alt="Extra Large">
+        <Avatar className="h-16 w-16">
           <Avatar.Image
             source={{
               uri: 'https://img.heroui.chat/image/avatar?w=400&h=400&u=3',
@@ -298,7 +298,7 @@ const CustomStylesContent = () => {
           />
           <Avatar.Fallback>XL</Avatar.Fallback>
         </Avatar>
-        <Avatar className="rounded-lg" alt="Square Avatar">
+        <Avatar className="rounded-lg">
           <Avatar.Image
             source={{
               uri: 'https://img.heroui.chat/image/avatar?w=400&h=400&u=5',
@@ -306,7 +306,7 @@ const CustomStylesContent = () => {
           />
           <Avatar.Fallback className="rounded-lg">SQ</Avatar.Fallback>
         </Avatar>
-        <Avatar className="p-[2.5px]" size="lg" alt="Gradient Border">
+        <Avatar className="p-[2.5px]" size="lg">
           <LinearGradient
             colors={['#ec4899', '#f59e0b']}
             start={{ x: 0, y: 0 }}
@@ -322,7 +322,7 @@ const CustomStylesContent = () => {
           <Avatar.Fallback className="border-none">GB</Avatar.Fallback>
         </Avatar>
         <View className="relative">
-          <Avatar size="lg" alt="Online User">
+          <Avatar size="lg">
             <Avatar.Image
               source={{
                 uri: 'https://img.heroui.chat/image/avatar?w=400&h=400&u=23',

--- a/example/src/app/(home)/components/skeleton.tsx
+++ b/example/src/app/(home)/components/skeleton.tsx
@@ -80,7 +80,7 @@ const CardSkeletonContent = () => {
               <Card.Header>
                 <View className="flex-row items-center gap-3 mb-4">
                   <SkeletonGroup.Item className="size-10 rounded-full">
-                    <Avatar size="sm" alt="Avatar">
+                    <Avatar size="sm">
                       <Avatar.Image
                         source={{
                           uri: 'https://img.heroui.chat/image/avatar?w=400&h=400&u=4',
@@ -284,7 +284,7 @@ const CircularSkeletonsContent = () => {
               className="flex-row gap-4 items-end justify-center"
             >
               <SkeletonGroup.Item className="size-10 rounded-full">
-                <Avatar size="sm" alt="Avatar">
+                <Avatar size="sm">
                   <Avatar.Image
                     source={{
                       uri: 'https://img.heroui.chat/image/avatar?w=400&h=400&u=3',
@@ -295,7 +295,7 @@ const CircularSkeletonsContent = () => {
               </SkeletonGroup.Item>
 
               <SkeletonGroup.Item className="size-12 rounded-full">
-                <Avatar size="md" alt="Avatar">
+                <Avatar size="md">
                   <Avatar.Image
                     source={{
                       uri: 'https://img.heroui.chat/image/avatar?w=400&h=400&u=5',
@@ -306,7 +306,7 @@ const CircularSkeletonsContent = () => {
               </SkeletonGroup.Item>
 
               <SkeletonGroup.Item className="size-16 rounded-full">
-                <Avatar size="lg" alt="Avatar">
+                <Avatar size="lg">
                   <Avatar.Image
                     source={{
                       uri: 'https://img.heroui.chat/image/avatar?w=400&h=400&u=20',

--- a/example/src/app/(home)/components/text.tsx
+++ b/example/src/app/(home)/components/text.tsx
@@ -1,0 +1,140 @@
+import { Text } from 'heroui-native';
+import { View } from 'react-native';
+import type { UsageVariant } from '../../../components/component-presentation/types';
+import { UsageVariantFlatList } from '../../../components/component-presentation/usage-variant-flatlist';
+
+const TypesContent = () => {
+  return (
+    <View className="flex-1 justify-center px-5 gap-4">
+      <Text type="h1">Heading 1</Text>
+      <Text type="h2">Heading 2</Text>
+      <Text type="h3">Heading 3</Text>
+      <Text type="h4">Heading 4</Text>
+      <Text type="h5">Heading 5</Text>
+      <Text type="h6">Heading 6</Text>
+      <Text type="body">Body text</Text>
+      <Text type="body-sm">Small body text</Text>
+      <Text type="body-xs">Extra-small body text</Text>
+      <Text type="code">const x = 42;</Text>
+    </View>
+  );
+};
+
+// ------------------------------------------------------------------------------
+
+const HeadingsContent = () => {
+  return (
+    <View className="flex-1 justify-center px-5 gap-4">
+      <Text.Heading type="h1">Page Title</Text.Heading>
+      <Text.Heading type="h2">Section Title</Text.Heading>
+      <Text.Heading type="h3">Subsection</Text.Heading>
+      <Text.Heading type="h4">Group Title</Text.Heading>
+      <Text.Heading type="h5">Label Heading</Text.Heading>
+      <Text.Heading type="h6">Small Heading</Text.Heading>
+    </View>
+  );
+};
+
+// ------------------------------------------------------------------------------
+
+const ParagraphsContent = () => {
+  return (
+    <View className="flex-1 justify-center px-5 gap-4">
+      <Text.Paragraph>
+        This is a default body paragraph. It uses the base font size and normal
+        weight for comfortable reading.
+      </Text.Paragraph>
+      <Text.Paragraph type="body-sm">
+        This is a smaller paragraph, useful for captions, footnotes, or
+        secondary descriptions.
+      </Text.Paragraph>
+      <Text.Paragraph type="body-xs">
+        Extra-small text for disclaimers or fine print.
+      </Text.Paragraph>
+    </View>
+  );
+};
+
+// ------------------------------------------------------------------------------
+
+const CodeContent = () => {
+  return (
+    <View className="flex-1 justify-center px-5 gap-4">
+      <Text.Code>npm install heroui-native</Text.Code>
+      <Text.Code>{'const greeting = "Hello, world!";'}</Text.Code>
+      <Text.Code>{'export default function App() { }'}</Text.Code>
+    </View>
+  );
+};
+
+// ------------------------------------------------------------------------------
+
+const ProseContent = () => {
+  return (
+    <View className="flex-1 justify-center px-5 gap-4">
+      <Text.Prose>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+        commodo consequat.
+      </Text.Prose>
+    </View>
+  );
+};
+
+// ------------------------------------------------------------------------------
+
+const CustomStylingContent = () => {
+  return (
+    <View className="flex-1 justify-center px-5 gap-4">
+      <Text type="h1" className="text-accent">
+        Accent Heading
+      </Text>
+      <Text type="body" className="text-muted">
+        Muted body text
+      </Text>
+      <Text type="body-sm" className="text-danger">
+        Danger small text
+      </Text>
+    </View>
+  );
+};
+
+// ------------------------------------------------------------------------------
+
+const TEXT_VARIANTS: UsageVariant[] = [
+  {
+    value: 'types',
+    label: 'Types',
+    content: <TypesContent />,
+  },
+  {
+    value: 'headings',
+    label: 'Headings',
+    content: <HeadingsContent />,
+  },
+  {
+    value: 'paragraphs',
+    label: 'Paragraphs',
+    content: <ParagraphsContent />,
+  },
+  {
+    value: 'code',
+    label: 'Code',
+    content: <CodeContent />,
+  },
+  {
+    value: 'prose',
+    label: 'Prose',
+    content: <ProseContent />,
+  },
+  {
+    value: 'custom',
+    label: 'Custom Styling',
+    content: <CustomStylingContent />,
+  },
+];
+
+export default function TextScreen() {
+  return <UsageVariantFlatList data={TEXT_VARIANTS} />;
+}

--- a/example/src/app/(home)/components/text.tsx
+++ b/example/src/app/(home)/components/text.tsx
@@ -49,7 +49,7 @@ const ParagraphsContent = () => {
         secondary descriptions.
       </Text.Paragraph>
       <Text.Paragraph type="body-xs">
-        Extra-small text for disclaimers or fine print.
+        Extra-small text for disclaimers or fine print. lore
       </Text.Paragraph>
     </View>
   );
@@ -63,24 +63,6 @@ const CodeContent = () => {
       <Text.Code>npm install heroui-native</Text.Code>
       <Text.Code>{'const greeting = "Hello, world!";'}</Text.Code>
       <Text.Code>{'export default function App() { }'}</Text.Code>
-    </View>
-  );
-};
-
-// ------------------------------------------------------------------------------
-
-const CustomStylingContent = () => {
-  return (
-    <View className="flex-1 justify-center px-5 gap-4">
-      <Text type="h1" className="text-accent">
-        Accent Heading
-      </Text>
-      <Text type="body" className="text-muted">
-        Muted body text
-      </Text>
-      <Text type="body-sm" className="text-danger">
-        Danger small text
-      </Text>
     </View>
   );
 };
@@ -107,11 +89,6 @@ const TEXT_VARIANTS: UsageVariant[] = [
     value: 'code',
     label: 'Code',
     content: <CodeContent />,
-  },
-  {
-    value: 'custom',
-    label: 'Custom Styling',
-    content: <CustomStylingContent />,
   },
 ];
 

--- a/example/src/app/(home)/components/text.tsx
+++ b/example/src/app/(home)/components/text.tsx
@@ -69,21 +69,6 @@ const CodeContent = () => {
 
 // ------------------------------------------------------------------------------
 
-const ProseContent = () => {
-  return (
-    <View className="flex-1 justify-center px-5 gap-4">
-      <Text.Prose>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
-        tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-        veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-        commodo consequat.
-      </Text.Prose>
-    </View>
-  );
-};
-
-// ------------------------------------------------------------------------------
-
 const CustomStylingContent = () => {
   return (
     <View className="flex-1 justify-center px-5 gap-4">
@@ -122,11 +107,6 @@ const TEXT_VARIANTS: UsageVariant[] = [
     value: 'code',
     label: 'Code',
     content: <CodeContent />,
-  },
-  {
-    value: 'prose',
-    label: 'Prose',
-    content: <ProseContent />,
   },
   {
     value: 'custom',

--- a/example/src/app/(home)/index.tsx
+++ b/example/src/app/(home)/index.tsx
@@ -161,7 +161,7 @@ export default function App() {
   return (
     <ScreenScrollView>
       <AppText className="text-muted text-base text-center my-4">
-        v1.0.2
+        v1.0.3
       </AppText>
       <View className="gap-6">
         {cards.map((card, index) => (

--- a/example/src/helpers/data/components.ts
+++ b/example/src/helpers/data/components.ts
@@ -146,6 +146,10 @@ export const COMPONENTS: ComponentItem[] = [
     path: 'tag-group',
   },
   {
+    title: 'Text',
+    path: 'text',
+  },
+  {
     title: 'TextArea',
     path: 'text-area',
   },

--- a/src/__tests__/text.test.tsx
+++ b/src/__tests__/text.test.tsx
@@ -1,23 +1,6 @@
-import { Text } from '../components/text';
-
-describe('Text', () => {
-  it('should export Text component', () => {
-    expect(Text).toBeDefined();
-  });
-
-  it('should have Heading sub-component', () => {
-    expect(Text.Heading).toBeDefined();
-  });
-
-  it('should have Paragraph sub-component', () => {
-    expect(Text.Paragraph).toBeDefined();
-  });
-
-  it('should have Code sub-component', () => {
-    expect(Text.Code).toBeDefined();
-  });
-
-  it('should have Prose sub-component', () => {
-    expect(Text.Prose).toBeDefined();
-  });
-});
+it.todo('Text: renders with default body type');
+it.todo('Text: applies correct className for each type variant');
+it.todo('Text.Heading: sets accessibilityRole header');
+it.todo('Text.Paragraph: defaults to body type');
+it.todo('Text.Code: applies monospace font family');
+it.todo('Text.Prose: renders body text');

--- a/src/__tests__/text.test.tsx
+++ b/src/__tests__/text.test.tsx
@@ -1,0 +1,23 @@
+import { Text } from '../components/text';
+
+describe('Text', () => {
+  it('should export Text component', () => {
+    expect(Text).toBeDefined();
+  });
+
+  it('should have Heading sub-component', () => {
+    expect(Text.Heading).toBeDefined();
+  });
+
+  it('should have Paragraph sub-component', () => {
+    expect(Text.Paragraph).toBeDefined();
+  });
+
+  it('should have Code sub-component', () => {
+    expect(Text.Code).toBeDefined();
+  });
+
+  it('should have Prose sub-component', () => {
+    expect(Text.Prose).toBeDefined();
+  });
+});

--- a/src/__tests__/text.test.tsx
+++ b/src/__tests__/text.test.tsx
@@ -1,6 +1,0 @@
-it.todo('Text: renders with default body type');
-it.todo('Text: applies correct className for each type variant');
-it.todo('Text.Heading: sets accessibilityRole header');
-it.todo('Text.Paragraph: defaults to body type');
-it.todo('Text.Code: applies monospace font family');
-it.todo('Text.Prose: renders body text');

--- a/src/components/avatar/avatar.md
+++ b/src/components/avatar/avatar.md
@@ -261,7 +261,7 @@ You can find more examples in the [GitHub repository](<https://github.com/heroui
 | `color`        | `'default' \| 'accent' \| 'success' \| 'warning' \| 'danger'` | `'accent'`  | Color variant of the avatar                                                               |
 | `className`    | `string`                                                      | -           | Additional CSS classes to apply                                                           |
 | `animation`    | `"disable-all"` \| `undefined`                                | `undefined` | Animation configuration. Use `"disable-all"` to disable all animations including children |
-| `alt`          | `string`                                                      | -           | Alternative text description for accessibility                                            |
+| `alt`          | `string`                                                      | `'Avatar'`  | Alternative text description for accessibility                                            |
 | `...ViewProps` | `ViewProps`                                                   | -           | All standard React Native View props are supported                                        |
 
 ### Avatar.Image

--- a/src/components/bottom-sheet/bottom-sheet.md
+++ b/src/components/bottom-sheet/bottom-sheet.md
@@ -80,17 +80,32 @@ Bottom sheet that appears detached from the bottom edge with custom spacing.
 
 Bottom sheet with multiple snap points and scrollable content.
 
+To make scrollable content work correctly inside `BottomSheet.Content`, follow these base principles:
+
+- Use a scrollable from [`@gorhom/bottom-sheet`](https://gorhom.dev/react-native-bottom-sheet/components/bottomsheetscrollview) (e.g. `BottomSheetScrollView`, `BottomSheetFlatList`, `BottomSheetSectionList`, `BottomSheetVirtualizedList`). A plain `ScrollView`/`FlatList` from `react-native` will let the sheet intercept the scroll gesture.
+- On `BottomSheet.Content`, disable over-drag and dynamic sizing so the sheet does not grow with its content or absorb the scroll: `enableOverDrag={false}` and `enableDynamicSizing={false}`.
+- Give `BottomSheet.Content` a fixed height via `contentContainerClassName="h-full"` (or any other fixed height). The constraint must be on `BottomSheet.Content`, not on the scrollable child — the scrollable needs a bounded parent to scroll inside.
+
 ```tsx
+import { BottomSheetScrollView } from '@gorhom/bottom-sheet';
+
 <BottomSheet>
   <BottomSheet.Trigger>...</BottomSheet.Trigger>
   <BottomSheet.Portal>
     <BottomSheet.Overlay />
-    <BottomSheet.Content snapPoints={['25%', '50%', '90%']}>
-      <ScrollView>...</ScrollView>
+    <BottomSheet.Content
+      snapPoints={['40%', '80%']}
+      enableOverDrag={false}
+      enableDynamicSizing={false}
+      contentContainerClassName="h-full"
+    >
+      <BottomSheetScrollView>...</BottomSheetScrollView>
     </BottomSheet.Content>
   </BottomSheet.Portal>
-</BottomSheet>
+</BottomSheet>;
 ```
+
+See the full example with a sticky footer (`BottomSheetFooter`) in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/main/example/src/components/bottom-sheet/scrollable-with-snap-points.tsx>).
 
 ### Custom Overlay
 
@@ -136,6 +151,36 @@ export const BottomSheetBlurOverlay = () => {
   </BottomSheet.Portal>
 </BottomSheet>
 ```
+
+### With Keyboard-Aware Input
+
+When rendering an `Input` or `InputOTP` inside `BottomSheet.Content`, use the `useBottomSheetAwareHandlers` hook to wire keyboard avoidance handlers. Pass the returned `onFocus` / `onBlur` to your input.
+
+> **Note**: `useBottomSheetAwareHandlers` must be used inside a `BottomSheet`. Call it from a child component rendered inside `BottomSheet.Content` — outside of a `BottomSheet` context the returned handlers are no-ops.
+
+For scrollable content, also configure `BottomSheet.Content` with `keyboardBehavior="extend"` (or `"interactive"`) and `keyboardShouldPersistTaps="handled"` on the scrollable so taps don't dismiss the keyboard before reaching their target.
+
+```tsx
+import { BottomSheet, Input, useBottomSheetAwareHandlers } from 'heroui-native';
+
+const BottomSheetTextInput = () => {
+  const { onFocus, onBlur } = useBottomSheetAwareHandlers();
+
+  return <Input placeholder="Type here..." onFocus={onFocus} onBlur={onBlur} />;
+};
+
+<BottomSheet>
+  <BottomSheet.Trigger>...</BottomSheet.Trigger>
+  <BottomSheet.Portal>
+    <BottomSheet.Overlay />
+    <BottomSheet.Content keyboardBehavior="extend">
+      <BottomSheetTextInput />
+    </BottomSheet.Content>
+  </BottomSheet.Portal>
+</BottomSheet>;
+```
+
+See full examples for [`Input`](<https://github.com/heroui-inc/heroui-native/blob/main/example/src/components/bottom-sheet/with-text-input.tsx>) and [`InputOTP`](<https://github.com/heroui-inc/heroui-native/blob/main/example/src/components/bottom-sheet/with-otp-input.tsx>) inside a bottom sheet.
 
 ## Example
 
@@ -320,6 +365,19 @@ const { progress } = useBottomSheetAnimation();
 | property   | type                  | description                                  |
 | ---------- | --------------------- | -------------------------------------------- |
 | `progress` | `SharedValue<number>` | Animation progress (0=idle, 1=open, 2=close) |
+
+### useBottomSheetAwareHandlers
+
+Hook that returns `onFocus` and `onBlur` handlers for keyboard avoidance when an `Input` or `InputOTP` is rendered inside `BottomSheet.Content`. Must be used inside a `BottomSheet` — outside of a `BottomSheet` context, the returned handlers are no-ops.
+
+```tsx
+const { onFocus, onBlur } = useBottomSheetAwareHandlers();
+```
+
+| property  | type                      | description                                                                          |
+| --------- | ------------------------- | ------------------------------------------------------------------------------------ |
+| `onFocus` | `(e: FocusEvent) => void` | Focus handler that notifies the bottom sheet about the keyboard target               |
+| `onBlur`  | `(e: BlurEvent) => void`  | Blur handler that conditionally clears the keyboard target in the bottom sheet state |
 
 ## Special Notes
 

--- a/src/components/button/button.styles.ts
+++ b/src/components/button/button.styles.ts
@@ -34,9 +34,9 @@ const root = tv({
       ['danger-soft']: 'bg-danger-soft border-0',
     },
     size: {
-      sm: 'h-[36px] px-3.5 gap-1.5 rounded-3xl',
-      md: 'h-[48px] px-4 gap-2 rounded-3xl',
-      lg: 'h-[56px] px-5 gap-2.5 rounded-4xl',
+      sm: 'h-10 px-3.5 gap-1.5 rounded-3xl',
+      md: 'h-12 px-4 gap-2 rounded-3xl',
+      lg: 'h-14 px-5 gap-2.5 rounded-4xl',
     },
     isIconOnly: {
       true: 'p-0 aspect-square',

--- a/src/components/chip/chip.styles.ts
+++ b/src/components/chip/chip.styles.ts
@@ -55,7 +55,7 @@ const root = tv({
     {
       variant: 'soft',
       color: 'accent',
-      className: 'bg-accent/15',
+      className: 'bg-accent-soft',
     },
     {
       variant: 'soft',
@@ -65,17 +65,17 @@ const root = tv({
     {
       variant: 'soft',
       color: 'success',
-      className: 'bg-success/15',
+      className: 'bg-success-soft',
     },
     {
       variant: 'soft',
       color: 'warning',
-      className: 'bg-warning/15',
+      className: 'bg-warning-soft',
     },
     {
       variant: 'soft',
       color: 'danger',
-      className: 'bg-danger/15',
+      className: 'bg-danger-soft',
     },
   ],
   defaultVariants: {

--- a/src/components/chip/chip.styles.ts
+++ b/src/components/chip/chip.styles.ts
@@ -13,8 +13,8 @@ const root = tv({
     },
     size: {
       sm: 'px-2 py-0.5 rounded-xl',
-      md: 'px-3 py-[3px] rounded-2xl',
-      lg: 'px-4 py-1 rounded-3xl',
+      md: 'px-3 py-1 rounded-2xl',
+      lg: 'px-4 py-1.5 rounded-3xl',
     },
     color: {
       accent: '',

--- a/src/components/input-otp/input-otp.md
+++ b/src/components/input-otp/input-otp.md
@@ -191,6 +191,8 @@ Use render props in Group to create custom slot layouts.
 
 When rendering an InputOTP inside a `BottomSheet`, use the `useBottomSheetAwareHandlers` hook to wire keyboard avoidance handlers. Pass the returned `onFocus` and `onBlur` to InputOTP.
 
+> **Note**: `useBottomSheetAwareHandlers` must be used inside a `BottomSheet`. Call it from a child component rendered inside `BottomSheet.Content` — outside of a `BottomSheet` context the returned handlers are no-ops.
+
 ```tsx
 import { InputOTP, useBottomSheetAwareHandlers } from 'heroui-native';
 

--- a/src/components/input/input.md
+++ b/src/components/input/input.md
@@ -112,6 +112,8 @@ import { Input, Label, TextField } from 'heroui-native';
 
 When rendering an Input inside a `BottomSheet`, use the `useBottomSheetAwareHandlers` hook to wire keyboard avoidance handlers. Pass the returned `onFocus` and `onBlur` to the Input.
 
+> **Note**: `useBottomSheetAwareHandlers` must be used inside a `BottomSheet`. Call it from a child component rendered inside `BottomSheet.Content` — outside of a `BottomSheet` context the returned handlers are no-ops.
+
 ```tsx
 import { Input, TextField, useBottomSheetAwareHandlers } from 'heroui-native';
 

--- a/src/components/input/input.styles.ts
+++ b/src/components/input/input.styles.ts
@@ -6,7 +6,8 @@ const input = tv({
   base: 'py-3.5 px-3 rounded-2xl text-foreground font-normal border-[1.5px] focus:border-accent',
   variants: {
     variant: {
-      primary: 'bg-field border-field ios:shadow-field android:shadow-sm',
+      primary:
+        'bg-field border-field-border ios:shadow-field android:shadow-sm',
       secondary: 'bg-default border-default',
     },
     isInvalid: {

--- a/src/components/input/input.styles.ts
+++ b/src/components/input/input.styles.ts
@@ -3,7 +3,7 @@ import { tv } from 'tailwind-variants';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const input = tv({
-  base: 'py-3.5 px-3 rounded-2xl text-foreground font-normal border-[1.5px] focus:border-accent',
+  base: 'min-h-12 px-3 rounded-2xl text-foreground font-normal border-[1.5px] focus:border-accent',
   variants: {
     variant: {
       primary:

--- a/src/components/scroll-shadow/scroll-shadow.tsx
+++ b/src/components/scroll-shadow/scroll-shadow.tsx
@@ -85,6 +85,13 @@ const ScrollShadowRoot = forwardRef<View, ScrollShadowProps>((props, ref) => {
   const orientation =
     orientationProp || (childHorizontal ? 'horizontal' : 'vertical');
 
+  const inverted =
+    children?.props &&
+    typeof children?.props === 'object' &&
+    'inverted' in children.props
+      ? children.props.inverted
+      : false;
+
   // Get all animation logic from root hook
   const {
     contentSize,
@@ -99,6 +106,11 @@ const ScrollShadowRoot = forwardRef<View, ScrollShadowProps>((props, ref) => {
     visibility,
     isEnabled,
   });
+
+  // When inverted, swap which animated style drives each visual edge so that
+  // shadows appear at the correct edge from the user's perspective.
+  const topEdgeShadowStyle = inverted ? bottomShadowStyle : topShadowStyle;
+  const bottomEdgeShadowStyle = inverted ? topShadowStyle : bottomShadowStyle;
 
   const onContentSizeChange = (w: number, h: number) => {
     const contentDimension = orientation === 'vertical' ? h : w;
@@ -180,7 +192,7 @@ const ScrollShadowRoot = forwardRef<View, ScrollShadowProps>((props, ref) => {
           style={[
             scrollShadowStyleSheet.topShadow,
             { height: size },
-            topShadowStyle,
+            topEdgeShadowStyle,
           ]}
         >
           <LinearGradientComponent
@@ -194,7 +206,7 @@ const ScrollShadowRoot = forwardRef<View, ScrollShadowProps>((props, ref) => {
           style={[
             scrollShadowStyleSheet.leftShadow,
             { width: size },
-            topShadowStyle,
+            topEdgeShadowStyle,
           ]}
         >
           <LinearGradientComponent
@@ -213,7 +225,7 @@ const ScrollShadowRoot = forwardRef<View, ScrollShadowProps>((props, ref) => {
           style={[
             scrollShadowStyleSheet.bottomShadow,
             { height: size },
-            bottomShadowStyle,
+            bottomEdgeShadowStyle,
           ]}
         >
           <LinearGradientComponent
@@ -227,7 +239,7 @@ const ScrollShadowRoot = forwardRef<View, ScrollShadowProps>((props, ref) => {
           style={[
             scrollShadowStyleSheet.rightShadow,
             { width: size },
-            bottomShadowStyle,
+            bottomEdgeShadowStyle,
           ]}
         >
           <LinearGradientComponent

--- a/src/components/search-field/search-field.tsx
+++ b/src/components/search-field/search-field.tsx
@@ -60,7 +60,7 @@ const SearchFieldRoot = forwardRef<ViewRef, SearchFieldProps>((props, ref) => {
   );
 
   const formFieldContextValue = useMemo(
-    () => ({ isDisabled, isInvalid, isRequired, hasFieldPadding: true }),
+    () => ({ isDisabled, isInvalid, isRequired, hasFieldPadding: false }),
     [isDisabled, isInvalid, isRequired]
   );
 

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -213,19 +213,6 @@ const SelectTriggerIndicator = forwardRef<ViewRef, SelectTriggerIndicatorProps>(
       ? [rContainerStyle, style]
       : style;
 
-    if (children) {
-      return (
-        <AnimatedTriggerIndicator
-          ref={ref}
-          className={triggerIndicatorClassName}
-          style={style}
-          {...restProps}
-        >
-          {children}
-        </AnimatedTriggerIndicator>
-      );
-    }
-
     return (
       <AnimatedTriggerIndicator
         ref={ref}
@@ -233,10 +220,12 @@ const SelectTriggerIndicator = forwardRef<ViewRef, SelectTriggerIndicatorProps>(
         style={triggerIndicatorStyle}
         {...restProps}
       >
-        <ChevronDownIcon
-          size={iconProps?.size ?? DEFAULT_ICON_SIZE}
-          color={iconProps?.color ?? themeColorForeground}
-        />
+        {children ?? (
+          <ChevronDownIcon
+            size={iconProps?.size ?? DEFAULT_ICON_SIZE}
+            color={iconProps?.color ?? themeColorForeground}
+          />
+        )}
       </AnimatedTriggerIndicator>
     );
   }

--- a/src/components/tabs/tabs.animation.ts
+++ b/src/components/tabs/tabs.animation.ts
@@ -1,3 +1,4 @@
+import { I18nManager } from 'react-native';
 import {
   useAnimatedStyle,
   useSharedValue,
@@ -22,6 +23,8 @@ import type {
   TabsIndicatorAnimation,
   TabsSeparatorAnimation,
 } from './tabs.types';
+
+const isRTL = I18nManager.isRTL;
 
 // --------------------------------------------------
 
@@ -54,7 +57,7 @@ export function useTabsIndicatorAnimation(options: {
 
   // Get active measurements from tabs context
   const { value } = TabsPrimitives.useRootContext();
-  const { measurements } = useTabsMeasurements();
+  const { listWidth, measurements } = useTabsMeasurements();
   const activeMeasurements = measurements[value];
 
   // Read from global animation context (always available in compound parts)
@@ -116,12 +119,18 @@ export function useTabsIndicatorAnimation(options: {
       };
     }
 
+    const translateX = getIndicatorTranslateX({
+      listWidth,
+      tabWidth: activeMeasurements.width,
+      tabX: activeMeasurements.x,
+    });
+
     if (!hasMeasured.value) {
       hasMeasured.value = true;
       return {
         width: activeMeasurements.width,
         height: activeMeasurements.height,
-        transform: [{ translateX: activeMeasurements.x }],
+        transform: [{ translateX }],
         opacity: 1,
       };
     }
@@ -131,7 +140,7 @@ export function useTabsIndicatorAnimation(options: {
       return {
         width: activeMeasurements.width,
         height: activeMeasurements.height,
-        transform: [{ translateX: activeMeasurements.x }],
+        transform: [{ translateX }],
         opacity: 1,
       };
     }
@@ -149,8 +158,8 @@ export function useTabsIndicatorAnimation(options: {
 
     const translateXAnimation =
       translateXConfig.type === 'timing'
-        ? withTiming(activeMeasurements.x, translateXConfig.timingConfig)
-        : withSpring(activeMeasurements.x, translateXConfig.springConfig);
+        ? withTiming(translateX, translateXConfig.timingConfig)
+        : withSpring(translateX, translateXConfig.springConfig);
 
     return {
       width: widthAnimation,
@@ -161,6 +170,7 @@ export function useTabsIndicatorAnimation(options: {
   }, [
     activeMeasurements,
     isAnimationDisabledValue,
+    listWidth,
     widthConfig,
     heightConfig,
     translateXConfig,
@@ -169,6 +179,22 @@ export function useTabsIndicatorAnimation(options: {
   return {
     rContainerStyle,
   };
+}
+
+function getIndicatorTranslateX({
+  listWidth,
+  tabWidth,
+  tabX,
+}: {
+  listWidth: number;
+  tabWidth: number;
+  tabX: number;
+}) {
+  if (!(isRTL && listWidth > 0)) {
+    return tabX;
+  }
+
+  return tabX - (listWidth - tabWidth);
 }
 
 // --------------------------------------------------

--- a/src/components/tabs/tabs.animation.ts
+++ b/src/components/tabs/tabs.animation.ts
@@ -126,6 +126,15 @@ export function useTabsIndicatorAnimation(options: {
     });
 
     if (!hasMeasured.value) {
+      if (isRTL && listWidth === 0) {
+        return {
+          width: 0,
+          height: 0,
+          transform: [{ translateX: 0 }],
+          opacity: 0,
+        };
+      }
+
       hasMeasured.value = true;
       return {
         width: activeMeasurements.width,
@@ -190,6 +199,7 @@ function getIndicatorTranslateX({
   tabWidth: number;
   tabX: number;
 }) {
+  'worklet';
   if (!(isRTL && listWidth > 0)) {
     return tabX;
   }

--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -63,6 +63,7 @@ const TabsRoot = forwardRef<TabsPrimitivesTypes.RootRef, TabsProps>(
     const [measurements, setMeasurementsState] = useState<
       Record<string, ItemMeasurements>
     >({});
+    const [listWidth, setListWidth] = useState(0);
     const [isScrollView, setIsScrollView] = useState(false);
 
     const setMeasurements = useCallback(
@@ -92,6 +93,8 @@ const TabsRoot = forwardRef<TabsPrimitivesTypes.RootRef, TabsProps>(
           value={{
             measurements,
             setMeasurements,
+            listWidth,
+            setListWidth,
             variant,
             isScrollView,
             setIsScrollView,
@@ -116,19 +119,28 @@ const TabsRoot = forwardRef<TabsPrimitivesTypes.RootRef, TabsProps>(
 
 const TabsList = forwardRef<TabsPrimitivesTypes.ListRef, TabsListProps>(
   (props, ref) => {
-    const { children, className, style, ...restProps } = props;
+    const { children, className, style, onLayout, ...restProps } = props;
 
-    const { variant, setIsScrollView } = useTabsMeasurements();
+    const { variant, setIsScrollView, setListWidth } = useTabsMeasurements();
 
-    const handleLayout = useCallback(() => {
-      const childrenArray = Children.toArray(children);
-      const hasScrollView =
-        childrenArray.length === 1 &&
-        isValidElement(childrenArray[0]) &&
-        (childrenArray[0].type as any)?.displayName ===
-          DISPLAY_NAME.SCROLL_VIEW;
-      setIsScrollView(hasScrollView);
-    }, [children, setIsScrollView]);
+    const handleLayout = useCallback(
+      (event: LayoutChangeEvent) => {
+        onLayout?.(event);
+
+        const childrenArray = Children.toArray(children);
+        const hasScrollView =
+          childrenArray.length === 1 &&
+          isValidElement(childrenArray[0]) &&
+          (childrenArray[0].type as any)?.displayName ===
+            DISPLAY_NAME.SCROLL_VIEW;
+        setIsScrollView(hasScrollView);
+
+        if (!hasScrollView) {
+          setListWidth(event.nativeEvent.layout.width);
+        }
+      },
+      [children, onLayout, setIsScrollView, setListWidth]
+    );
 
     const listClassName = tabsClassNames.list({ variant, className });
 
@@ -154,13 +166,14 @@ const TabsScrollView = forwardRef<ScrollView, TabsScrollViewProps>(
       children,
       className,
       contentContainerClassName,
+      onContentSizeChange,
       showsHorizontalScrollIndicator = false,
       scrollAlign = 'center',
       ...restProps
     } = props;
 
     const { value } = useTabs();
-    const { measurements, variant } = useTabsMeasurements();
+    const { measurements, setListWidth, variant } = useTabsMeasurements();
     const { width: screenWidth } = useWindowDimensions();
 
     const scrollViewClassName = tabsClassNames.scrollView({
@@ -174,6 +187,14 @@ const TabsScrollView = forwardRef<ScrollView, TabsScrollViewProps>(
       });
 
     const scrollRef = useRef<ScrollView>(null);
+
+    const handleContentSizeChange = useCallback(
+      (width: number, height: number) => {
+        setListWidth(width);
+        onContentSizeChange?.(width, height);
+      },
+      [onContentSizeChange, setListWidth]
+    );
 
     useEffect(() => {
       if (scrollAlign === 'none' || !measurements[value]) return;
@@ -210,6 +231,7 @@ const TabsScrollView = forwardRef<ScrollView, TabsScrollViewProps>(
         showsHorizontalScrollIndicator={showsHorizontalScrollIndicator}
         className={scrollViewClassName}
         contentContainerClassName={contentContainerClassNameValue}
+        onContentSizeChange={handleContentSizeChange}
         {...restProps}
       >
         {children}

--- a/src/components/tabs/tabs.types.ts
+++ b/src/components/tabs/tabs.types.ts
@@ -335,6 +335,8 @@ export type ItemMeasurements = {
 export type MeasurementsContextValue = {
   measurements: Record<string, ItemMeasurements>;
   setMeasurements: (key: string, measurements: ItemMeasurements) => void;
+  listWidth: number;
+  setListWidth: (width: number) => void;
   variant: 'primary' | 'secondary';
   isScrollView: boolean;
   setIsScrollView: (isScrollView: boolean) => void;

--- a/src/components/text-field/text-field.tsx
+++ b/src/components/text-field/text-field.tsx
@@ -42,7 +42,7 @@ const TextFieldRoot = forwardRef<ViewRef, TextFieldRootProps>((props, ref) => {
   );
 
   const formFieldContextValue = useMemo(
-    () => ({ isDisabled, isInvalid, isRequired, hasFieldPadding: true }),
+    () => ({ isDisabled, isInvalid, isRequired, hasFieldPadding: false }),
     [isDisabled, isInvalid, isRequired]
   );
 

--- a/src/components/text/index.ts
+++ b/src/components/text/index.ts
@@ -1,0 +1,10 @@
+export { default as Text } from './text';
+export { textClassNames } from './text.styles';
+export type {
+  TextCodeProps,
+  TextHeadingProps,
+  TextParagraphProps,
+  TextProseProps,
+  TextRootProps,
+  TextType,
+} from './text.types';

--- a/src/components/text/index.ts
+++ b/src/components/text/index.ts
@@ -1,9 +1,12 @@
 export { default as Text } from './text';
 export { textClassNames } from './text.styles';
 export type {
+  TextAlign,
   TextCodeProps,
+  TextColor,
   TextHeadingProps,
   TextParagraphProps,
   TextRootProps,
   TextType,
+  TextWeight,
 } from './text.types';

--- a/src/components/text/index.ts
+++ b/src/components/text/index.ts
@@ -4,7 +4,6 @@ export type {
   TextCodeProps,
   TextHeadingProps,
   TextParagraphProps,
-  TextProseProps,
   TextRootProps,
   TextType,
 } from './text.types';

--- a/src/components/text/text.constants.ts
+++ b/src/components/text/text.constants.ts
@@ -1,0 +1,17 @@
+/**
+ * Display names for Text components
+ */
+export const DISPLAY_NAME = {
+  TEXT_ROOT: 'HeroUINative.Text',
+  TEXT_HEADING: 'HeroUINative.Text.Heading',
+  TEXT_PARAGRAPH: 'HeroUINative.Text.Paragraph',
+  TEXT_CODE: 'HeroUINative.Text.Code',
+  TEXT_PROSE: 'HeroUINative.Text.Prose',
+} as const;
+
+/**
+ * Monospaced font family fallback for the Code sub-component.
+ * Platform-specific monospace defaults are handled by RN when this value
+ * is used as `fontFamily`.
+ */
+export const CODE_FONT_FAMILY = 'monospace';

--- a/src/components/text/text.constants.ts
+++ b/src/components/text/text.constants.ts
@@ -9,8 +9,9 @@ export const DISPLAY_NAME = {
 } as const;
 
 /**
- * Monospaced font family fallback for the Code sub-component.
- * Platform-specific monospace defaults are handled by RN when this value
- * is used as `fontFamily`.
+ * Monospaced font family used by `Text.Code` on Android and web.
+ *
+ * iOS uses `'Menlo'` directly; the platform branch lives in
+ * `styleSheet.code` in `text.styles.ts`.
  */
 export const CODE_FONT_FAMILY = 'monospace';

--- a/src/components/text/text.constants.ts
+++ b/src/components/text/text.constants.ts
@@ -6,7 +6,6 @@ export const DISPLAY_NAME = {
   TEXT_HEADING: 'HeroUINative.Text.Heading',
   TEXT_PARAGRAPH: 'HeroUINative.Text.Paragraph',
   TEXT_CODE: 'HeroUINative.Text.Code',
-  TEXT_PROSE: 'HeroUINative.Text.Prose',
 } as const;
 
 /**

--- a/src/components/text/text.md
+++ b/src/components/text/text.md
@@ -1,0 +1,177 @@
+# Text
+
+Primitive typography component for rendering styled text with semantic type variants.
+
+## Import
+
+```tsx
+import { Text } from 'heroui-native';
+```
+
+## Anatomy
+
+```tsx
+<Text>...</Text>
+
+{/* Sub-components */}
+<Text.Heading>...</Text.Heading>
+<Text.Paragraph>...</Text.Paragraph>
+<Text.Code>...</Text.Code>
+<Text.Prose>...</Text.Prose>
+```
+
+- **Text**: Root text element. The `type` prop selects a semantic typography preset (heading, body, or code).
+- **Text.Heading**: Convenience wrapper restricted to heading types (`h1`–`h6`). Adds `accessibilityRole="header"` automatically.
+- **Text.Paragraph**: Convenience wrapper restricted to body types (`body`, `body-sm`, `body-xs`).
+- **Text.Code**: Renders monospaced text using a platform-appropriate monospace font family.
+- **Text.Prose**: Minimal wrapper for longer body text passages. Currently equivalent to `body` type.
+
+## Usage
+
+### Basic Usage
+
+The Text component renders body text by default.
+
+```tsx
+<Text>Hello, world!</Text>
+```
+
+### Type Variants
+
+Use the `type` prop to select a semantic typography preset.
+
+```tsx
+<Text type="h1">Heading 1</Text>
+<Text type="h2">Heading 2</Text>
+<Text type="h3">Heading 3</Text>
+<Text type="h4">Heading 4</Text>
+<Text type="h5">Heading 5</Text>
+<Text type="h6">Heading 6</Text>
+<Text type="body">Body text</Text>
+<Text type="body-sm">Small body text</Text>
+<Text type="body-xs">Extra-small body text</Text>
+<Text type="code">Code snippet</Text>
+```
+
+### Headings
+
+Use `Text.Heading` for heading text with automatic header accessibility role.
+
+```tsx
+<Text.Heading type="h1">Page Title</Text.Heading>
+<Text.Heading type="h2">Section Title</Text.Heading>
+<Text.Heading type="h3">Subsection Title</Text.Heading>
+```
+
+### Paragraphs
+
+Use `Text.Paragraph` for body text.
+
+```tsx
+<Text.Paragraph>
+  This is a paragraph of body text with the default size.
+</Text.Paragraph>
+<Text.Paragraph type="body-sm">
+  This is smaller body text.
+</Text.Paragraph>
+```
+
+### Code
+
+Use `Text.Code` for inline code snippets with monospaced font.
+
+```tsx
+<Text.Code>console.log('hello')</Text.Code>
+```
+
+### Prose
+
+Use `Text.Prose` for longer passages of body text.
+
+```tsx
+<Text.Prose>
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
+  tempor incididunt ut labore et dolore magna aliqua.
+</Text.Prose>
+```
+
+### Custom Styling
+
+Override or extend styles with the `className` prop.
+
+```tsx
+<Text type="h1" className="text-accent">Colored Heading</Text>
+<Text type="body" className="text-muted">Muted body text</Text>
+```
+
+## Example
+
+```tsx
+import { Text } from 'heroui-native';
+import { View } from 'react-native';
+
+export default function TextExample() {
+  return (
+    <View className="flex-1 justify-center px-5 gap-4">
+      <Text.Heading type="h1">Welcome</Text.Heading>
+      <Text.Heading type="h3">Getting Started</Text.Heading>
+      <Text.Paragraph>
+        This is a body paragraph rendered with the Text component.
+      </Text.Paragraph>
+      <Text.Paragraph type="body-sm">
+        Smaller supporting text for captions or footnotes.
+      </Text.Paragraph>
+      <Text.Code>npm install heroui-native</Text.Code>
+    </View>
+  );
+}
+```
+
+You can find more examples in the [GitHub repository](<https://github.com/heroui-inc/heroui-native/blob/main/example/src/app/(home)/components/text.tsx>).
+
+## API Reference
+
+### Text
+
+Text extends all standard React Native `TextProps` with additional typography props.
+
+| prop           | type                                                                                            | default  | description                                         |
+| -------------- | ----------------------------------------------------------------------------------------------- | -------- | --------------------------------------------------- |
+| `type`         | `'h1' \| 'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6' \| 'body' \| 'body-sm' \| 'body-xs' \| 'code'` | `'body'` | Semantic typography variant                         |
+| `children`     | `React.ReactNode`                                                                               | -        | Content to render                                   |
+| `className`    | `string`                                                                                        | -        | Additional CSS classes                              |
+| `...TextProps` | `TextProps`                                                                                     | -        | All standard React Native Text props are supported  |
+
+### Text.Heading
+
+| prop           | type                                                  | default | description                                        |
+| -------------- | ----------------------------------------------------- | ------- | -------------------------------------------------- |
+| `type`         | `'h1' \| 'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6'`      | `'h1'`  | Heading level                                      |
+| `children`     | `React.ReactNode`                                     | -       | Content to render                                  |
+| `className`    | `string`                                              | -       | Additional CSS classes                             |
+| `...TextProps` | `TextProps`                                            | -       | All standard React Native Text props are supported |
+
+### Text.Paragraph
+
+| prop           | type                                       | default  | description                                        |
+| -------------- | ------------------------------------------ | -------- | -------------------------------------------------- |
+| `type`         | `'body' \| 'body-sm' \| 'body-xs'`         | `'body'` | Paragraph text size                                |
+| `children`     | `React.ReactNode`                          | -        | Content to render                                  |
+| `className`    | `string`                                   | -        | Additional CSS classes                             |
+| `...TextProps` | `TextProps`                                | -        | All standard React Native Text props are supported |
+
+### Text.Code
+
+| prop           | type              | default | description                                        |
+| -------------- | ----------------- | ------- | -------------------------------------------------- |
+| `children`     | `React.ReactNode` | -       | Content to render                                  |
+| `className`    | `string`          | -       | Additional CSS classes                             |
+| `...TextProps` | `TextProps`       | -       | All standard React Native Text props are supported |
+
+### Text.Prose
+
+| prop           | type              | default | description                                        |
+| -------------- | ----------------- | ------- | -------------------------------------------------- |
+| `children`     | `React.ReactNode` | -       | Content to render                                  |
+| `className`    | `string`          | -       | Additional CSS classes                             |
+| `...TextProps` | `TextProps`       | -       | All standard React Native Text props are supported |

--- a/src/components/text/text.md
+++ b/src/components/text/text.md
@@ -19,10 +19,10 @@ import { Text } from 'heroui-native';
 <Text.Code>...</Text.Code>
 ```
 
-- **Text**: Root text element. The `type` prop selects a semantic typography preset (heading, body, or code).
+- **Text**: Root text element. Selects a typography preset via `type` and exposes orthogonal `align`, `color`, `weight`, and `truncate` props.
 - **Text.Heading**: Convenience wrapper restricted to heading types (`h1`–`h6`). Adds `accessibilityRole="header"` automatically.
 - **Text.Paragraph**: Convenience wrapper restricted to body types (`body`, `body-sm`, `body-xs`).
-- **Text.Code**: Renders monospaced text using a platform-appropriate monospace font family.
+- **Text.Code**: Chip-styled inline monospaced text. Uses a platform-appropriate monospace font family.
 
 ## Usage
 
@@ -76,19 +76,64 @@ Use `Text.Paragraph` for body text.
 
 ### Code
 
-Use `Text.Code` for inline code snippets with monospaced font.
+Use `Text.Code` (or equivalently `<Text type="code">`) for inline code snippets. Both render a chip-styled, monospaced inline element with a subtle background, rounded corners, and a `self-start` layout so it does not stretch in flex containers. The platform monospace `fontFamily` is applied at the `Text` root, so the two forms are interchangeable.
 
 ```tsx
 <Text.Code>console.log('hello')</Text.Code>
+<Text type="code">console.log('hello')</Text>
 ```
 
-### Custom Styling
+### Alignment
 
-Override or extend styles with the `className` prop.
+Use the `align` prop to control horizontal alignment. `start` and `end` are RTL-aware (they flip under right-to-left layouts).
 
 ```tsx
-<Text type="h1" className="text-accent">Colored Heading</Text>
-<Text type="body" className="text-muted">Muted body text</Text>
+<Text align="start">Start-aligned</Text>
+<Text align="center">Center-aligned</Text>
+<Text align="end">End-aligned</Text>
+<Text align="justify">Justified text spreads across the line.</Text>
+```
+
+> **Note:** `text-justify` is iOS-only on React Native; Android falls back to left alignment.
+
+### Color
+
+Use the `color` prop to apply a semantic foreground color preset.
+
+```tsx
+<Text color="default">Default foreground</Text>
+<Text color="muted">Muted secondary text</Text>
+```
+
+For other theme colors, pass the corresponding utility through `className` (e.g. `className="text-accent"`, `className="text-danger"`).
+
+### Weight
+
+Use the `weight` prop to override the font weight implied by `type`. The override merges via `tailwind-merge`, so it always wins over the type variant's default weight.
+
+```tsx
+<Text type="h1" weight="bold">Bold H1</Text>
+<Text weight="medium">Medium body</Text>
+<Text weight="semibold">Semibold body</Text>
+```
+
+### Truncation
+
+Use the `truncate` boolean prop to limit the text to a single line with an ellipsis. It is mapped to React Native's `numberOfLines={1}`. An explicit `numberOfLines` prop, if provided, takes precedence.
+
+```tsx
+<Text truncate>
+  A long line of text that will be cut off with an ellipsis when it overflows
+  the container.
+</Text>;
+
+{
+  /* Multi-line truncation via the underlying RN prop */
+}
+<Text numberOfLines={2}>
+  Two-line truncation works through React Native's standard `numberOfLines`
+  prop.
+</Text>;
 ```
 
 ## Example
@@ -105,7 +150,7 @@ export default function TextExample() {
       <Text.Paragraph>
         This is a body paragraph rendered with the Text component.
       </Text.Paragraph>
-      <Text.Paragraph type="body-sm">
+      <Text.Paragraph color="muted" type="body-sm">
         Smaller supporting text for captions or footnotes.
       </Text.Paragraph>
       <Text.Code>npm install heroui-native</Text.Code>
@@ -120,37 +165,47 @@ You can find more examples in the [GitHub repository](<https://github.com/heroui
 
 ### Text
 
-Text extends all standard React Native `TextProps` with additional typography props.
+`Text` extends all standard React Native `TextProps` with additional typography props.
 
-| prop           | type                                                                                            | default  | description                                         |
-| -------------- | ----------------------------------------------------------------------------------------------- | -------- | --------------------------------------------------- |
-| `type`         | `'h1' \| 'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6' \| 'body' \| 'body-sm' \| 'body-xs' \| 'code'` | `'body'` | Semantic typography variant                         |
-| `children`     | `React.ReactNode`                                                                               | -        | Content to render                                   |
-| `className`    | `string`                                                                                        | -        | Additional CSS classes                              |
-| `...TextProps` | `TextProps`                                                                                     | -        | All standard React Native Text props are supported  |
+| prop           | type                                                                                         | default     | description                                                                                                                    |
+| -------------- | -------------------------------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `type`         | `'h1' \| 'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6' \| 'body' \| 'body-sm' \| 'body-xs' \| 'code'` | `'body'`    | Semantic typography variant (size, default weight, line-height)                                                                |
+| `align`        | `'start' \| 'center' \| 'end' \| 'justify'`                                                  | `'start'`   | Horizontal alignment. `start` and `end` are RTL-aware. `justify` is iOS-only.                                                  |
+| `color`        | `'default' \| 'muted'`                                                                       | `'default'` | Semantic foreground color preset                                                                                               |
+| `weight`       | `'normal' \| 'medium' \| 'semibold' \| 'bold'`                                               | -           | Font weight override. When set, overrides the weight implied by `type`.                                                        |
+| `truncate`     | `boolean`                                                                                    | `false`     | Truncates the text to a single line with an ellipsis (sets `numberOfLines={1}`). An explicit `numberOfLines` takes precedence. |
+| `children`     | `React.ReactNode`                                                                            | -           | Content to render                                                                                                              |
+| `className`    | `string`                                                                                     | -           | Additional CSS classes                                                                                                         |
+| `...TextProps` | `TextProps`                                                                                  | -           | All standard React Native `Text` props are supported                                                                           |
 
 ### Text.Heading
 
-| prop           | type                                                  | default | description                                        |
-| -------------- | ----------------------------------------------------- | ------- | -------------------------------------------------- |
-| `type`         | `'h1' \| 'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6'`      | `'h1'`  | Heading level                                      |
-| `children`     | `React.ReactNode`                                     | -       | Content to render                                  |
-| `className`    | `string`                                              | -       | Additional CSS classes                             |
-| `...TextProps` | `TextProps`                                            | -       | All standard React Native Text props are supported |
+Inherits all `Text` root props (`align`, `color`, `weight`, `truncate`, `className`, and React Native `TextProps`). Sets `accessibilityRole="header"` automatically and narrows `type` to heading variants.
+
+| prop           | type                                           | default | description                                          |
+| -------------- | ---------------------------------------------- | ------- | ---------------------------------------------------- |
+| `type`         | `'h1' \| 'h2' \| 'h3' \| 'h4' \| 'h5' \| 'h6'` | `'h1'`  | Heading level                                        |
+| `children`     | `React.ReactNode`                              | -       | Content to render                                    |
+| `className`    | `string`                                       | -       | Additional CSS classes                               |
+| `...TextProps` | `TextProps`                                    | -       | All standard React Native `Text` props are supported |
 
 ### Text.Paragraph
 
-| prop           | type                                       | default  | description                                        |
-| -------------- | ------------------------------------------ | -------- | -------------------------------------------------- |
-| `type`         | `'body' \| 'body-sm' \| 'body-xs'`         | `'body'` | Paragraph text size                                |
-| `children`     | `React.ReactNode`                          | -        | Content to render                                  |
-| `className`    | `string`                                   | -        | Additional CSS classes                             |
-| `...TextProps` | `TextProps`                                | -        | All standard React Native Text props are supported |
+Inherits all `Text` root props (`align`, `color`, `weight`, `truncate`, `className`, and React Native `TextProps`). Narrows `type` to body variants.
+
+| prop           | type                               | default  | description                                          |
+| -------------- | ---------------------------------- | -------- | ---------------------------------------------------- |
+| `type`         | `'body' \| 'body-sm' \| 'body-xs'` | `'body'` | Paragraph text size                                  |
+| `children`     | `React.ReactNode`                  | -        | Content to render                                    |
+| `className`    | `string`                           | -        | Additional CSS classes                               |
+| `...TextProps` | `TextProps`                        | -        | All standard React Native `Text` props are supported |
 
 ### Text.Code
 
-| prop           | type              | default | description                                        |
-| -------------- | ----------------- | ------- | -------------------------------------------------- |
-| `children`     | `React.ReactNode` | -       | Content to render                                  |
-| `className`    | `string`          | -       | Additional CSS classes                             |
-| `...TextProps` | `TextProps`       | -       | All standard React Native Text props are supported |
+Inherits all `Text` root props (`align`, `color`, `weight`, `truncate`, `className`, `style`, and React Native `TextProps`). Thin wrapper that forces `type="code"`; the platform monospace `fontFamily` is merged in at the `Text` root, so `<Text type="code">` and `<Text.Code>` render identically.
+
+| prop           | type              | default | description                                          |
+| -------------- | ----------------- | ------- | ---------------------------------------------------- |
+| `children`     | `React.ReactNode` | -       | Content to render                                    |
+| `className`    | `string`          | -       | Additional CSS classes                               |
+| `...TextProps` | `TextProps`       | -       | All standard React Native `Text` props are supported |

--- a/src/components/text/text.md
+++ b/src/components/text/text.md
@@ -17,14 +17,12 @@ import { Text } from 'heroui-native';
 <Text.Heading>...</Text.Heading>
 <Text.Paragraph>...</Text.Paragraph>
 <Text.Code>...</Text.Code>
-<Text.Prose>...</Text.Prose>
 ```
 
 - **Text**: Root text element. The `type` prop selects a semantic typography preset (heading, body, or code).
 - **Text.Heading**: Convenience wrapper restricted to heading types (`h1`–`h6`). Adds `accessibilityRole="header"` automatically.
 - **Text.Paragraph**: Convenience wrapper restricted to body types (`body`, `body-sm`, `body-xs`).
 - **Text.Code**: Renders monospaced text using a platform-appropriate monospace font family.
-- **Text.Prose**: Minimal wrapper for longer body text passages. Currently equivalent to `body` type.
 
 ## Usage
 
@@ -82,17 +80,6 @@ Use `Text.Code` for inline code snippets with monospaced font.
 
 ```tsx
 <Text.Code>console.log('hello')</Text.Code>
-```
-
-### Prose
-
-Use `Text.Prose` for longer passages of body text.
-
-```tsx
-<Text.Prose>
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
-  tempor incididunt ut labore et dolore magna aliqua.
-</Text.Prose>
 ```
 
 ### Custom Styling
@@ -161,14 +148,6 @@ Text extends all standard React Native `TextProps` with additional typography pr
 | `...TextProps` | `TextProps`                                | -        | All standard React Native Text props are supported |
 
 ### Text.Code
-
-| prop           | type              | default | description                                        |
-| -------------- | ----------------- | ------- | -------------------------------------------------- |
-| `children`     | `React.ReactNode` | -       | Content to render                                  |
-| `className`    | `string`          | -       | Additional CSS classes                             |
-| `...TextProps` | `TextProps`       | -       | All standard React Native Text props are supported |
-
-### Text.Prose
 
 | prop           | type              | default | description                                        |
 | -------------- | ----------------- | ------- | -------------------------------------------------- |

--- a/src/components/text/text.styles.ts
+++ b/src/components/text/text.styles.ts
@@ -1,0 +1,42 @@
+import { tv } from 'tailwind-variants';
+import { combineStyles } from '../../helpers/internal/utils';
+
+/**
+ * Typography style map driven by Tailwind utility classes.
+ *
+ * Token mapping rationale (derived from existing native component usage):
+ *   h1  → text-3xl  font-bold       (largest heading)
+ *   h2  → text-2xl  font-bold
+ *   h3  → text-xl   font-semibold
+ *   h4  → text-lg   font-semibold
+ *   h5  → text-base font-semibold
+ *   h6  → text-sm   font-semibold
+ *   body    → text-base font-normal  (default running text, matches HeroText)
+ *   body-sm → text-sm   font-normal
+ *   body-xs → text-xs   font-normal
+ *   code    → text-sm   font-normal  (monospaced via fontFamily style)
+ */
+const root = tv({
+  base: 'text-foreground',
+  variants: {
+    type: {
+      'h1': 'text-3xl font-bold',
+      'h2': 'text-2xl font-bold',
+      'h3': 'text-xl font-semibold',
+      'h4': 'text-lg font-semibold',
+      'h5': 'text-base font-semibold',
+      'h6': 'text-sm font-semibold',
+      'body': 'text-base font-normal',
+      'body-sm': 'text-sm font-normal',
+      'body-xs': 'text-xs font-normal',
+      'code': 'text-sm font-normal',
+    },
+  },
+  defaultVariants: {
+    type: 'body',
+  },
+});
+
+export const textClassNames = combineStyles({
+  root,
+});

--- a/src/components/text/text.styles.ts
+++ b/src/components/text/text.styles.ts
@@ -1,42 +1,57 @@
+import { Platform, StyleSheet } from 'react-native';
 import { tv } from 'tailwind-variants';
 import { combineStyles } from '../../helpers/internal/utils';
+import { CODE_FONT_FAMILY } from './text.constants';
 
-/**
- * Typography style map driven by Tailwind utility classes.
- *
- * Token mapping rationale (derived from existing native component usage):
- *   h1  → text-3xl  font-bold       (largest heading)
- *   h2  → text-2xl  font-bold
- *   h3  → text-xl   font-semibold
- *   h4  → text-lg   font-semibold
- *   h5  → text-base font-semibold
- *   h6  → text-sm   font-semibold
- *   body    → text-base font-normal  (default running text, matches HeroText)
- *   body-sm → text-sm   font-normal
- *   body-xs → text-xs   font-normal
- *   code    → text-sm   font-normal  (monospaced via fontFamily style)
- */
 const root = tv({
-  base: 'text-foreground',
+  base: 'font-normal',
   variants: {
     type: {
-      'h1': 'text-3xl font-bold',
-      'h2': 'text-2xl font-bold',
-      'h3': 'text-xl font-semibold',
-      'h4': 'text-lg font-semibold',
-      'h5': 'text-base font-semibold',
-      'h6': 'text-sm font-semibold',
-      'body': 'text-base font-normal',
-      'body-sm': 'text-sm font-normal',
-      'body-xs': 'text-xs font-normal',
-      'code': 'text-sm font-normal',
+      'h1': 'text-4xl font-semibold tracking-tight',
+      'h2': 'text-3xl font-semibold tracking-tight',
+      'h3': 'text-2xl font-semibold tracking-tight',
+      'h4': 'text-xl font-semibold tracking-tight',
+      'h5': 'text-lg font-semibold tracking-tight',
+      'h6': 'text-base font-semibold tracking-tight',
+      'body': 'text-base leading-7',
+      'body-sm': 'text-sm leading-6',
+      'body-xs': 'text-xs leading-5',
+      'code': 'self-start text-sm rounded-md bg-default px-1.5 py-0.5',
+    },
+    align: {
+      start: 'text-left rtl:text-right',
+      center: 'text-center',
+      end: 'text-right rtl:text-left',
+      justify: 'text-justify',
+    },
+    color: {
+      default: 'text-foreground',
+      muted: 'text-muted',
+    },
+    weight: {
+      normal: 'font-normal',
+      medium: 'font-medium',
+      semibold: 'font-semibold',
+      bold: 'font-bold',
     },
   },
   defaultVariants: {
     type: 'body',
+    align: 'start',
+    color: 'default',
   },
 });
 
 export const textClassNames = combineStyles({
   root,
+});
+
+export const styleSheet = StyleSheet.create({
+  code: {
+    fontFamily: Platform.select({
+      ios: 'Menlo',
+      android: CODE_FONT_FAMILY,
+      default: CODE_FONT_FAMILY,
+    }),
+  },
 });

--- a/src/components/text/text.tsx
+++ b/src/components/text/text.tsx
@@ -1,0 +1,122 @@
+import { forwardRef, useMemo } from 'react';
+import { Platform, StyleSheet } from 'react-native';
+import { HeroText } from '../../helpers/internal/components';
+import type { TextRef } from '../../helpers/internal/types';
+import { CODE_FONT_FAMILY, DISPLAY_NAME } from './text.constants';
+import { textClassNames } from './text.styles';
+import type {
+  TextCodeProps,
+  TextHeadingProps,
+  TextParagraphProps,
+  TextProseProps,
+  TextRootProps,
+} from './text.types';
+
+// --------------------------------------------------
+
+const TextRoot = forwardRef<TextRef, TextRootProps>((props, ref) => {
+  const { children, type = 'body', className, ...restProps } = props;
+
+  const rootClassName = textClassNames.root({ type, className });
+
+  return (
+    <HeroText ref={ref} className={rootClassName} {...restProps}>
+      {children}
+    </HeroText>
+  );
+});
+
+// --------------------------------------------------
+
+const TextHeading = forwardRef<TextRef, TextHeadingProps>((props, ref) => {
+  const { type = 'h1', accessibilityRole = 'header', ...restProps } = props;
+  return (
+    <TextRoot
+      ref={ref}
+      type={type}
+      accessibilityRole={accessibilityRole}
+      {...restProps}
+    />
+  );
+});
+
+// --------------------------------------------------
+
+const TextParagraph = forwardRef<TextRef, TextParagraphProps>((props, ref) => {
+  const { type = 'body', ...restProps } = props;
+  return <TextRoot ref={ref} type={type} {...restProps} />;
+});
+
+// --------------------------------------------------
+
+const TextCode = forwardRef<TextRef, TextCodeProps>((props, ref) => {
+  const { style, ...restProps } = props;
+
+  const mergedStyle = useMemo(
+    () =>
+      Array.isArray(style) ? [styles.code, ...style] : [styles.code, style],
+    [style]
+  );
+
+  return <TextRoot ref={ref} type="code" style={mergedStyle} {...restProps} />;
+});
+
+// --------------------------------------------------
+
+const TextProse = forwardRef<TextRef, TextProseProps>((props, ref) => {
+  return <TextRoot ref={ref} type="body" {...props} />;
+});
+
+// --------------------------------------------------
+
+TextRoot.displayName = DISPLAY_NAME.TEXT_ROOT;
+TextHeading.displayName = DISPLAY_NAME.TEXT_HEADING;
+TextParagraph.displayName = DISPLAY_NAME.TEXT_PARAGRAPH;
+TextCode.displayName = DISPLAY_NAME.TEXT_CODE;
+TextProse.displayName = DISPLAY_NAME.TEXT_PROSE;
+
+/**
+ * Compound Text component with semantic sub-components.
+ *
+ * @component Text - Generic text element with a `type` prop for semantic
+ * typography variants (headings, body, code). Maps each type to native
+ * typography tokens via Tailwind utility classes.
+ *
+ * @component Text.Heading - Convenience wrapper restricted to heading types
+ * (`h1`–`h6`). Sets `accessibilityRole="header"` automatically.
+ *
+ * @component Text.Paragraph - Convenience wrapper restricted to body types
+ * (`body`, `body-sm`, `body-xs`).
+ *
+ * @component Text.Code - Renders monospaced text using the `code` type and
+ * applies a platform monospace font family.
+ *
+ * @component Text.Prose - Minimal body-text wrapper intended for longer
+ * prose passages. Currently equivalent to `body` type.
+ *
+ * @see Full documentation: https://heroui.com/docs/native/components/text
+ */
+const CompoundText = Object.assign(TextRoot, {
+  /** Heading text – renders h1-h6 with header accessibility role */
+  Heading: TextHeading,
+  /** Paragraph text – renders body / body-sm / body-xs */
+  Paragraph: TextParagraph,
+  /** Code text – monospaced font with code styling */
+  Code: TextCode,
+  /** Prose text – long-form body content */
+  Prose: TextProse,
+});
+
+export default CompoundText;
+
+// --------------------------------------------------
+
+const styles = StyleSheet.create({
+  code: {
+    fontFamily: Platform.select({
+      ios: 'Menlo',
+      android: CODE_FONT_FAMILY,
+      default: CODE_FONT_FAMILY,
+    }),
+  },
+});

--- a/src/components/text/text.tsx
+++ b/src/components/text/text.tsx
@@ -8,7 +8,6 @@ import type {
   TextCodeProps,
   TextHeadingProps,
   TextParagraphProps,
-  TextProseProps,
   TextRootProps,
 } from './text.types';
 
@@ -63,17 +62,10 @@ const TextCode = forwardRef<TextRef, TextCodeProps>((props, ref) => {
 
 // --------------------------------------------------
 
-const TextProse = forwardRef<TextRef, TextProseProps>((props, ref) => {
-  return <TextRoot ref={ref} type="body" {...props} />;
-});
-
-// --------------------------------------------------
-
 TextRoot.displayName = DISPLAY_NAME.TEXT_ROOT;
 TextHeading.displayName = DISPLAY_NAME.TEXT_HEADING;
 TextParagraph.displayName = DISPLAY_NAME.TEXT_PARAGRAPH;
 TextCode.displayName = DISPLAY_NAME.TEXT_CODE;
-TextProse.displayName = DISPLAY_NAME.TEXT_PROSE;
 
 /**
  * Compound Text component with semantic sub-components.
@@ -91,9 +83,6 @@ TextProse.displayName = DISPLAY_NAME.TEXT_PROSE;
  * @component Text.Code - Renders monospaced text using the `code` type and
  * applies a platform monospace font family.
  *
- * @component Text.Prose - Minimal body-text wrapper intended for longer
- * prose passages. Currently equivalent to `body` type.
- *
  * @see Full documentation: https://heroui.com/docs/native/components/text
  */
 const CompoundText = Object.assign(TextRoot, {
@@ -103,8 +92,6 @@ const CompoundText = Object.assign(TextRoot, {
   Paragraph: TextParagraph,
   /** Code text – monospaced font with code styling */
   Code: TextCode,
-  /** Prose text – long-form body content */
-  Prose: TextProse,
 });
 
 export default CompoundText;

--- a/src/components/text/text.tsx
+++ b/src/components/text/text.tsx
@@ -1,9 +1,8 @@
-import { forwardRef, useMemo } from 'react';
-import { Platform, StyleSheet } from 'react-native';
+import { forwardRef } from 'react';
 import { HeroText } from '../../helpers/internal/components';
 import type { TextRef } from '../../helpers/internal/types';
-import { CODE_FONT_FAMILY, DISPLAY_NAME } from './text.constants';
-import { textClassNames } from './text.styles';
+import { DISPLAY_NAME } from './text.constants';
+import { styleSheet, textClassNames } from './text.styles';
 import type {
   TextCodeProps,
   TextHeadingProps,
@@ -14,12 +13,38 @@ import type {
 // --------------------------------------------------
 
 const TextRoot = forwardRef<TextRef, TextRootProps>((props, ref) => {
-  const { children, type = 'body', className, ...restProps } = props;
+  const {
+    children,
+    type = 'body',
+    align = 'start',
+    color = 'default',
+    weight,
+    truncate = false,
+    numberOfLines,
+    style,
+    className,
+    ...restProps
+  } = props;
 
-  const rootClassName = textClassNames.root({ type, className });
+  const rootClassName = textClassNames.root({
+    type,
+    align,
+    color,
+    weight,
+    className,
+  });
+
+  const resolvedNumberOfLines = numberOfLines ?? (truncate ? 1 : undefined);
+  const resolvedStyle = type === 'code' ? [styleSheet.code, style] : style;
 
   return (
-    <HeroText ref={ref} className={rootClassName} {...restProps}>
+    <HeroText
+      ref={ref}
+      className={rootClassName}
+      numberOfLines={resolvedNumberOfLines}
+      style={resolvedStyle}
+      {...restProps}
+    >
       {children}
     </HeroText>
   );
@@ -49,15 +74,7 @@ const TextParagraph = forwardRef<TextRef, TextParagraphProps>((props, ref) => {
 // --------------------------------------------------
 
 const TextCode = forwardRef<TextRef, TextCodeProps>((props, ref) => {
-  const { style, ...restProps } = props;
-
-  const mergedStyle = useMemo(
-    () =>
-      Array.isArray(style) ? [styles.code, ...style] : [styles.code, style],
-    [style]
-  );
-
-  return <TextRoot ref={ref} type="code" style={mergedStyle} {...restProps} />;
+  return <TextRoot ref={ref} type="code" {...props} />;
 });
 
 // --------------------------------------------------
@@ -70,9 +87,13 @@ TextCode.displayName = DISPLAY_NAME.TEXT_CODE;
 /**
  * Compound Text component with semantic sub-components.
  *
- * @component Text - Generic text element with a `type` prop for semantic
- * typography variants (headings, body, code). Maps each type to native
- * typography tokens via Tailwind utility classes.
+ * @component Text - Root text element. Selects a typography preset via
+ * `type` and exposes orthogonal `align`, `color`, `weight`, and `truncate`
+ * props. `truncate` is implemented via React Native's `numberOfLines={1}`;
+ * an explicit `numberOfLines` prop, if provided, takes precedence. When
+ * `type="code"`, the platform-appropriate monospace `fontFamily` from
+ * `styleSheet.code` is merged into `style` (since the project's NativeWind
+ * theme has no `font-mono` token).
  *
  * @component Text.Heading - Convenience wrapper restricted to heading types
  * (`h1`–`h6`). Sets `accessibilityRole="header"` automatically.
@@ -80,8 +101,9 @@ TextCode.displayName = DISPLAY_NAME.TEXT_CODE;
  * @component Text.Paragraph - Convenience wrapper restricted to body types
  * (`body`, `body-sm`, `body-xs`).
  *
- * @component Text.Code - Renders monospaced text using the `code` type and
- * applies a platform monospace font family.
+ * @component Text.Code - Chip-styled inline monospaced text. Thin wrapper
+ * that forces `type="code"`; the monospace `fontFamily` is applied at the
+ * root.
  *
  * @see Full documentation: https://heroui.com/docs/native/components/text
  */
@@ -90,20 +112,8 @@ const CompoundText = Object.assign(TextRoot, {
   Heading: TextHeading,
   /** Paragraph text – renders body / body-sm / body-xs */
   Paragraph: TextParagraph,
-  /** Code text – monospaced font with code styling */
+  /** Code text – chip-styled inline monospaced text */
   Code: TextCode,
 });
 
 export default CompoundText;
-
-// --------------------------------------------------
-
-const styles = StyleSheet.create({
-  code: {
-    fontFamily: Platform.select({
-      ios: 'Menlo',
-      android: CODE_FONT_FAMILY,
-      default: CODE_FONT_FAMILY,
-    }),
-  },
-});

--- a/src/components/text/text.types.ts
+++ b/src/components/text/text.types.ts
@@ -1,0 +1,71 @@
+import type { TextProps as RNTextProps } from 'react-native';
+
+/**
+ * Semantic type variants for the Text component.
+ *
+ * Heading types (`h1`–`h6`) map to decreasing font sizes with bold/semibold weight.
+ * Body types (`body`, `body-sm`, `body-xs`) map to regular-weight running text.
+ * `code` maps to a monospaced style.
+ */
+export type TextType =
+  | 'h1'
+  | 'h2'
+  | 'h3'
+  | 'h4'
+  | 'h5'
+  | 'h6'
+  | 'body'
+  | 'body-sm'
+  | 'body-xs'
+  | 'code';
+
+/**
+ * Props for the Text component root
+ */
+export interface TextRootProps extends RNTextProps {
+  /**
+   * Semantic type that determines typography styling (size, weight, line-height).
+   * @default 'body'
+   */
+  type?: TextType;
+  /**
+   * Additional CSS classes
+   */
+  className?: string;
+  /**
+   * Content to render
+   */
+  children?: React.ReactNode;
+}
+
+/**
+ * Props for Text.Heading sub-component
+ */
+export interface TextHeadingProps extends Omit<TextRootProps, 'type'> {
+  /**
+   * Heading level, restricted to heading types
+   * @default 'h1'
+   */
+  type?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+}
+
+/**
+ * Props for Text.Paragraph sub-component
+ */
+export interface TextParagraphProps extends Omit<TextRootProps, 'type'> {
+  /**
+   * Paragraph type, restricted to body types
+   * @default 'body'
+   */
+  type?: 'body' | 'body-sm' | 'body-xs';
+}
+
+/**
+ * Props for Text.Code sub-component
+ */
+export interface TextCodeProps extends Omit<TextRootProps, 'type'> {}
+
+/**
+ * Props for Text.Prose sub-component (multi-line body text wrapper)
+ */
+export interface TextProseProps extends Omit<TextRootProps, 'type'> {}

--- a/src/components/text/text.types.ts
+++ b/src/components/text/text.types.ts
@@ -64,8 +64,3 @@ export interface TextParagraphProps extends Omit<TextRootProps, 'type'> {
  * Props for Text.Code sub-component
  */
 export interface TextCodeProps extends Omit<TextRootProps, 'type'> {}
-
-/**
- * Props for Text.Prose sub-component (multi-line body text wrapper)
- */
-export interface TextProseProps extends Omit<TextRootProps, 'type'> {}

--- a/src/components/text/text.types.ts
+++ b/src/components/text/text.types.ts
@@ -3,9 +3,9 @@ import type { TextProps as RNTextProps } from 'react-native';
 /**
  * Semantic type variants for the Text component.
  *
- * Heading types (`h1`–`h6`) map to decreasing font sizes with bold/semibold weight.
- * Body types (`body`, `body-sm`, `body-xs`) map to regular-weight running text.
- * `code` maps to a monospaced style.
+ * Heading types (`h1`–`h6`) map to decreasing font sizes with semibold weight.
+ * Body types (`body`, `body-sm`, `body-xs`) map to running text with explicit
+ * line-heights. `code` maps to a chip-like monospaced style.
  */
 export type TextType =
   | 'h1'
@@ -20,6 +20,25 @@ export type TextType =
   | 'code';
 
 /**
+ * Horizontal text alignment.
+ *
+ * `start` and `end` are RTL-aware (flip to right/left under RTL).
+ *
+ * @note `justify` is iOS-only on React Native; Android falls back to left.
+ */
+export type TextAlign = 'start' | 'center' | 'end' | 'justify';
+
+/**
+ * Semantic foreground color preset.
+ */
+export type TextColor = 'default' | 'muted';
+
+/**
+ * Font weight override, applied independently of the `type` variant.
+ */
+export type TextWeight = 'normal' | 'medium' | 'semibold' | 'bold';
+
+/**
  * Props for the Text component root
  */
 export interface TextRootProps extends RNTextProps {
@@ -28,6 +47,26 @@ export interface TextRootProps extends RNTextProps {
    * @default 'body'
    */
   type?: TextType;
+  /**
+   * Horizontal alignment. RTL-aware for `start` and `end`.
+   * @default 'start'
+   */
+  align?: TextAlign;
+  /**
+   * Semantic foreground color preset.
+   * @default 'default'
+   */
+  color?: TextColor;
+  /**
+   * Font weight override. When set, overrides the weight implied by `type`.
+   */
+  weight?: TextWeight;
+  /**
+   * Truncates the text to a single line with an ellipsis.
+   *
+   * @default false
+   */
+  truncate?: boolean;
   /**
    * Additional CSS classes
    */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -36,6 +36,7 @@ export * from './components/surface';
 export * from './components/switch';
 export * from './components/tabs';
 export * from './components/tag-group';
+export * from './components/text';
 export * from './components/text-area';
 export * from './components/text-field';
 export * from './components/toast';

--- a/src/primitives/avatar/avatar.tsx
+++ b/src/primitives/avatar/avatar.tsx
@@ -39,7 +39,7 @@ export function useRootContext() {
 // --------------------------------------------------
 
 const Root = forwardRef<RootRef, RootProps>(
-  ({ asChild, alt, ...viewProps }, ref) => {
+  ({ asChild, alt = 'Avatar', ...viewProps }, ref) => {
     const [status, setStatus] = useState<AvatarStatus>('error');
 
     const Component = asChild ? Slot.View : View;

--- a/src/primitives/avatar/avatar.types.ts
+++ b/src/primitives/avatar/avatar.types.ts
@@ -18,8 +18,11 @@ type AvatarStatus = 'loading' | 'loaded' | 'error';
  * Extends SlottableViewProps to support the asChild pattern.
  */
 type RootProps = SlottableViewProps & {
-  /** Alternative text description for the avatar, used for accessibility */
-  alt: string;
+  /**
+   * Alternative text description for the avatar, used for accessibility.
+   * @default 'Avatar'
+   */
+  alt?: string;
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -7884,6 +7884,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"expo-localization@npm:~17.0.8":
+  version: 17.0.8
+  resolution: "expo-localization@npm:17.0.8"
+  dependencies:
+    rtl-detect: ^1.0.2
+  peerDependencies:
+    expo: "*"
+    react: "*"
+  checksum: 70ddc37ec97392c7c2b783135695a2b06e5b38c7397989a0986632e91e75b36a87579267322910ac5edf53975440ad17b62f270206ce246df5a30881e4933aa5
+  languageName: node
+  linkType: hard
+
 "expo-manifests@npm:~1.0.10":
   version: 1.0.10
   resolution: "expo-manifests@npm:1.0.10"
@@ -9010,6 +9022,7 @@ __metadata:
     expo-image: ~3.0.11
     expo-linear-gradient: ~15.0.8
     expo-linking: ~8.0.11
+    expo-localization: ~17.0.8
     expo-router: ~6.0.21
     expo-splash-screen: ~31.0.13
     expo-status-bar: ~3.0.9
@@ -13983,6 +13996,13 @@ __metadata:
   bin:
     rimraf: bin.js
   checksum: 87f4164e396f0171b0a3386cc1877a817f572148ee13a7e113b238e48e8a9f2f31d009a92ec38a591ff1567d9662c6b67fd8818a2dbbaed74bc26a87a2a4a9a0
+  languageName: node
+  linkType: hard
+
+"rtl-detect@npm:^1.0.2":
+  version: 1.1.2
+  resolution: "rtl-detect@npm:1.1.2"
+  checksum: 4a43a1e5df0617eb86d5485640b318787d12b86acf53d840a3b2ff701ee941e95479d4e9ae97e907569ec763d1c47218cb87639bc87bcdad60a85747e5270cf0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**PRs included in this release:**

- PR #398: fix(scroll-shadow): respect child's inverted prop
- PR #396: fix(tabs): align indicator in RTL
- PR #400: feat: add Text component with semantic type prop and sub-components
- PR #404: refactor(avatar): make alt prop optional with default value
- PR #406: chore: refine button, chip, and input styles
- PR #407: fix(text-field, search-field): remove side padding on child components
- PR #409: fix(select): unify trigger indicator render branches

**Resolved issues:**

- Issue #334: Tabs indicator is mispositioned in RTL layouts
- Issue #393: ScrollShadow ignores child's inverted prop