### PR TITLE
docs(readme): update preview app section with App Store link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,31 +30,12 @@ Visit [https://heroui.com/docs/native/getting-started](https://heroui.com/docs/n
 
 ## Preview App
 
-Experience HeroUI Native components in action with our preview app! You can explore all components and their variants directly on your device.
+Experience HeroUI Native components in action with our official preview app! You can explore all components and their variants directly on your device.
 
-### Prerequisites
+### Download
 
-Make sure you have the latest version of [Expo Go](https://expo.dev/go) installed on your mobile device
-
-### How to Access
-
-Choose one of the following methods to access the preview app:
-
-#### Option 1: Scan the QR Code
-
-Use your device's camera or Expo Go app to scan:
-
-<p align="center">
-  <img width="25%" src="https://heroui-assets.nyc3.cdn.digitaloceanspaces.com/images/qr-code-native.png" alt="Expo Go QR Code" />
-</p>
-
-> **Note for Android users:** If scanning the QR code with your device's camera or other scanner apps redirects to a browser and shows a 404 error, open Expo Go first and use its built-in QR scanner instead.
-
-#### Option 2: Click the Link
-
-**[📱 Open Demo App in Expo Go](https://link.heroui.com/native-demo)**
-
-This will automatically open the app in Expo Go if it's installed on your device.
+- **iOS:** [Download on the App Store](https://apps.apple.com/app/id6757860059)
+- **Android:** Coming soon to Google Play
 
 ## Quick Start with Example App
 


### PR DESCRIPTION
## 📝 Description

Updates the README's Preview App section to direct users to the official native preview app on the App Store instead of running it through Expo Go. Streamlines the section by removing the QR code, Expo Go prerequisites, and platform-specific scanning notes.

## ⛳️ Current behavior (updates)

The README instructs users to install Expo Go, then scan a QR code or click an Expo link to preview HeroUI Native components on their device.

## 🚀 New behavior

- Replaces Expo Go preview flow with direct app store distribution
- Adds iOS App Store download link for the official preview app
- Notes Android availability as "Coming soon to Google Play"
- Removes QR code image, Expo Go prerequisites, and Android scanning caveat
- Reduces the Preview App section to a concise download list

## 💣 Is this a breaking change (Yes/No):

**No** - Documentation-only change with no impact on the library API or consumer code.

## 📝 Additional Information

Change is isolated to `README.md` (4 insertions, 23 deletions). No code, dependencies, or tests are affected. Verify the App Store link resolves to the published preview app before merging.