### PR TITLE
Add default dynamicTypeRamp to Typography components

### DIFF
--- a/src/components/text/text.constants.ts
+++ b/src/components/text/text.constants.ts
@@ -1,3 +1,6 @@
+import type { TextPropsIOS } from 'react-native';
+import type { TextType } from './text.types';
+
 /**
  * Display names for Text components
  */
@@ -7,6 +10,22 @@ export const DISPLAY_NAME = {
   TEXT_PARAGRAPH: 'HeroUINative.Text.Paragraph',
   TEXT_CODE: 'HeroUINative.Text.Code',
 } as const;
+
+export const DYNAMIC_TYPE_RAMP: Record<
+  TextType,
+  TextPropsIOS['dynamicTypeRamp']
+> = {
+  'h1': 'largeTitle',
+  'h2': 'title1',
+  'h3': 'title2',
+  'h4': 'title3',
+  'h5': 'headline',
+  'h6': 'subheadline',
+  'body': 'body',
+  'body-sm': 'body',
+  'body-xs': 'footnote',
+  'code': 'body',
+};
 
 /**
  * Monospaced font family used by `Text.Code` on Android and web.

--- a/src/components/text/text.tsx
+++ b/src/components/text/text.tsx
@@ -1,7 +1,7 @@
 import { forwardRef } from 'react';
 import { HeroText } from '../../helpers/internal/components';
 import type { TextRef } from '../../helpers/internal/types';
-import { DISPLAY_NAME } from './text.constants';
+import { DISPLAY_NAME, DYNAMIC_TYPE_RAMP } from './text.constants';
 import { styleSheet, textClassNames } from './text.styles';
 import type {
   TextCodeProps,
@@ -53,12 +53,18 @@ const TextRoot = forwardRef<TextRef, TextRootProps>((props, ref) => {
 // --------------------------------------------------
 
 const TextHeading = forwardRef<TextRef, TextHeadingProps>((props, ref) => {
-  const { type = 'h1', accessibilityRole = 'header', ...restProps } = props;
+  const {
+    type = 'h1',
+    accessibilityRole = 'header',
+    dynamicTypeRamp = DYNAMIC_TYPE_RAMP[type],
+    ...restProps
+  } = props;
   return (
     <TextRoot
       ref={ref}
       type={type}
       accessibilityRole={accessibilityRole}
+      dynamicTypeRamp={dynamicTypeRamp}
       {...restProps}
     />
   );
@@ -67,8 +73,19 @@ const TextHeading = forwardRef<TextRef, TextHeadingProps>((props, ref) => {
 // --------------------------------------------------
 
 const TextParagraph = forwardRef<TextRef, TextParagraphProps>((props, ref) => {
-  const { type = 'body', ...restProps } = props;
-  return <TextRoot ref={ref} type={type} {...restProps} />;
+  const {
+    type = 'body',
+    dynamicTypeRamp = DYNAMIC_TYPE_RAMP[type],
+    ...restProps
+  } = props;
+  return (
+    <TextRoot
+      ref={ref}
+      type={type}
+      dynamicTypeRamp={dynamicTypeRamp}
+      {...restProps}
+    />
+  );
 });
 
 // --------------------------------------------------


### PR DESCRIPTION
## 📝 Description

Hi, I'm going through text accessibility for iOS now and having this prop would help a little with text scaling. Seems like this is the Apple intends it to be.
In Apple's Dynamic Type, fonts scale in different factors depending on their semantics, i.e. title scale slower than body since they are already large.
Ideally this prop should be added to all labels, but it would be a little more intricate, while for Typography it's pretty straight forward.
One thing I'm not sure about is `h6` -> `subheadline` mapping, since in Apply system `subheadline` is smaller than `body`. Feel free to adjust any of the values.
Would you consider merging something like this? Thanks!

## ⛳️ Current behavior (updates)

Text in different Typography components scales the same way.

## 🚀 New behavior

Text in different Typography components scales with different factor depending on its type (iOS only).

## 💣 Is this a breaking change (Yes/No):

No

## 📝 Additional Information

Source:
https://developer.apple.com/design/human-interface-guidelines/typography#Specifications

Scaling for different size settings (default Large setting is unchanged):

<table>
  <tr>
    <td align="center">
	Without `dynamicTypeRamp`
    </td>
    <td align="center">
      With `dynamicTypeRamp`
    </td>
  </tr>
  <tr>
    <td colspan="2" align="center">
      xSmall
    </td>
  </tr>
  <tr>
    <td align="center">
      <img width="1170" height="2532" alt="IMG_4792" src="https://github.com/user-attachments/assets/4e7287cd-5e4a-4a52-b71b-6a42b8d7394e" /> 
    </td>
    <td align="center">
      <img width="1170" height="2532" alt="IMG_4793" src="https://github.com/user-attachments/assets/5b901f31-08f3-4704-86a6-17cd4bfacb80" />
    </td>
  </tr>
  <tr>
    <td colspan="2" align="center">
      Large (default)
    </td>
  </tr>
  <tr>
    <td align="center">
      <img width="1170" height="2532" alt="IMG_4794" src="https://github.com/user-attachments/assets/4a2ad9ee-fd0c-49ed-af34-d04d1816cfb6" />
    </td>
    <td align="center">
      <img width="1170" height="2532" alt="IMG_4795" src="https://github.com/user-attachments/assets/457aea4c-6bf7-497e-9545-ba3da2db2997" />
    </td>
  </tr>

  <tr>
    <td colspan="2" align="center">
      xxxLarge
    </td>
  </tr>
  <tr>
    <td align="center">
		<img width="1170" height="2532" alt="IMG_4796" src="https://github.com/user-attachments/assets/5832857f-a893-4e0a-8726-ea5792a425e2" />
    </td>
    <td align="center">
		<img width="1170" height="2532" alt="IMG_4797" src="https://github.com/user-attachments/assets/03c34ea2-a356-4d4b-9f58-a94fbee944fc" />
    </td>
  </tr>

  <tr>
    <td colspan="2" align="center">
      AX2
    </td>
  </tr>
  <tr>
    <td align="center">
		<img width="1170" height="2532" alt="IMG_4798" src="https://github.com/user-attachments/assets/40501a43-1613-4504-bca5-35c4f18f027e" />
    </td>
    <td align="center">
		<img width="1170" height="2532" alt="IMG_4799" src="https://github.com/user-attachments/assets/44cdcb21-5f36-4c65-8be5-689b445b2685" />
    </td>
  </tr>
</table>






