### PR TITLE
refactor(text): rename text to typography

### DIFF
--- a/example/src/app/(home)/components/typography.tsx
+++ b/example/src/app/(home)/components/typography.tsx
@@ -1,4 +1,4 @@
-import { Text } from 'heroui-native';
+import { Typography } from 'heroui-native';
 import { View } from 'react-native';
 import type { UsageVariant } from '../../../components/component-presentation/types';
 import { UsageVariantFlatList } from '../../../components/component-presentation/usage-variant-flatlist';
@@ -6,16 +6,16 @@ import { UsageVariantFlatList } from '../../../components/component-presentation
 const TypesContent = () => {
   return (
     <View className="flex-1 justify-center px-5 gap-4">
-      <Text type="h1">Heading 1</Text>
-      <Text type="h2">Heading 2</Text>
-      <Text type="h3">Heading 3</Text>
-      <Text type="h4">Heading 4</Text>
-      <Text type="h5">Heading 5</Text>
-      <Text type="h6">Heading 6</Text>
-      <Text type="body">Body text</Text>
-      <Text type="body-sm">Small body text</Text>
-      <Text type="body-xs">Extra-small body text</Text>
-      <Text type="code">const x = 42;</Text>
+      <Typography type="h1">Heading 1</Typography>
+      <Typography type="h2">Heading 2</Typography>
+      <Typography type="h3">Heading 3</Typography>
+      <Typography type="h4">Heading 4</Typography>
+      <Typography type="h5">Heading 5</Typography>
+      <Typography type="h6">Heading 6</Typography>
+      <Typography type="body">Body text</Typography>
+      <Typography type="body-sm">Small body text</Typography>
+      <Typography type="body-xs">Extra-small body text</Typography>
+      <Typography type="code">const x = 42;</Typography>
     </View>
   );
 };
@@ -25,12 +25,12 @@ const TypesContent = () => {
 const HeadingsContent = () => {
   return (
     <View className="flex-1 justify-center px-5 gap-4">
-      <Text.Heading type="h1">Page Title</Text.Heading>
-      <Text.Heading type="h2">Section Title</Text.Heading>
-      <Text.Heading type="h3">Subsection</Text.Heading>
-      <Text.Heading type="h4">Group Title</Text.Heading>
-      <Text.Heading type="h5">Label Heading</Text.Heading>
-      <Text.Heading type="h6">Small Heading</Text.Heading>
+      <Typography.Heading type="h1">Page Title</Typography.Heading>
+      <Typography.Heading type="h2">Section Title</Typography.Heading>
+      <Typography.Heading type="h3">Subsection</Typography.Heading>
+      <Typography.Heading type="h4">Group Title</Typography.Heading>
+      <Typography.Heading type="h5">Label Heading</Typography.Heading>
+      <Typography.Heading type="h6">Small Heading</Typography.Heading>
     </View>
   );
 };
@@ -40,17 +40,17 @@ const HeadingsContent = () => {
 const ParagraphsContent = () => {
   return (
     <View className="flex-1 justify-center px-5 gap-4">
-      <Text.Paragraph>
+      <Typography.Paragraph>
         This is a default body paragraph. It uses the base font size and normal
         weight for comfortable reading.
-      </Text.Paragraph>
-      <Text.Paragraph type="body-sm">
+      </Typography.Paragraph>
+      <Typography.Paragraph type="body-sm">
         This is a smaller paragraph, useful for captions, footnotes, or
         secondary descriptions.
-      </Text.Paragraph>
-      <Text.Paragraph type="body-xs">
+      </Typography.Paragraph>
+      <Typography.Paragraph type="body-xs">
         Extra-small text for disclaimers or fine print. lore
-      </Text.Paragraph>
+      </Typography.Paragraph>
     </View>
   );
 };
@@ -60,16 +60,16 @@ const ParagraphsContent = () => {
 const CodeContent = () => {
   return (
     <View className="flex-1 justify-center px-5 gap-4">
-      <Text.Code>npm install heroui-native</Text.Code>
-      <Text.Code>{'const greeting = "Hello, world!";'}</Text.Code>
-      <Text.Code>{'export default function App() { }'}</Text.Code>
+      <Typography.Code>npm install heroui-native</Typography.Code>
+      <Typography.Code>{'const greeting = "Hello, world!";'}</Typography.Code>
+      <Typography.Code>{'export default function App() { }'}</Typography.Code>
     </View>
   );
 };
 
 // ------------------------------------------------------------------------------
 
-const TEXT_VARIANTS: UsageVariant[] = [
+const TYPOGRAPHY_VARIANTS: UsageVariant[] = [
   {
     value: 'types',
     label: 'Types',
@@ -92,6 +92,6 @@ const TEXT_VARIANTS: UsageVariant[] = [
   },
 ];
 
-export default function TextScreen() {
-  return <UsageVariantFlatList data={TEXT_VARIANTS} />;
+export default function TypographyScreen() {
+  return <UsageVariantFlatList data={TYPOGRAPHY_VARIANTS} />;
 }

--- a/example/src/helpers/data/components.ts
+++ b/example/src/helpers/data/components.ts
@@ -146,8 +146,8 @@ export const COMPONENTS: ComponentItem[] = [
     path: 'tag-group',
   },
   {
-    title: 'Text',
-    path: 'text',
+    title: 'Typography',
+    path: 'typography',
   },
   {
     title: 'TextArea',

--- a/src/components/text/index.ts
+++ b/src/components/text/index.ts
@@ -1,12 +1,75 @@
-export { default as Text } from './text';
-export { textClassNames } from './text.styles';
-export type {
-  TextAlign,
-  TextCodeProps,
-  TextColor,
-  TextHeadingProps,
-  TextParagraphProps,
-  TextRootProps,
-  TextType,
-  TextWeight,
+import TypographyComponent from './text';
+import { textClassNames as typographyClassNamesValue } from './text.styles';
+import type {
+  TextAlign as TextAlignSource,
+  TextCodeProps as TextCodePropsSource,
+  TextColor as TextColorSource,
+  TextHeadingProps as TextHeadingPropsSource,
+  TextParagraphProps as TextParagraphPropsSource,
+  TextRootProps as TextRootPropsSource,
+  TextType as TextTypeSource,
+  TextWeight as TextWeightSource,
 } from './text.types';
+
+export { TypographyComponent as Typography };
+
+export const typographyClassNames = typographyClassNamesValue;
+
+export type TypographyAlign = TextAlignSource;
+export type TypographyCodeProps = TextCodePropsSource;
+export type TypographyColor = TextColorSource;
+export type TypographyHeadingProps = TextHeadingPropsSource;
+export type TypographyParagraphProps = TextParagraphPropsSource;
+export type TypographyRootProps = TextRootPropsSource;
+export type TypographyType = TextTypeSource;
+export type TypographyWeight = TextWeightSource;
+
+/**
+ * @deprecated Use `Typography` instead. Will be removed in a future major version.
+ */
+export const Text = TypographyComponent;
+
+/**
+ * @deprecated Use `typographyClassNames` instead. Will be removed in a future major version.
+ */
+export const textClassNames = typographyClassNamesValue;
+
+/**
+ * @deprecated Use `TypographyAlign` instead.
+ */
+export type TextAlign = TextAlignSource;
+
+/**
+ * @deprecated Use `TypographyCodeProps` instead.
+ */
+export type TextCodeProps = TextCodePropsSource;
+
+/**
+ * @deprecated Use `TypographyColor` instead.
+ */
+export type TextColor = TextColorSource;
+
+/**
+ * @deprecated Use `TypographyHeadingProps` instead.
+ */
+export type TextHeadingProps = TextHeadingPropsSource;
+
+/**
+ * @deprecated Use `TypographyParagraphProps` instead.
+ */
+export type TextParagraphProps = TextParagraphPropsSource;
+
+/**
+ * @deprecated Use `TypographyRootProps` instead.
+ */
+export type TextRootProps = TextRootPropsSource;
+
+/**
+ * @deprecated Use `TypographyType` instead.
+ */
+export type TextType = TextTypeSource;
+
+/**
+ * @deprecated Use `TypographyWeight` instead.
+ */
+export type TextWeight = TextWeightSource;

--- a/src/components/text/text.md
+++ b/src/components/text/text.md
@@ -1,37 +1,37 @@
-# Text
+# Typography
 
 Primitive typography component for rendering styled text with semantic type variants.
 
 ## Import
 
 ```tsx
-import { Text } from 'heroui-native';
+import { Typography } from 'heroui-native';
 ```
 
 ## Anatomy
 
 ```tsx
-<Text>...</Text>
+<Typography>...</Typography>
 
 {/* Sub-components */}
-<Text.Heading>...</Text.Heading>
-<Text.Paragraph>...</Text.Paragraph>
-<Text.Code>...</Text.Code>
+<Typography.Heading>...</Typography.Heading>
+<Typography.Paragraph>...</Typography.Paragraph>
+<Typography.Code>...</Typography.Code>
 ```
 
-- **Text**: Root text element. Selects a typography preset via `type` and exposes orthogonal `align`, `color`, `weight`, and `truncate` props.
-- **Text.Heading**: Convenience wrapper restricted to heading types (`h1`–`h6`). Adds `accessibilityRole="header"` automatically.
-- **Text.Paragraph**: Convenience wrapper restricted to body types (`body`, `body-sm`, `body-xs`).
-- **Text.Code**: Chip-styled inline monospaced text. Uses a platform-appropriate monospace font family.
+- **Typography**: Root text element. Selects a typography preset via `type` and exposes orthogonal `align`, `color`, `weight`, and `truncate` props.
+- **Typography.Heading**: Convenience wrapper restricted to heading types (`h1`–`h6`). Adds `accessibilityRole="header"` automatically.
+- **Typography.Paragraph**: Convenience wrapper restricted to body types (`body`, `body-sm`, `body-xs`).
+- **Typography.Code**: Chip-styled inline monospaced text. Uses a platform-appropriate monospace font family.
 
 ## Usage
 
 ### Basic Usage
 
-The Text component renders body text by default.
+The Typography component renders body text by default.
 
 ```tsx
-<Text>Hello, world!</Text>
+<Typography>Hello, world!</Typography>
 ```
 
 ### Type Variants
@@ -39,48 +39,48 @@ The Text component renders body text by default.
 Use the `type` prop to select a semantic typography preset.
 
 ```tsx
-<Text type="h1">Heading 1</Text>
-<Text type="h2">Heading 2</Text>
-<Text type="h3">Heading 3</Text>
-<Text type="h4">Heading 4</Text>
-<Text type="h5">Heading 5</Text>
-<Text type="h6">Heading 6</Text>
-<Text type="body">Body text</Text>
-<Text type="body-sm">Small body text</Text>
-<Text type="body-xs">Extra-small body text</Text>
-<Text type="code">Code snippet</Text>
+<Typography type="h1">Heading 1</Typography>
+<Typography type="h2">Heading 2</Typography>
+<Typography type="h3">Heading 3</Typography>
+<Typography type="h4">Heading 4</Typography>
+<Typography type="h5">Heading 5</Typography>
+<Typography type="h6">Heading 6</Typography>
+<Typography type="body">Body text</Typography>
+<Typography type="body-sm">Small body text</Typography>
+<Typography type="body-xs">Extra-small body text</Typography>
+<Typography type="code">Code snippet</Typography>
 ```
 
 ### Headings
 
-Use `Text.Heading` for heading text with automatic header accessibility role.
+Use `Typography.Heading` for heading text with automatic header accessibility role.
 
 ```tsx
-<Text.Heading type="h1">Page Title</Text.Heading>
-<Text.Heading type="h2">Section Title</Text.Heading>
-<Text.Heading type="h3">Subsection Title</Text.Heading>
+<Typography.Heading type="h1">Page Title</Typography.Heading>
+<Typography.Heading type="h2">Section Title</Typography.Heading>
+<Typography.Heading type="h3">Subsection Title</Typography.Heading>
 ```
 
 ### Paragraphs
 
-Use `Text.Paragraph` for body text.
+Use `Typography.Paragraph` for body text.
 
 ```tsx
-<Text.Paragraph>
+<Typography.Paragraph>
   This is a paragraph of body text with the default size.
-</Text.Paragraph>
-<Text.Paragraph type="body-sm">
+</Typography.Paragraph>
+<Typography.Paragraph type="body-sm">
   This is smaller body text.
-</Text.Paragraph>
+</Typography.Paragraph>
 ```
 
 ### Code
 
-Use `Text.Code` (or equivalently `<Text type="code">`) for inline code snippets. Both render a chip-styled, monospaced inline element with a subtle background, rounded corners, and a `self-start` layout so it does not stretch in flex containers. The platform monospace `fontFamily` is applied at the `Text` root, so the two forms are interchangeable.
+Use `Typography.Code` (or equivalently `<Typography type="code">`) for inline code snippets. Both render a chip-styled, monospaced inline element with a subtle background, rounded corners, and a `self-start` layout so it does not stretch in flex containers. The platform monospace `fontFamily` is applied at the `Typography` root, so the two forms are interchangeable.
 
 ```tsx
-<Text.Code>console.log('hello')</Text.Code>
-<Text type="code">console.log('hello')</Text>
+<Typography.Code>console.log('hello')</Typography.Code>
+<Typography type="code">console.log('hello')</Typography>
 ```
 
 ### Alignment
@@ -88,10 +88,10 @@ Use `Text.Code` (or equivalently `<Text type="code">`) for inline code snippets.
 Use the `align` prop to control horizontal alignment. `start` and `end` are RTL-aware (they flip under right-to-left layouts).
 
 ```tsx
-<Text align="start">Start-aligned</Text>
-<Text align="center">Center-aligned</Text>
-<Text align="end">End-aligned</Text>
-<Text align="justify">Justified text spreads across the line.</Text>
+<Typography align="start">Start-aligned</Typography>
+<Typography align="center">Center-aligned</Typography>
+<Typography align="end">End-aligned</Typography>
+<Typography align="justify">Justified text spreads across the line.</Typography>
 ```
 
 > **Note:** `text-justify` is iOS-only on React Native; Android falls back to left alignment.
@@ -101,8 +101,8 @@ Use the `align` prop to control horizontal alignment. `start` and `end` are RTL-
 Use the `color` prop to apply a semantic foreground color preset.
 
 ```tsx
-<Text color="default">Default foreground</Text>
-<Text color="muted">Muted secondary text</Text>
+<Typography color="default">Default foreground</Typography>
+<Typography color="muted">Muted secondary text</Typography>
 ```
 
 For other theme colors, pass the corresponding utility through `className` (e.g. `className="text-accent"`, `className="text-danger"`).
@@ -112,9 +112,9 @@ For other theme colors, pass the corresponding utility through `className` (e.g.
 Use the `weight` prop to override the font weight implied by `type`. The override merges via `tailwind-merge`, so it always wins over the type variant's default weight.
 
 ```tsx
-<Text type="h1" weight="bold">Bold H1</Text>
-<Text weight="medium">Medium body</Text>
-<Text weight="semibold">Semibold body</Text>
+<Typography type="h1" weight="bold">Bold H1</Typography>
+<Typography weight="medium">Medium body</Typography>
+<Typography weight="semibold">Semibold body</Typography>
 ```
 
 ### Truncation
@@ -122,38 +122,38 @@ Use the `weight` prop to override the font weight implied by `type`. The overrid
 Use the `truncate` boolean prop to limit the text to a single line with an ellipsis. It is mapped to React Native's `numberOfLines={1}`. An explicit `numberOfLines` prop, if provided, takes precedence.
 
 ```tsx
-<Text truncate>
+<Typography truncate>
   A long line of text that will be cut off with an ellipsis when it overflows
   the container.
-</Text>;
+</Typography>;
 
 {
   /* Multi-line truncation via the underlying RN prop */
 }
-<Text numberOfLines={2}>
+<Typography numberOfLines={2}>
   Two-line truncation works through React Native's standard `numberOfLines`
   prop.
-</Text>;
+</Typography>;
 ```
 
 ## Example
 
 ```tsx
-import { Text } from 'heroui-native';
+import { Typography } from 'heroui-native';
 import { View } from 'react-native';
 
-export default function TextExample() {
+export default function TypographyExample() {
   return (
     <View className="flex-1 justify-center px-5 gap-4">
-      <Text.Heading type="h1">Welcome</Text.Heading>
-      <Text.Heading type="h3">Getting Started</Text.Heading>
-      <Text.Paragraph>
-        This is a body paragraph rendered with the Text component.
-      </Text.Paragraph>
-      <Text.Paragraph color="muted" type="body-sm">
+      <Typography.Heading type="h1">Welcome</Typography.Heading>
+      <Typography.Heading type="h3">Getting Started</Typography.Heading>
+      <Typography.Paragraph>
+        This is a body paragraph rendered with the Typography component.
+      </Typography.Paragraph>
+      <Typography.Paragraph color="muted" type="body-sm">
         Smaller supporting text for captions or footnotes.
-      </Text.Paragraph>
-      <Text.Code>npm install heroui-native</Text.Code>
+      </Typography.Paragraph>
+      <Typography.Code>npm install heroui-native</Typography.Code>
     </View>
   );
 }
@@ -163,9 +163,9 @@ You can find more examples in the [GitHub repository](<https://github.com/heroui
 
 ## API Reference
 
-### Text
+### Typography
 
-`Text` extends all standard React Native `TextProps` with additional typography props.
+`Typography` extends all standard React Native `TextProps` with additional typography props.
 
 | prop           | type                                                                                         | default     | description                                                                                                                    |
 | -------------- | -------------------------------------------------------------------------------------------- | ----------- | ------------------------------------------------------------------------------------------------------------------------------ |
@@ -178,9 +178,9 @@ You can find more examples in the [GitHub repository](<https://github.com/heroui
 | `className`    | `string`                                                                                     | -           | Additional CSS classes                                                                                                         |
 | `...TextProps` | `TextProps`                                                                                  | -           | All standard React Native `Text` props are supported                                                                           |
 
-### Text.Heading
+### Typography.Heading
 
-Inherits all `Text` root props (`align`, `color`, `weight`, `truncate`, `className`, and React Native `TextProps`). Sets `accessibilityRole="header"` automatically and narrows `type` to heading variants.
+Inherits all `Typography` root props (`align`, `color`, `weight`, `truncate`, `className`, and React Native `TextProps`). Sets `accessibilityRole="header"` automatically and narrows `type` to heading variants.
 
 | prop           | type                                           | default | description                                          |
 | -------------- | ---------------------------------------------- | ------- | ---------------------------------------------------- |
@@ -189,9 +189,9 @@ Inherits all `Text` root props (`align`, `color`, `weight`, `truncate`, `classNa
 | `className`    | `string`                                       | -       | Additional CSS classes                               |
 | `...TextProps` | `TextProps`                                    | -       | All standard React Native `Text` props are supported |
 
-### Text.Paragraph
+### Typography.Paragraph
 
-Inherits all `Text` root props (`align`, `color`, `weight`, `truncate`, `className`, and React Native `TextProps`). Narrows `type` to body variants.
+Inherits all `Typography` root props (`align`, `color`, `weight`, `truncate`, `className`, and React Native `TextProps`). Narrows `type` to body variants.
 
 | prop           | type                               | default  | description                                          |
 | -------------- | ---------------------------------- | -------- | ---------------------------------------------------- |
@@ -200,9 +200,9 @@ Inherits all `Text` root props (`align`, `color`, `weight`, `truncate`, `classNa
 | `className`    | `string`                           | -        | Additional CSS classes                               |
 | `...TextProps` | `TextProps`                        | -        | All standard React Native `Text` props are supported |
 
-### Text.Code
+### Typography.Code
 
-Inherits all `Text` root props (`align`, `color`, `weight`, `truncate`, `className`, `style`, and React Native `TextProps`). Thin wrapper that forces `type="code"`; the platform monospace `fontFamily` is merged in at the `Text` root, so `<Text type="code">` and `<Text.Code>` render identically.
+Inherits all `Typography` root props (`align`, `color`, `weight`, `truncate`, `className`, `style`, and React Native `TextProps`). Thin wrapper that forces `type="code"`; the platform monospace `fontFamily` is merged in at the `Typography` root, so `<Typography type="code">` and `<Typography.Code>` render identically.
 
 | prop           | type              | default | description                                          |
 | -------------- | ----------------- | ------- | ---------------------------------------------------- |

--- a/src/components/text/text.tsx
+++ b/src/components/text/text.tsx
@@ -85,9 +85,9 @@ TextParagraph.displayName = DISPLAY_NAME.TEXT_PARAGRAPH;
 TextCode.displayName = DISPLAY_NAME.TEXT_CODE;
 
 /**
- * Compound Text component with semantic sub-components.
+ * Compound Typography component with semantic sub-components.
  *
- * @component Text - Root text element. Selects a typography preset via
+ * @component Typography - Root text element. Selects a typography preset via
  * `type` and exposes orthogonal `align`, `color`, `weight`, and `truncate`
  * props. `truncate` is implemented via React Native's `numberOfLines={1}`;
  * an explicit `numberOfLines` prop, if provided, takes precedence. When
@@ -95,19 +95,19 @@ TextCode.displayName = DISPLAY_NAME.TEXT_CODE;
  * `styleSheet.code` is merged into `style` (since the project's NativeWind
  * theme has no `font-mono` token).
  *
- * @component Text.Heading - Convenience wrapper restricted to heading types
- * (`h1`–`h6`). Sets `accessibilityRole="header"` automatically.
+ * @component Typography.Heading - Convenience wrapper restricted to heading
+ * types (`h1`–`h6`). Sets `accessibilityRole="header"` automatically.
  *
- * @component Text.Paragraph - Convenience wrapper restricted to body types
- * (`body`, `body-sm`, `body-xs`).
+ * @component Typography.Paragraph - Convenience wrapper restricted to body
+ * types (`body`, `body-sm`, `body-xs`).
  *
- * @component Text.Code - Chip-styled inline monospaced text. Thin wrapper
- * that forces `type="code"`; the monospace `fontFamily` is applied at the
- * root.
+ * @component Typography.Code - Chip-styled inline monospaced text. Thin
+ * wrapper that forces `type="code"`; the monospace `fontFamily` is applied
+ * at the root.
  *
- * @see Full documentation: https://heroui.com/docs/native/components/text
+ * @see Full documentation: https://heroui.com/docs/native/components/typography
  */
-const CompoundText = Object.assign(TextRoot, {
+const CompoundTypography = Object.assign(TextRoot, {
   /** Heading text – renders h1-h6 with header accessibility role */
   Heading: TextHeading,
   /** Paragraph text – renders body / body-sm / body-xs */
@@ -116,4 +116,4 @@ const CompoundText = Object.assign(TextRoot, {
   Code: TextCode,
 });
 
-export default CompoundText;
+export default CompoundTypography;


### PR DESCRIPTION
## 📝 Description

Renames the public `Text` typography component to `Typography` to avoid clashing with React Native’s `Text` and align naming with semantic typography usage. The example app and component documentation are updated to use the new API while keeping deprecated `Text` exports for backward compatibility.

## ⛳️ Current behavior (updates)

Consumers import `Text`, `Text.Heading`, `Text.Paragraph`, and `Text.Code` from `heroui-native`, with related types and `textClassNames` under the `Text*` naming.

## 🚀 New behavior

- Primary export is `Typography` with sub-components `Typography.Heading`, `Typography.Paragraph`, and `Typography.Code`
- New `typographyClassNames` and `Typography*` type aliases replace the public naming convention
- `Text`, `textClassNames`, and `Text*` types remain as deprecated aliases
- Example screen renamed from `text` to `typography` in the component catalog
- Docs and JSDoc updated to reference Typography and the new docs URL

## 💣 Is this a breaking change (Yes/No):

**No** - Existing `Text` imports and types still work via deprecated re-exports; migrate to `Typography` when convenient before a future major removal.

## 📝 Additional Information

Five files changed (library exports, implementation comments, docs, and example). Manual verification of the typography example screen and imports using both `Typography` and deprecated `Text` is recommended.