### PR TITLE
feat(provider): add global text input props config

### DIFF
--- a/docs/provider.md
+++ b/docs/provider.md
@@ -1,6 +1,6 @@
 # HeroUINativeProvider
 
-Configure HeroUI Native provider with text, animation, and toast settings
+Configure HeroUI Native provider with text, text input, animation, and toast settings
 
 ## Overview
 
@@ -8,6 +8,7 @@ The provider serves as the main entry point for HeroUI Native, wrapping your app
 
 - **Safe Area Insets**: Automatically handles safe area insets updates via `SafeAreaListener` and syncs them with Uniwind for use in Tailwind classes (e.g., `pb-safe-offset-3`)
 - **Text Configuration**: Global text component settings for consistency across all HeroUI components
+- **Text Input Configuration**: Global text input settings for consistency across all HeroUI input components
 - **Animation Configuration**: Global animation control to disable all animations across the application
 - **Toast Configuration**: Global toast system configuration including insets, default props, and wrapper components
 - **Portal Management**: Handles overlays, modals, and other components that render on top of the app hierarchy
@@ -65,6 +66,37 @@ export default function App() {
   );
 }
 ```
+
+### Text Input Component Configuration
+
+Global settings for all TextInput-based components within HeroUI Native (e.g. Input, TextArea, SearchField, InputGroup, InputOTP). These props are carefully selected to include only those that make sense to configure globally across all inputs in the application:
+
+```tsx
+import { HeroUINativeProvider } from 'heroui-native';
+import type { HeroUINativeConfig } from 'heroui-native';
+
+const config: HeroUINativeConfig = {
+  textInputProps: {
+    // Respect Text Size accessibility settings
+    allowFontScaling: false,
+
+    // Maximum font size multiplier when allowFontScaling is enabled
+    maxFontSizeMultiplier: 1.5,
+  },
+};
+
+export default function App() {
+  return (
+    <HeroUINativeProvider config={config}>
+      {/* Your app content */}
+    </HeroUINativeProvider>
+  );
+}
+```
+
+<Callout type="info">
+  **Note**: These props are applied as defaults. Any prop passed directly to an individual input component overrides the corresponding global value.
+</Callout>
 
 ### Animation Configuration
 
@@ -171,6 +203,11 @@ const config: HeroUINativeConfig = {
     allowFontScaling: true,
     adjustsFontSizeToFit: false,
   },
+  // Global text input configuration
+  textInputProps: {
+    allowFontScaling: true,
+    maxFontSizeMultiplier: 1.5,
+  },
   // Global animation configuration
   animation: 'disable-all', // Optional: disable all animations
   // Developer information messages configuration
@@ -246,13 +283,14 @@ HeroUINativeProvider
 ├── SafeAreaListener (handles safe area insets updates)
 │   └── GlobalAnimationSettingsProvider (animation configuration)
 │       └── TextComponentProvider (text configuration)
-│           └── ToastProvider (toast configuration, conditionally rendered)
-│               └── Your App
-│               └── PortalHost (for overlays)
+│           └── TextInputComponentProvider (text input configuration)
+│               └── ToastProvider (toast configuration, conditionally rendered)
+│                   └── Your App
+│                   └── PortalHost (for overlays)
 ```
 
 <Callout type="info">
-  **Note**: The `ToastProvider` is conditionally rendered based on the `toast` configuration. If `toast` is set to `false` or `'disabled'`, the `ToastProvider` will not be rendered, and the app content and `PortalHost` will be rendered directly under `TextComponentProvider`.
+  **Note**: The `ToastProvider` is conditionally rendered based on the `toast` configuration. If `toast` is set to `false` or `'disabled'`, the `ToastProvider` will not be rendered, and the app content and `PortalHost` will be rendered directly under `TextInputComponentProvider`.
 </Callout>
 
 ### Safe Area Insets Handling
@@ -327,7 +365,8 @@ HeroUINativeProviderRaw
 ├── SafeAreaListener (handles safe area insets updates)
 │   └── GlobalAnimationSettingsProvider (animation configuration)
 │       └── TextComponentProvider (text configuration)
-│           └── Your App
+│           └── TextInputComponentProvider (text input configuration)
+│               └── Your App
 ```
 
 ## Best Practices
@@ -413,6 +452,10 @@ import { HeroUINativeProvider, type HeroUINativeConfig } from 'heroui-native';
 const config: HeroUINativeConfig = {
   // Full type safety and autocomplete
   textProps: {
+    allowFontScaling: true,
+    maxFontSizeMultiplier: 1.5,
+  },
+  textInputProps: {
     allowFontScaling: true,
     maxFontSizeMultiplier: 1.5,
   },

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -1,6 +1,7 @@
 import { forwardRef } from 'react';
-import { TextInput, type TextInput as TextInputType } from 'react-native';
+import { type TextInput as TextInputType } from 'react-native';
 import { useIsOnSurface } from '../../helpers/external/hooks';
+import { HeroTextInput } from '../../helpers/internal/components';
 import { useFormField } from '../../helpers/internal/contexts';
 import { DISPLAY_NAME } from './input.constants';
 import { inputClassNames, inputStyleSheet } from './input.styles';
@@ -56,7 +57,7 @@ const InputRoot = forwardRef<TextInputType, InputProps>((props, ref) => {
   });
 
   return (
-    <TextInput
+    <HeroTextInput
       ref={ref}
       className={inputClassName}
       style={[inputStyleSheet.borderCurve, style]}

--- a/src/helpers/external/hooks/index.ts
+++ b/src/helpers/external/hooks/index.ts
@@ -1,4 +1,5 @@
 export { useTextComponent } from '../../../providers/text-component/index';
+export { useTextInputComponent } from '../../../providers/text-input-component/index';
 export * from '../../internal/hooks/use-combined-animation-disabled-state';
 export * from './use-bottom-sheet-aware-handlers';
 export * from './use-is-on-surface';

--- a/src/helpers/internal/components/hero-text-input.tsx
+++ b/src/helpers/internal/components/hero-text-input.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import {
+  TextInput as RNTextInput,
+  type TextInputProps as RNTextInputProps,
+} from 'react-native';
+import { useTextInputComponent } from '../../external/hooks';
+
+/**
+ * Props for HeroTextInput component
+ */
+export interface HeroTextInputProps extends RNTextInputProps {}
+
+/**
+ * HeroTextInput component that automatically applies global text input
+ * configuration from HeroUINativeProvider.
+ *
+ * This component is distinct from React Native's TextInput component and
+ * merges globally configured props (applied as defaults) with the props
+ * passed directly to the component.
+ *
+ * Global text input props that can be configured:
+ * - allowFontScaling: Respect Text Size accessibility settings
+ * - maxFontSizeMultiplier: Maximum font scale when allowFontScaling is enabled
+ *
+ * @example
+ * ```tsx
+ * <HeroTextInput value={value} onChangeText={setValue} />
+ * ```
+ *
+ * @example
+ * Global configuration in HeroUINativeProvider:
+ * ```tsx
+ * <HeroUINativeProvider config={{
+ *   textInputProps: {
+ *     allowFontScaling: false,
+ *     maxFontSizeMultiplier: 1.5
+ *   }
+ * }}>
+ *   <App />
+ * </HeroUINativeProvider>
+ * ```
+ */
+export const HeroTextInput = React.forwardRef<RNTextInput, HeroTextInputProps>(
+  (props, ref) => {
+    const { textInputProps } = useTextInputComponent();
+
+    const mergedProps = Object.assign({}, textInputProps, props);
+
+    return <RNTextInput ref={ref} {...mergedProps} />;
+  }
+);
+
+HeroTextInput.displayName = 'HeroTextInput';

--- a/src/helpers/internal/components/index.ts
+++ b/src/helpers/internal/components/index.ts
@@ -7,3 +7,4 @@ export * from './chevron-right-icon';
 export * from './close-icon';
 export * from './full-window-overlay';
 export * from './hero-text';
+export * from './hero-text-input';

--- a/src/primitives/input-otp/input-otp.tsx
+++ b/src/primitives/input-otp/input-otp.tsx
@@ -21,6 +21,7 @@ import {
   type BlurEvent,
   type FocusEvent,
 } from 'react-native';
+import { HeroTextInput } from '../../helpers/internal/components';
 import { useControllableState } from '../../helpers/internal/hooks';
 import * as SlotPrimitive from '../slot';
 import type {
@@ -281,7 +282,7 @@ const Root = forwardRef<RootRef, RootProps>(
           className={className}
         >
           {children}
-          <TextInput
+          <HeroTextInput
             ref={inputRef}
             style={[
               StyleSheet.absoluteFill,

--- a/src/providers/hero-ui-native-raw/provider.tsx
+++ b/src/providers/hero-ui-native-raw/provider.tsx
@@ -4,6 +4,7 @@ import { Uniwind } from 'uniwind';
 import { useDevInfo } from '../../helpers/internal/hooks';
 import { GlobalAnimationSettingsProvider } from '../animation-settings';
 import { TextComponentProvider } from '../text-component/provider';
+import { TextInputComponentProvider } from '../text-input-component/provider';
 import type { HeroUINativeProviderRawProps } from './types';
 
 /**
@@ -18,6 +19,7 @@ import type { HeroUINativeProviderRawProps } from './types';
  * Currently provides:
  * - Global animation settings
  * - Global text component configuration
+ * - Global text input component configuration
  *
  * @param {HeroUINativeProviderRawProps} props - Provider configuration props
  * @param {ReactNode} props.children - Child components to wrap
@@ -28,7 +30,7 @@ const HeroUINativeProviderRaw: React.FC<HeroUINativeProviderRawProps> = ({
   children,
   config = {},
 }) => {
-  const { textProps, animation, devInfo } = config;
+  const { textProps, textInputProps, animation, devInfo } = config;
 
   useDevInfo(devInfo);
 
@@ -40,7 +42,9 @@ const HeroUINativeProviderRaw: React.FC<HeroUINativeProviderRawProps> = ({
     >
       <GlobalAnimationSettingsProvider animation={animation}>
         <TextComponentProvider value={{ textProps }}>
-          {children}
+          <TextInputComponentProvider value={{ textInputProps }}>
+            {children}
+          </TextInputComponentProvider>
         </TextComponentProvider>
       </GlobalAnimationSettingsProvider>
     </SafeAreaListener>

--- a/src/providers/hero-ui-native-raw/types.ts
+++ b/src/providers/hero-ui-native-raw/types.ts
@@ -10,7 +10,7 @@ import type { HeroUINativeConfig } from '../hero-ui-native/types';
  */
 export type HeroUINativeConfigRaw = Pick<
   HeroUINativeConfig,
-  'textProps' | 'animation' | 'devInfo'
+  'textProps' | 'textInputProps' | 'animation' | 'devInfo'
 >;
 
 /**

--- a/src/providers/hero-ui-native/provider.tsx
+++ b/src/providers/hero-ui-native/provider.tsx
@@ -5,6 +5,7 @@ import { useDevInfo } from '../../helpers/internal/hooks';
 import { PortalHost } from '../../primitives/portal';
 import { GlobalAnimationSettingsProvider } from '../animation-settings';
 import { TextComponentProvider } from '../text-component/provider';
+import { TextInputComponentProvider } from '../text-input-component/provider';
 import { ToastProvider } from '../toast/provider';
 import type { HeroUINativeProviderProps } from './types';
 
@@ -19,6 +20,7 @@ import type { HeroUINativeProviderProps } from './types';
  * Currently provides:
  * - Global animation settings
  * - Global text component configuration
+ * - Global text input component configuration
  * - Toast notification system
  * - Portal management for overlays
  *
@@ -31,7 +33,7 @@ const HeroUINativeProvider: React.FC<HeroUINativeProviderProps> = ({
   children,
   config = {},
 }) => {
-  const { textProps, toast, animation, devInfo } = config;
+  const { textProps, textInputProps, toast, animation, devInfo } = config;
 
   useDevInfo(devInfo);
 
@@ -47,17 +49,19 @@ const HeroUINativeProvider: React.FC<HeroUINativeProviderProps> = ({
     >
       <GlobalAnimationSettingsProvider animation={animation}>
         <TextComponentProvider value={{ textProps }}>
-          {isToastEnabled ? (
-            <ToastProvider {...toastProps}>
-              {children}
-              <PortalHost />
-            </ToastProvider>
-          ) : (
-            <>
-              {children}
-              <PortalHost />
-            </>
-          )}
+          <TextInputComponentProvider value={{ textInputProps }}>
+            {isToastEnabled ? (
+              <ToastProvider {...toastProps}>
+                {children}
+                <PortalHost />
+              </ToastProvider>
+            ) : (
+              <>
+                {children}
+                <PortalHost />
+              </>
+            )}
+          </TextInputComponentProvider>
         </TextComponentProvider>
       </GlobalAnimationSettingsProvider>
     </SafeAreaListener>

--- a/src/providers/hero-ui-native/types.ts
+++ b/src/providers/hero-ui-native/types.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react';
 import type { AnimationRootDisableAll } from '../../helpers/internal/types';
 import type { TextComponentContextValue } from '../text-component/types';
+import type { TextInputComponentContextValue } from '../text-input-component/types';
 import type { ToastProviderProps } from '../toast/types';
 
 /**
@@ -30,12 +31,15 @@ export interface DevInfoConfig {
  *
  * @interface HeroUINativeConfig
  * @extends TextComponentContextValue
+ * @extends TextInputComponentContextValue
  *
  * @description
  * Contains configuration options for the HeroUI Native provider.
  * Additional configuration options can be added in future versions.
  */
-export interface HeroUINativeConfig extends TextComponentContextValue {
+export interface HeroUINativeConfig
+  extends TextComponentContextValue,
+    TextInputComponentContextValue {
   /**
    * Global animation configuration
    *

--- a/src/providers/text-input-component/index.ts
+++ b/src/providers/text-input-component/index.ts
@@ -1,0 +1,2 @@
+export * from './provider';
+export * from './types';

--- a/src/providers/text-input-component/provider.tsx
+++ b/src/providers/text-input-component/provider.tsx
@@ -1,0 +1,9 @@
+import { createContext } from '../../helpers/internal/utils';
+import type { TextInputComponentContextValue } from './types';
+
+const [TextInputComponentProvider, useTextInputComponent] =
+  createContext<TextInputComponentContextValue>({
+    name: 'TextInputComponentContext',
+  });
+
+export { TextInputComponentProvider, useTextInputComponent };

--- a/src/providers/text-input-component/types.ts
+++ b/src/providers/text-input-component/types.ts
@@ -1,0 +1,38 @@
+import type { TextInputProps } from 'react-native';
+
+/**
+ * Global text input component configuration props.
+ * These props are carefully selected to include only those that make sense
+ * to configure globally across all TextInput components in the application.
+ *
+ * @description
+ * Includes font scaling settings that typically should be consistent
+ * throughout the app for better UX.
+ */
+export type TextInputComponentProps = {
+  /**
+   * Specifies whether fonts should scale to respect Text Size accessibility settings.
+   *
+   * @default true
+   */
+  allowFontScaling?: TextInputProps['allowFontScaling'];
+  /**
+   * Specifies the largest possible scale a font can reach when `allowFontScaling` is enabled.
+   *
+   * Possible values:
+   *
+   * - `null` or `undefined`: inherit from the parent node or the global default (0)
+   * - `0`: no max, ignore parent/global default
+   * - `>= 1`: sets the `maxFontSizeMultiplier` of this node to this value
+   *
+   * @default `undefined`
+   */
+  maxFontSizeMultiplier?: TextInputProps['maxFontSizeMultiplier'];
+};
+
+/**
+ * Context value for text input component configuration
+ */
+export interface TextInputComponentContextValue {
+  textInputProps?: TextInputComponentProps;
+}


### PR DESCRIPTION
## 📝 Description

Adds the ability to configure a subset of `TextInput` props globally through `HeroUINativeProvider` and `HeroUINativeProviderRaw`, starting with `allowFontScaling` and `maxFontSizeMultiplier`. This mirrors the existing global `textProps` pattern and keeps input font-scaling behavior consistent across the app.

## ⛳️ Current behavior (updates)

Global configuration only covered `textProps` for Text components; input components had no shared, provider-level configuration.

## 🚀 New behavior

- New `textInputProps` config on `HeroUINativeConfig` and `HeroUINativeConfigRaw` (`allowFontScaling`, `maxFontSizeMultiplier`).
- New `TextInputComponentProvider` / `useTextInputComponent` and a `HeroTextInput` helper that applies global props as overridable defaults.
- Applied across `Input` (and thus `TextArea`, `SearchField`, `InputGroup`) and the `InputOTP` primitive.
- Updated `docs/provider.md` with the new section, examples, and provider hierarchy.

## 💣 Is this a breaking change (Yes/No):

**No** - Global props are applied as defaults, and any prop passed directly to a component still overrides them.

## 📝 Additional Information

Type-checking passes via `yarn typecheck` with no new lint errors. No new dependencies were added.