### PR TITLE
fix(select): use accent-soft-foreground for check icon

### DIFF
--- a/src/components/select/select.md
+++ b/src/components/select/select.md
@@ -699,7 +699,7 @@ When using a render function for `children`, the following props are provided:
 | prop    | type     | default          | description       |
 | ------- | -------- | ---------------- | ----------------- |
 | `size`  | `number` | `16`             | Size of the icon  |
-| `color` | `string` | `--colors-muted` | Color of the icon |
+| `color` | `string` | theme accent-soft-foreground color | Color of the icon |
 
 ## Hooks
 

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -703,10 +703,12 @@ const SelectItemIndicator = forwardRef<
   SelectPrimitivesTypes.ItemIndicatorRef,
   SelectItemIndicatorProps
 >(({ className, children, iconProps, ...props }, ref) => {
-  const themeColorAccent = useThemeColor('accent');
+  const themeColorAccentSoftForeground = useThemeColor(
+    'accent-soft-foreground'
+  );
 
   const iconSize = iconProps?.size ?? 16;
-  const iconColor = iconProps?.color ?? themeColorAccent;
+  const iconColor = iconProps?.color ?? themeColorAccentSoftForeground;
 
   const itemIndicatorClassName = selectClassNames.itemIndicator({ className });
 

--- a/src/components/select/select.types.ts
+++ b/src/components/select/select.types.ts
@@ -428,6 +428,7 @@ export interface SelectItemIndicatorIconProps {
   size?: number;
   /**
    * Color of the check icon
+   * @default theme accent-soft-foreground color
    */
   color?: string;
 }


### PR DESCRIPTION
## 📝 Description

Updates the default check icon color on `Select.ItemIndicator` from the `accent` theme token to `accent-soft-foreground`. This aligns the selected-item indicator with the intended semantic foreground color for better contrast and visual consistency.

## ⛳️ Current behavior (updates)

The check icon in `Select.ItemIndicator` defaults to the `accent` theme color when `iconProps.color` is not provided.

## 🚀 New behavior

- Default check icon color uses `accent-soft-foreground` instead of `accent`
- JSDoc and component docs updated to reflect the new default

## 💣 Is this a breaking change (Yes/No):

**No** - Only the default icon color changes when `iconProps.color` is omitted; the API is unchanged and custom colors still work.

## 📝 Additional Information

Single commit on branch `fix/select-indicator`. No new dependencies. Manual verification recommended on light and dark themes to confirm indicator contrast in selected list items.