### PR TITLE
perf(popover): mount content once via shared-value driven enter animation

### DIFF
--- a/src/components/menu/menu.tsx
+++ b/src/components/menu/menu.tsx
@@ -258,17 +258,66 @@ const MenuContentPopover = forwardRef<
       className,
     });
 
-    const { entering, exiting } = usePopupPopoverContentAnimation({
-      placement,
-      offset,
-      animation,
-    });
+    const { isDrivenEntering, rEnteringStyle, entering, exiting } =
+      usePopupPopoverContentAnimation({
+        placement,
+        offset,
+        animation,
+        isReady,
+      });
 
     const rContainerStyle = useMenuContentPopoverAnimation({
       isSubMenuOpen,
       animation,
     });
 
+    // Single-mount path: the content subtree is rendered once and animated in
+    // via a shared value once it has been measured and positioned (`isReady`).
+    // `rEnteringStyle` precedes `rContainerStyle` so the sub-menu scale still
+    // wins once the enter transition has settled, while opacity comes from the
+    // entering style.
+    if (isDrivenEntering) {
+      return (
+        <MenuContentContext value={{ placement }}>
+          <AnimatedContent
+            ref={ref}
+            exiting={isSubMenuOpen ? FadeOut.duration(150) : exiting}
+            placement={placement}
+            align={align}
+            avoidCollisions={avoidCollisions}
+            offset={offset}
+            alignOffset={alignOffset}
+            insets={insets}
+            collapsable={false}
+            pointerEvents={isReady ? undefined : 'none'}
+            className={contentClassName}
+            style={[
+              menuStyleSheet.borderCurve,
+              rEnteringStyle,
+              rContainerStyle,
+              style,
+            ]}
+            {...props}
+          >
+            {children}
+            {isSubMenuOpen && (
+              <Pressable
+                className="absolute inset-0 z-40"
+                onPress={() => {
+                  if (openSubMenuId !== null) {
+                    closeSubMenu(openSubMenuId);
+                  }
+                }}
+              />
+            )}
+          </AnimatedContent>
+        </MenuContentContext>
+      );
+    }
+
+    // Fallback path: a custom entering Keyframe was provided, which must fire
+    // on mount, so a hidden probe measures the content before the visible node
+    // mounts and plays the Keyframe.
     return (
       <MenuContentContext value={{ placement }}>
         {isReady && (

--- a/src/components/popover/popover.tsx
+++ b/src/components/popover/popover.tsx
@@ -256,12 +256,43 @@ const PopoverContentPopover = forwardRef<
       className,
     });
 
-    const { entering, exiting } = usePopupPopoverContentAnimation({
-      placement,
-      offset,
-      animation,
-    });
+    const { isDrivenEntering, rEnteringStyle, entering, exiting } =
+      usePopupPopoverContentAnimation({
+        placement,
+        offset,
+        animation,
+        isReady,
+      });
 
+    // Single-mount path: the content subtree is rendered once and animated in
+    // via a shared value once it has been measured and positioned (`isReady`).
+    if (isDrivenEntering) {
+      return (
+        <PopoverContentContext value={{ placement }}>
+          <AnimatedContent
+            ref={ref}
+            exiting={exiting}
+            placement={placement}
+            align={align}
+            avoidCollisions={avoidCollisions}
+            offset={offset}
+            alignOffset={alignOffset}
+            insets={insets}
+            collapsable={false}
+            pointerEvents={isReady ? undefined : 'none'}
+            className={contentClassName}
+            style={[popoverStyleSheet.contentContainer, style, rEnteringStyle]}
+            {...props}
+          >
+            {children}
+          </AnimatedContent>
+        </PopoverContentContext>
+      );
+    }
+
+    // Fallback path: a custom entering Keyframe was provided, which must fire
+    // on mount, so a hidden probe measures the content before the visible node
+    // mounts and plays the Keyframe.
     return (
       <PopoverContentContext value={{ placement }}>
         {isReady && (

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -358,12 +358,41 @@ const SelectContentPopover = forwardRef<
       className,
     });
 
-    const { entering, exiting } = usePopupPopoverContentAnimation({
-      placement,
-      offset,
-      animation,
-    });
+    const { isDrivenEntering, rEnteringStyle, entering, exiting } =
+      usePopupPopoverContentAnimation({
+        placement,
+        offset,
+        animation,
+        isReady,
+      });
 
+    // Single-mount path: the content subtree is rendered once and animated in
+    // via a shared value once it has been measured and positioned (`isReady`).
+    if (isDrivenEntering) {
+      return (
+        <AnimatedPopoverContent
+          ref={ref}
+          exiting={exiting}
+          placement={placement}
+          align={align}
+          avoidCollisions={avoidCollisions}
+          offset={offset}
+          alignOffset={alignOffset}
+          insets={insets}
+          collapsable={false}
+          pointerEvents={isReady ? undefined : 'none'}
+          className={contentClassName}
+          style={[selectStyleSheet.contentContainer, style, rEnteringStyle]}
+          {...props}
+        >
+          {children}
+        </AnimatedPopoverContent>
+      );
+    }
+
+    // Fallback path: a custom entering Keyframe was provided, which must fire
+    // on mount, so a hidden probe measures the content before the visible node
+    // mounts and plays the Keyframe.
     return (
       <>
         {isReady && (

--- a/src/helpers/internal/hooks/use-popup-popover-content-animation.ts
+++ b/src/helpers/internal/hooks/use-popup-popover-content-animation.ts
@@ -1,6 +1,11 @@
+import { useEffect } from 'react';
 import {
   Easing,
   Keyframe,
+  interpolate,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
   type EntryOrExitLayoutType,
 } from 'react-native-reanimated';
 import { useAnimationSettings } from '../contexts/animation-settings-context';
@@ -14,6 +19,18 @@ import {
  * Placement options for popover/select content
  */
 export type PopoverContentPlacement = 'top' | 'bottom' | 'left' | 'right';
+
+/**
+ * Duration (ms) of the shared-value driven entering transition.
+ * Mirrors the default entering Keyframe duration.
+ */
+const DRIVEN_ENTERING_DURATION = 200;
+
+/**
+ * Maximum translate distance (px) applied during the entering transition.
+ * Mirrors the clamp used by the default entering/exiting Keyframes.
+ */
+const MAX_TRANSLATE_DISTANCE = 12;
 
 /**
  * Props for usePopupPopoverContentAnimation hook
@@ -31,73 +48,15 @@ export interface UsePopupPopoverContentAnimationProps {
    * Animation configuration for content
    */
   animation?: PopupPopoverContentAnimation;
+  /**
+   * Whether the content has been measured and positioned on screen.
+   * The driven entering transition only plays once this becomes `true`,
+   * which allows the content subtree to be mounted a single time while
+   * still animating in at the correct position.
+   * @default false
+   */
+  isReady?: boolean;
 }
-/**
- * Get default entering animation based on placement
- * Uses Keyframes with translateY/translateX, scale, and opacity transitions
- */
-function getDefaultEnteringAnimation(
-  placement: PopoverContentPlacement,
-  offset: number
-): EntryOrExitLayoutType {
-  const translateDistance = Math.min(offset, 12);
-
-  switch (placement) {
-    case 'top':
-      // Content comes from below (translateY: translateDistance -> 0)
-      return new Keyframe({
-        0: {
-          transform: [{ translateY: translateDistance }, { scale: 0.97 }],
-          opacity: 0.25,
-        },
-        100: {
-          transform: [{ translateY: 0 }, { scale: 1 }],
-          opacity: 1,
-          easing: Easing.out(Easing.ease),
-        },
-      }).duration(200);
-    case 'bottom':
-      // Content comes from above (translateY: -translateDistance -> 0)
-      return new Keyframe({
-        0: {
-          transform: [{ translateY: -translateDistance }, { scale: 0.97 }],
-          opacity: 0.25,
-        },
-        100: {
-          transform: [{ translateY: 0 }, { scale: 1 }],
-          opacity: 1,
-          easing: Easing.out(Easing.ease),
-        },
-      }).duration(200);
-    case 'left':
-      // Content comes from right (translateX: translateDistance -> 0)
-      return new Keyframe({
-        0: {
-          transform: [{ translateX: translateDistance }, { scale: 0.97 }],
-          opacity: 0.25,
-        },
-        100: {
-          transform: [{ translateX: 0 }, { scale: 1 }],
-          opacity: 1,
-          easing: Easing.out(Easing.ease),
-        },
-      }).duration(200);
-    case 'right':
-      // Content comes from left (translateX: -translateDistance -> 0)
-      return new Keyframe({
-        0: {
-          transform: [{ translateX: -translateDistance }, { scale: 0.97 }],
-          opacity: 0.25,
-        },
-        100: {
-          transform: [{ translateX: 0 }, { scale: 1 }],
-          opacity: 1,
-          easing: Easing.out(Easing.ease),
-        },
-      }).duration(200);
-  }
-}
-
 /**
  * Get default exiting animation based on placement
  * Mirrors the entering animation for each placement
@@ -165,13 +124,43 @@ function getDefaultExitingAnimation(
 }
 
 /**
- * Animation hook for popover/select content components
- * Returns entering and exiting animations based on configuration and placement
+ * Get the signed translate axis/distance for the driven entering transition.
+ * `top`/`left` start at `+distance`, `bottom`/`right` start at `-distance`,
+ * mirroring the default exiting Keyframe's direction per placement.
+ */
+function getEnteringTranslate(
+  placement: PopoverContentPlacement,
+  offset: number
+): { axis: 'x' | 'y'; distance: number } {
+  const distance = Math.min(offset, MAX_TRANSLATE_DISTANCE);
+
+  switch (placement) {
+    case 'top':
+      return { axis: 'y', distance };
+    case 'bottom':
+      return { axis: 'y', distance: -distance };
+    case 'left':
+      return { axis: 'x', distance };
+    case 'right':
+      return { axis: 'x', distance: -distance };
+  }
+}
+
+/**
+ * Animation hook for popover/select content components.
+ *
+ * Returns a shared-value driven entering style (`rEnteringStyle`) plus the
+ * exiting Keyframe. The driven entering style lets the content subtree mount a
+ * single time (for measurement) while the enter animation is deferred until the
+ * content is positioned on screen (`isReady`). When a custom `entering` Keyframe
+ * is supplied, `isDrivenEntering` is `false` and the consumer should fall back
+ * to the legacy Keyframe entering path.
  */
 export function usePopupPopoverContentAnimation({
   placement,
   offset,
   animation,
+  isReady = false,
 }: UsePopupPopoverContentAnimationProps) {
   const { isAllAnimationsDisabled } = useAnimationSettings();
 
@@ -182,18 +171,62 @@ export function usePopupPopoverContentAnimation({
     isAllAnimationsDisabled,
   });
 
-  // Get entering animation value with default based on placement
-  const enteringValue =
-    animationConfig?.entering ?? getDefaultEnteringAnimation(placement, offset);
+  const customEntering = animationConfig?.entering;
+
+  // The entering transition is driven via a shared value whenever no custom
+  // entering Keyframe is supplied. This keeps the content mounted once while
+  // still animating in at the resolved position.
+  const isDrivenEntering = !customEntering;
 
   // Get exiting animation value with default based on placement
   const exitingValue =
     animationConfig?.exiting ?? getDefaultExitingAnimation(placement, offset);
 
-  // Return entering and exiting animations
-  // If animations are disabled, return undefined to disable animations
+  const { axis, distance } = getEnteringTranslate(placement, offset);
+
+  const progress = useSharedValue(0);
+
+  useEffect(() => {
+    if (!isReady) {
+      progress.set(0);
+      return;
+    }
+
+    if (isAnimationDisabledValue) {
+      progress.set(1);
+      return;
+    }
+
+    progress.set(
+      withTiming(1, {
+        duration: DRIVEN_ENTERING_DURATION,
+        easing: Easing.out(Easing.ease),
+      })
+    );
+  }, [isReady, isAnimationDisabledValue, progress]);
+
+  const rEnteringStyle = useAnimatedStyle(() => {
+    const opacity = interpolate(progress.get(), [0, 1], [0, 1]);
+    const scale = interpolate(progress.get(), [0, 1], [0.97, 1]);
+    const translate = interpolate(progress.get(), [0, 1], [distance, 0]);
+
+    return {
+      opacity,
+      transform:
+        axis === 'y'
+          ? [{ translateY: translate }, { scale }]
+          : [{ translateX: translate }, { scale }],
+    };
+  });
+
+  // Return entering/exiting animations plus the driven entering style.
+  // If animations are disabled, Keyframe animations are undefined; the driven
+  // style still resolves to the fully-shown state once `isReady` is `true`.
   return {
-    entering: isAnimationDisabledValue ? undefined : enteringValue,
+    isDrivenEntering,
+    rEnteringStyle,
+    entering:
+      isDrivenEntering || isAnimationDisabledValue ? undefined : customEntering,
     exiting: isAnimationDisabledValue ? undefined : exitingValue,
   };
 }


### PR DESCRIPTION
## 📝 Description

Reworks the entering animation for Popover, Menu, and Select content so the content subtree mounts a single time and animates in via a shared value once measured and positioned. This avoids the double-mount previously required to measure content before playing the entering Keyframe.

## ⛳️ Current behavior (updates)

Popup content is mounted twice (a hidden probe to measure, then a visible node) so the entering Keyframe can fire on mount at the correct position.

## 🚀 New behavior

- Default entering animation is now driven by a shared value (`rEnteringStyle`) that plays once content is positioned (`isReady`), keeping the subtree mounted only once.
- `usePopupPopoverContentAnimation` returns `isDrivenEntering` and `rEnteringStyle`, with translate/scale/opacity interpolated from a progress value.
- Custom entering Keyframes still use the legacy probe-and-mount fallback path.
- Content is hidden from pointer events until ready; disabled animations resolve directly to the shown state.

## 💣 Is this a breaking change (Yes/No):

**No** - Public component APIs are unchanged; the single-mount path is internal and custom entering animations retain the previous behavior.

## 📝 Additional Information

Changes span `menu.tsx`, `popover.tsx`, `select.tsx`, and the shared `use-popup-popover-content-animation` hook. Recommend verifying enter/exit animations across all four placements, sub-menu transitions, and the disabled-animations case.