### PR TITLE
fix(styles): declare @source in the shipped stylesheet

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,3 +1,5 @@
+@source "..";
+
 @import './variables.css';
 @import './utilities.css';
 @import './theme.css';


### PR DESCRIPTION
Closes #454

## 📝 Description

`heroui-native/styles` does not declare an `@source` for its own files, so every app has to hardcode a filesystem path into `node_modules`. That path depends on where the package manager puts the package, so it breaks in workspaces, and it breaks silently: a missing `@source` directory is a no-op in Tailwind, so you get components rendering with no styles and no error anywhere.

This adds one line to `src/styles/index.css` so the package points at its own files.

## ⛳️ Current behavior (updates)

Apps follow the quick start and write a path relative to their `global.css`:

```css
@import 'heroui-native/styles';
@source './node_modules/heroui-native/lib';
```

The `@import` uses package exports and finds the package anywhere. The `@source` is a filesystem glob and only works if the package sits at that literal path. Those agree in a single-package app and disagree in a workspace, where the installer decides which `node_modules` holds the package. On bun's isolated linker it lands in the app, on the hoisted linker it lands at the workspace root, and pnpm and yarn split the same way.

## 🚀 New behavior

```css
@source "..";
```

Tailwind v4 resolves `@source` relative to the CSS file containing it, so this points at the package's own code wherever it is installed:

- published: `lib/module/styles/index.css` resolves it to `lib/module`
- in this repo: `src/styles/index.css` resolves it to `src`, which is what `example/global.css` already scans manually

Apps can then drop their `@source` line entirely.

## 💣 Is this a breaking change (Yes/No):

No. Existing app-level `@source` lines keep working, they just become redundant.

## 📝 Additional Information

Tested against a bun workspace on `heroui-native@1.0.3` by patching the installed copy, removing the app-level `@source`, and running `expo export --platform ios --no-bytecode`, then hashing the compiled Uniwind stylesheet:

| build | payload sha256 | CSS custom properties |
|---|---|---|
| isolated linker, app-level `@source` (works today) | `505f1db…` | 247 |
| hoisted linker, app-level `@source` (broken case) | `01e9753…` | 219 |
| hoisted linker, no app-level `@source`, patched package | `505f1db…` | 247 |

The docs can drop the path-examples comment block once this ships. Happy to follow up with that, and with removing the now-redundant `@source '../src'` from `example/global.css`, if you want them in separate PRs.
