### PR TITLE
fix(theme): resolve border-field merge conflict via configured tv

### DIFF
--- a/docs/theming.md
+++ b/docs/theming.md
@@ -394,7 +394,7 @@ We use Tailwind's `@theme` directive to automatically create calculated variable
   --color-field-placeholder: var(--field-placeholder, var(--muted));
   --color-field-border: var(--field-border, var(--border));
   --radius-field: var(--field-radius, var(--radius-xl));
-  --border-width-field: var(--field-border-width, var(--border-width));
+  --border-width-field-width: var(--field-border-width, var(--border-width));
 
   --shadow-surface: var(--surface-shadow);
   --shadow-overlay: var(--overlay-shadow);
@@ -531,5 +531,7 @@ We use Tailwind's `@theme` directive to automatically create calculated variable
   --radius-4xl: calc(var(--radius) * 4); /* 2rem (32px) */
 }
 ```
+
+> **Field border utilities:** Use `border-field-width` for the field border width and `border-field-border` for the field border color. Pair them together (`border-field-width border-field-border`) when you need both. The `border-field` class remains a border-color utility from `--color-field` only; do not use it for width. If you previously used `border-field` for width, migrate to `border-field-width`. Customize the width via the `--field-border-width` primitive.
 
 Form controls now rely on the `--field-*` variables and their calculated hover/focus variants. Update them in your theme to restyle inputs, checkboxes, radios, and OTP slots without impacting surfaces like buttons or cards.

--- a/example/global.css
+++ b/example/global.css
@@ -20,6 +20,9 @@
       --font-bold: 'Inter-Bold';
       
       --radius: 0.5rem;
+
+      --field-border-width: 0px;
+      --field-border: #3b82f6;
     }
 
     @variant dark {
@@ -29,6 +32,9 @@
       --font-bold: 'Inter-Bold';
 
       --radius: 0.5rem;
+
+      --field-border-width: 0px;
+      --field-border: #3b82f6;
     }
   }
 }

--- a/example/global.css
+++ b/example/global.css
@@ -20,9 +20,6 @@
       --font-bold: 'Inter-Bold';
       
       --radius: 0.5rem;
-
-      --field-border-width: 0px;
-      --field-border: #3b82f6;
     }
 
     @variant dark {
@@ -32,9 +29,6 @@
       --font-bold: 'Inter-Bold';
 
       --radius: 0.5rem;
-
-      --field-border-width: 0px;
-      --field-border: #3b82f6;
     }
   }
 }

--- a/example/src/app/(home)/components/radio-group.tsx
+++ b/example/src/app/(home)/components/radio-group.tsx
@@ -34,6 +34,7 @@ const BasicRadioGroupContent = () => {
         <RadioGroup
           value={withDescSelection}
           onValueChange={setWithDescSelection}
+          isInvalid
         >
           <RadioGroup.Item value="desc1">
             <View className="flex-1">

--- a/src/components/accordion/accordion.styles.ts
+++ b/src/components/accordion/accordion.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({

--- a/src/components/alert/alert.styles.ts
+++ b/src/components/alert/alert.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 /**

--- a/src/components/avatar/avatar.styles.ts
+++ b/src/components/avatar/avatar.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 /**

--- a/src/components/bottom-sheet/bottom-sheet.styles.ts
+++ b/src/components/bottom-sheet/bottom-sheet.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 /**

--- a/src/components/button/button.styles.ts
+++ b/src/components/button/button.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 /**

--- a/src/components/card/card.styles.ts
+++ b/src/components/card/card.styles.ts
@@ -1,4 +1,4 @@
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({

--- a/src/components/checkbox/checkbox.styles.ts
+++ b/src/components/checkbox/checkbox.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 /**
@@ -22,7 +22,7 @@ import { combineStyles } from '../../helpers/internal/utils';
  * set `isAnimatedStyleActive={false}` on `Checkbox`.
  */
 const root = tv({
-  base: 'size-6 rounded-lg overflow-hidden',
+  base: 'size-6 rounded-lg border-field-width border-field-border overflow-hidden',
   variants: {
     variant: {
       primary: 'bg-field shadow-field',
@@ -38,7 +38,7 @@ const root = tv({
     },
     isInvalid: {
       true: 'border border-danger',
-      false: 'border-0',
+      false: '',
     },
   },
   compoundVariants: [

--- a/src/components/chip/chip.styles.ts
+++ b/src/components/chip/chip.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({

--- a/src/components/close-button/close-button.styles.ts
+++ b/src/components/close-button/close-button.styles.ts
@@ -1,4 +1,4 @@
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({

--- a/src/components/control-field/control-field.styles.ts
+++ b/src/components/control-field/control-field.styles.ts
@@ -1,4 +1,4 @@
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({

--- a/src/components/description/description.styles.ts
+++ b/src/components/description/description.styles.ts
@@ -1,4 +1,4 @@
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({

--- a/src/components/dialog/dialog.styles.ts
+++ b/src/components/dialog/dialog.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const portal = tv({

--- a/src/components/field-error/field-error.styles.ts
+++ b/src/components/field-error/field-error.styles.ts
@@ -1,4 +1,4 @@
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({

--- a/src/components/input-group/input-group.styles.ts
+++ b/src/components/input-group/input-group.styles.ts
@@ -1,4 +1,4 @@
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const prefix = tv({

--- a/src/components/input-otp/input-otp.styles.ts
+++ b/src/components/input-otp/input-otp.styles.ts
@@ -11,17 +11,17 @@ const group = tv({
 });
 
 const slot = tv({
-  base: 'h-12 w-11 items-center justify-center rounded-xl border-[1.5px] overflow-hidden',
+  base: 'h-12 w-11 items-center justify-center rounded-field border-field-width border-field-border overflow-hidden',
   variants: {
     variant: {
-      primary: 'bg-field border-field-border shadow-field',
-      secondary: 'bg-default border-default',
+      primary: 'bg-field shadow-field',
+      secondary: 'bg-default',
     },
     isActive: {
-      true: 'border-accent',
+      true: 'outline-2 outline-accent',
     },
     isInvalid: {
-      true: 'border-danger',
+      true: 'outline-2 outline-danger',
     },
     isDisabled: {
       true: 'opacity-disabled pointer-events-none',

--- a/src/components/input-otp/input-otp.styles.ts
+++ b/src/components/input-otp/input-otp.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({

--- a/src/components/input/input.styles.ts
+++ b/src/components/input/input.styles.ts
@@ -10,7 +10,7 @@ const input = tv({
       secondary: 'bg-default',
     },
     isInvalid: {
-      true: 'focus:outline-danger',
+      true: 'outline-danger focus:outline-danger',
       false: '',
     },
     isDisabled: {

--- a/src/components/input/input.styles.ts
+++ b/src/components/input/input.styles.ts
@@ -1,17 +1,16 @@
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const input = tv({
-  base: 'min-h-12 px-3 rounded-2xl text-foreground font-normal border-[1.5px] focus:border-accent',
+  base: 'min-h-12 px-3 text-foreground font-normal rounded-field border-field-width border-field-border outline-2 outline-transparent focus:outline-accent',
   variants: {
     variant: {
-      primary:
-        'bg-field border-field-border ios:shadow-field android:shadow-sm',
-      secondary: 'bg-default border-default',
+      primary: 'bg-field ios:shadow-field android:shadow-sm',
+      secondary: 'bg-default',
     },
     isInvalid: {
-      true: 'border-danger focus:border-danger',
+      true: 'focus:outline-danger',
       false: '',
     },
     isDisabled: {

--- a/src/components/label/label.styles.ts
+++ b/src/components/label/label.styles.ts
@@ -1,4 +1,4 @@
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({

--- a/src/components/link-button/link-button.styles.ts
+++ b/src/components/link-button/link-button.styles.ts
@@ -1,4 +1,4 @@
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({

--- a/src/components/list-group/list-group.styles.ts
+++ b/src/components/list-group/list-group.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({

--- a/src/components/menu/menu.styles.ts
+++ b/src/components/menu/menu.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const portal = tv({

--- a/src/components/popover/popover.styles.ts
+++ b/src/components/popover/popover.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const portal = tv({

--- a/src/components/pressable-feedback/pressable-feedback.styles.ts
+++ b/src/components/pressable-feedback/pressable-feedback.styles.ts
@@ -1,6 +1,6 @@
 /* eslint-disable prettier/prettier */
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({

--- a/src/components/radio-group/radio-group.styles.ts
+++ b/src/components/radio-group/radio-group.styles.ts
@@ -1,4 +1,4 @@
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({

--- a/src/components/radio/radio.styles.ts
+++ b/src/components/radio/radio.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 /** Root item layout style */

--- a/src/components/radio/radio.styles.ts
+++ b/src/components/radio/radio.styles.ts
@@ -9,7 +9,7 @@ const root = tv({
 
 /** Indicator container style (the radio circle) */
 const indicator = tv({
-  base: 'size-6 rounded-full border border-field-border items-center justify-center overflow-hidden',
+  base: 'size-6 rounded-full border-field-width border-field-border items-center justify-center overflow-hidden',
   variants: {
     variant: {
       primary: 'bg-field shadow-field',
@@ -28,7 +28,7 @@ const indicator = tv({
     {
       isInvalid: true,
       isSelected: true,
-      className: 'bg-danger border-danger',
+      className: 'bg-danger',
     },
   ],
   defaultVariants: {

--- a/src/components/scroll-shadow/scroll-shadow.styles.ts
+++ b/src/components/scroll-shadow/scroll-shadow.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 /**

--- a/src/components/search-field/search-field.styles.ts
+++ b/src/components/search-field/search-field.styles.ts
@@ -1,4 +1,4 @@
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({

--- a/src/components/select/select.styles.ts
+++ b/src/components/select/select.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const trigger = tv({

--- a/src/components/separator/separator.styles.ts
+++ b/src/components/separator/separator.styles.ts
@@ -1,4 +1,4 @@
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({

--- a/src/components/skeleton-group/skeleton-group.styles.ts
+++ b/src/components/skeleton-group/skeleton-group.styles.ts
@@ -1,4 +1,4 @@
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({

--- a/src/components/skeleton/skeleton.styles.ts
+++ b/src/components/skeleton/skeleton.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 /**

--- a/src/components/slider/slider.styles.ts
+++ b/src/components/slider/slider.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({

--- a/src/components/spinner/spinner.styles.ts
+++ b/src/components/spinner/spinner.styles.ts
@@ -1,4 +1,4 @@
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({

--- a/src/components/sub-menu/sub-menu.styles.ts
+++ b/src/components/sub-menu/sub-menu.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({

--- a/src/components/surface/surface.styles.ts
+++ b/src/components/surface/surface.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({

--- a/src/components/switch/switch.styles.ts
+++ b/src/components/switch/switch.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 /**

--- a/src/components/tabs/tabs.styles.ts
+++ b/src/components/tabs/tabs.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({

--- a/src/components/tag-group/tag-group.styles.ts
+++ b/src/components/tag-group/tag-group.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({

--- a/src/components/text-area/text-area.styles.ts
+++ b/src/components/text-area/text-area.styles.ts
@@ -1,4 +1,4 @@
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({

--- a/src/components/text-field/text-field.styles.ts
+++ b/src/components/text-field/text-field.styles.ts
@@ -1,4 +1,4 @@
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({

--- a/src/components/text/text.styles.ts
+++ b/src/components/text/text.styles.ts
@@ -1,5 +1,5 @@
 import { Platform, StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 import { CODE_FONT_FAMILY } from './text.constants';
 

--- a/src/components/toast/toast.styles.ts
+++ b/src/components/toast/toast.styles.ts
@@ -1,5 +1,5 @@
 import { StyleSheet } from 'react-native';
-import { tv } from 'tailwind-variants';
+import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 /**

--- a/src/helpers/external/utils/cn.ts
+++ b/src/helpers/external/utils/cn.ts
@@ -1,12 +1,78 @@
-import { cnMerge, type CnOptions } from 'tailwind-variants';
+import { extendTailwindMerge } from 'tailwind-merge';
+import {
+  cx,
+  defaultConfig,
+  tv as tvBase,
+  type CnOptions,
+  type TV,
+  type TWMergeConfig,
+} from 'tailwind-variants';
 
+/**
+ * Shared `tailwind-merge` configuration for HeroUI Native.
+ *
+ * @see https://www.tailwind-variants.org/docs/config
+ */
+export const twMergeConfig: TWMergeConfig = {
+  classGroups: {
+    'opacity': [{ opacity: ['disabled'] }],
+    'border-w': [{ border: ['field-width'] }],
+  },
+};
+
+/**
+ * Global config for all `tv` usage.
+ *
+ * @see https://www.tailwind-variants.org/docs/config#global-config
+ */
+defaultConfig.twMergeConfig = {
+  ...defaultConfig.twMergeConfig,
+  classGroups: {
+    ...defaultConfig.twMergeConfig?.classGroups,
+    ...twMergeConfig.classGroups,
+  },
+};
+
+const twMerge = extendTailwindMerge({
+  extend: {
+    classGroups: twMergeConfig.classGroups,
+  },
+});
+
+/**
+ * Merges class names with `tailwind-merge`, honoring {@link twMergeConfig}.
+ *
+ * Uses `cx` + `extendTailwindMerge` because `cnMerge(...)(config)` does not
+ * apply `twMergeConfig` from the config argument (tailwind-variants reads
+ * merge config from module-global state only).
+ *
+ * @param args - Class values to merge.
+ * @returns The merged, de-conflicted class string.
+ */
 export function cn(...args: CnOptions) {
-  return cnMerge(args)({
-    twMerge: true,
+  const merged = cx(args);
+
+  if (!merged) {
+    return merged;
+  }
+
+  return twMerge(merged);
+}
+
+/**
+ * HeroUI Native `tv` with {@link twMergeConfig} merged on every call.
+ *
+ * @see https://www.tailwind-variants.org/docs/config#advanced-custom-tv-wrapper
+ */
+export const tv: TV = (options, config) =>
+  tvBase(options, {
+    ...config,
+    twMerge: config?.twMerge ?? true,
     twMergeConfig: {
+      ...config?.twMergeConfig,
       classGroups: {
-        opacity: [{ opacity: ['disabled'] }],
+        ...config?.twMergeConfig?.classGroups,
+        ...twMergeConfig.classGroups,
       },
     },
   });
-}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -47,7 +47,7 @@
   --color-field-placeholder: var(--field-placeholder, var(--muted));
   --color-field-border: var(--field-border, var(--border));
   --radius-field: var(--field-radius, var(--radius-xl));
-  --border-width-field: var(--field-border-width, var(--border-width));
+  --border-width-field-width: var(--field-border-width, var(--border-width));
 
   --shadow-surface: var(--surface-shadow);
   --shadow-overlay: var(--overlay-shadow);

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -11,7 +11,7 @@
 
   /* Base radius */
   --radius: 0.5rem;
-  --field-radius: calc(var(--radius) * 1.5);
+  --field-radius: calc(var(--radius) * 1.75);
 
   /* Opacity */
   --opacity-disabled: 0.5;


### PR DESCRIPTION
## 📝 Description

Resolves the `border-field` / `border-field-border` class conflict by renaming the field border-width theme token to `border-field-width` and configuring `tailwind-variants` globally so width and color utilities no longer collapse during merge. Form-field components (input, OTP, radio, checkbox) are migrated to the new token plus outline-based focus/active/invalid states.

## ⛳️ Current behavior (updates)

In 1.0.5, `border-field` generated both a width and a color utility under the same name, so `tailwind-merge` dropped the width; field components hardcoded border widths (`border`, `border-[1.5px]`) and used border-color for focus/invalid.

## 🚀 New behavior

- `border-field-width` (width) and `border-field-border` (color) are separate, non-conflicting utilities.
- Configured `tv`/`cn` with a shared `twMergeConfig` (`border-w` group) registered globally; all `*.styles.ts` import `tv` from the lib.
- Input/OTP/radio/checkbox use `border-field-width` and `outline-*` for focus/active/invalid; invalid outline now shows at rest.
- `--field-radius` multiplier `1.5` → `1.75`.

## 💣 Is this a breaking change (Yes/No):

**Yes (visual/behavioral; public API unchanged).** Users should verify: (1) borders set via `--field-border` color alone no longer appear — `--field-border-width` now defaults to `0px`, so also set a width; (2) focus/active/invalid use `outline-*`; (3) `border-field` used directly for width must become `border-field-width`; (4) overrides of the `--border-width-field` theme key must use `--border-width-field-width` (or the `--field-border-width` primitive); (5) field corner radius changes slightly (`--field-radius` 1.5 → 1.75).

## 📝 Additional Information

Type-checked and linted; verified merged output keeps both `border-field-width` and `border-field-border`. Recommend confirming Input/OTP/radio/checkbox on both new and old RN architecture, and setting a non-zero `--field-border-width` default if resting borders are expected for consumers relying on `--field-border` color.