### PR TITLE
fix(portal): key portal subtrees by name in PortalHost

### DIFF
--- a/src/primitives/portal/portal.tsx
+++ b/src/primitives/portal/portal.tsx
@@ -65,7 +65,19 @@ export function PortalHost({ name = DEFAULT_PORTAL_HOST }: { name?: string }) {
   const map = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
   const portalMap = map.get(name) ?? new Map<string, React.ReactNode>();
   if (portalMap.size === 0) return null;
-  return <>{Array.from(portalMap.values())}</>;
+  // Key each portal subtree by its unique portal name. Rendering the values
+  // as an unkeyed array makes React reconcile portals by array index, so when
+  // a portal unregisters (e.g. a screen with an open bottom sheet unmounts)
+  // sibling portals shift index and inherit each other's component state,
+  // including gorhom bottom-sheet open positions. This causes unrelated
+  // sheets to appear open ("ghost sheets") or open sheets to stay invisible.
+  return (
+    <>
+      {Array.from(portalMap.entries()).map(([portalName, portalChildren]) => (
+        <React.Fragment key={portalName}>{portalChildren}</React.Fragment>
+      ))}
+    </>
+  );
 }
 
 // --------------------------------------------------


### PR DESCRIPTION
## Description

Fixes #441

`PortalHost` rendered all registered portals as an unkeyed array, so React reconciled them by array index. When a portal unregistered (e.g. a screen with an open bottom sheet unmounting via `router.replace()`) or registered mid-list, sibling portals shifted index and inherited each other's component state — including gorhom bottom-sheet instances and their animated open positions. Because open/close snaps are only issued on `isOpen` transitions, the adopted sheet never received a close command. Result: unrelated sheets appear open ("ghost sheets"), or an open sheet inherits a closed instance and stays invisible (which may also explain #225).

## Change

Key each portal subtree by its unique portal name in `PortalHost`, so React tracks portals by identity instead of array position. One function touched, no API or visual changes.

```tsx
return (
  <>
    {Array.from(portalMap.entries()).map(([portalName, portalChildren]) => (
      <React.Fragment key={portalName}>{portalChildren}</React.Fragment>
    ))}
  </>
);
```

## Testing

- `yarn typecheck`, `yarn lint`, `yarn test` all pass.
- Verified in an Expo SDK 57 / RN 0.85 / React 19 app (iOS) via a patched 1.0.5: the repro in the linked issue (open sheet on screen B → `router.replace()` away → screen A's sheet appears open) no longer occurs, and BottomSheet/Dialog/Popover/Select all keep opening and closing normally.

---

🤖 This bug was diagnosed and the fix authored by [Claude Code](https://claude.com/claude-code) (Claude Fable 5), working in an app that hit the issue.
