### PR TITLE
Mix soft colors with foreground instead of black

### DIFF
--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -81,19 +81,19 @@
   --color-default-soft-hover: color-mix(in oklab, var(--default) 60%, transparent);
 
   --color-accent-soft: color-mix(in oklab, var(--accent) 15%, transparent);
-  --color-accent-soft-foreground: color-mix(in oklab, var(--accent) 80%, var(--black) 20%);
+  --color-accent-soft-foreground: color-mix(in oklab, var(--accent) 80%, var(--foreground) 20%);
   --color-accent-soft-hover: color-mix(in oklab, var(--accent) 20%, transparent);
 
   --color-danger-soft: color-mix(in oklab, var(--danger) 15%, transparent);
-  --color-danger-soft-foreground: color-mix(in oklab, var(--danger) 80%, var(--black) 20%);
+  --color-danger-soft-foreground: color-mix(in oklab, var(--danger) 80%, var(--foreground) 20%);
   --color-danger-soft-hover: color-mix(in oklab, var(--danger) 20%, transparent);
 
   --color-warning-soft: color-mix(in oklab, var(--warning) 15%, transparent);
-  --color-warning-soft-foreground: color-mix(in oklab, var(--warning) 65%, var(--black) 35%);
+  --color-warning-soft-foreground: color-mix(in oklab, var(--warning) 65%, var(--foreground) 35%);
   --color-warning-soft-hover: color-mix(in oklab, var(--warning) 20%, transparent);
 
   --color-success-soft: color-mix(in oklab, var(--success) 15%, transparent);
-  --color-success-soft-foreground: color-mix(in oklab, var(--success) 70%, var(--black) 30%);
+  --color-success-soft-foreground: color-mix(in oklab, var(--success) 70%, var(--foreground) 30%);
   --color-success-soft-hover: color-mix(in oklab, var(--success) 20%, transparent);
 
   /* Separator Colors - Levels */


### PR DESCRIPTION
## 📝 Description

Hi, I believe soft colors were meant to be mixed with foreground color, according to docs.

## ⛳️ Current behavior (updates)

By default soft colors in dark mode make semantic colors _less_ accessible by mixing in black while going against dark background.

## 🚀 New behavior

Soft colors are more accessible by mixing in foreground color, i.e. snow color.

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information
