### PR TITLE
docs(menu,popover,select): add iOS native modal offset guidance

### DIFF
--- a/src/components/menu/menu.md
+++ b/src/components/menu/menu.md
@@ -778,3 +778,25 @@ const { isOpen, onOpenChange, isDisabled } = useSubMenu();
 | `onOpenChange` | `(open: boolean) => void` | Callback to change the open state           |
 | `isDisabled`   | `boolean`                 | Whether the sub-menu is disabled            |
 | `nativeID`     | `string`                  | Unique identifier for the sub-menu instance |
+
+## Special Notes
+
+### Element Inspector (iOS)
+
+Menu uses FullWindowOverlay on iOS. To enable the React Native element inspector during development, set `disableFullWindowOverlay={true}` on `Menu.Portal`. Tradeoff: the menu will not appear above native modals when disabled.
+
+### Native Modal (iOS)
+
+When a `Menu` is opened inside a screen presented as a native modal (`presentation: 'modal' | 'formSheet' | 'pageSheet'`), the menu content may render shifted upward. In the new architecture (Fabric), `react-native-screens` marks `RNSModalScreen` as a Fabric root, so the trigger's position is reported relative to the modal's origin while `FullWindowOverlay` (where the menu is mounted) is anchored to the iOS application window. Compensate by adding `safeAreaInsets.top` to `offset`:
+
+```tsx
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+const insets = useSafeAreaInsets();
+
+<Menu.Content presentation="popover" offset={insets.top}>
+  ...
+</Menu.Content>;
+```
+
+See `example/src/app/(home)/components/menu-in-modal-screen.tsx` for a complete example.

--- a/src/components/popover/popover.md
+++ b/src/components/popover/popover.md
@@ -505,3 +505,19 @@ const CustomContent = () => {
 ### Element Inspector (iOS)
 
 Popover uses FullWindowOverlay on iOS. To enable the React Native element inspector during development, set `disableFullWindowOverlay={true}` on `Popover.Portal`. Tradeoff: the popover will not appear above native modals when disabled.
+
+### Native Modal (iOS)
+
+When a `Popover` is opened inside a screen presented as a native modal (`presentation: 'modal' | 'formSheet' | 'pageSheet'`), the popover content may render shifted upward. In the new architecture (Fabric), `react-native-screens` marks `RNSModalScreen` as a Fabric root, so the trigger's position is reported relative to the modal's origin while `FullWindowOverlay` (where the popover is mounted) is anchored to the iOS application window. Compensate by adding `safeAreaInsets.top` to `offset`:
+
+```tsx
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+const insets = useSafeAreaInsets();
+
+<Popover.Content presentation="popover" offset={insets.top + 20}>
+  ...
+</Popover.Content>;
+```
+
+See `example/src/app/(home)/components/popover-native-modal.tsx` for a complete example.

--- a/src/components/select/select.md
+++ b/src/components/select/select.md
@@ -795,3 +795,19 @@ const { itemValue, label } = useSelectItem();
 ### Element Inspector (iOS)
 
 Select uses FullWindowOverlay on iOS. To enable the React Native element inspector during development, set `disableFullWindowOverlay={true}` on `Select.Portal`. Tradeoff: the select dropdown will not appear above native modals when disabled.
+
+### Native Modal (iOS)
+
+When a `Select` is opened inside a screen presented as a native modal (`presentation: 'modal' | 'formSheet' | 'pageSheet'`), the dropdown may render shifted upward. In the new architecture (Fabric), `react-native-screens` marks `RNSModalScreen` as a Fabric root, so the trigger's position is reported relative to the modal's origin while `FullWindowOverlay` (where the dropdown is mounted) is anchored to the iOS application window. Compensate by adding `safeAreaInsets.top` to `offset`:
+
+```tsx
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+const insets = useSafeAreaInsets();
+
+<Select.Content presentation="popover" offset={insets.top + 10}>
+  ...
+</Select.Content>;
+```
+
+See `example/src/app/(home)/components/select-native-modal.tsx` for a complete example.


### PR DESCRIPTION
Closes #405 

## 📝 Description

Documents an iOS positioning issue when Menu, Popover, and Select are opened inside native modal screens (`modal`, `formSheet`, `pageSheet`). Adds Special Notes explaining the Fabric/`FullWindowOverlay` coordinate mismatch and the recommended `safeAreaInsets.top` offset workaround.

## ⛳️ Current behavior (updates)

Overlay components on iOS use `FullWindowOverlay`, but no docs covered the upward shift that can occur when triggers live inside a modal presentation.

## 🚀 New behavior

- Added **Native Modal (iOS)** sections to `menu.md`, `popover.md`, and `select.md`
- Explains why trigger coordinates are modal-relative while overlay content is window-anchored
- Documents compensating via `offset={insets.top}` (with component-specific examples)
- Links to example app files for full usage patterns

## 💣 Is this a breaking change (Yes/No):

**No** - Documentation-only change; no API or runtime behavior is modified.

## 📝 Additional Information

Popover and Select docs reference existing example files (`popover-native-modal.tsx`, `select-native-modal.tsx`). The Menu doc references `menu-in-modal-screen.tsx`, which is not yet in the repo and may need to be added separately. Manual verification on an iOS modal screen is recommended.