### PR TITLE
fix(text): restore font-weight so the Typography weight prop works without custom font variables

### DIFF
--- a/src/components/text/__tests__/text.styles.test.ts
+++ b/src/components/text/__tests__/text.styles.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { textClassNames } from '../text.styles';
+
+const WEIGHTS = ['normal', 'medium', 'semibold', 'bold'] as const;
+
+describe('Typography weight', () => {
+  it.each(WEIGHTS)(
+    'applies the %s weight class when the weight prop is set',
+    (weight) => {
+      expect(textClassNames.root({ weight })).toContain(
+        `text__root--weight-${weight}`
+      );
+    }
+  );
+
+  it('applies no weight class when the weight prop is omitted', () => {
+    expect(textClassNames.root({})).not.toContain('text__root--weight');
+  });
+
+  it('keeps className overrides after the weight class', () => {
+    const result = textClassNames.root({
+      weight: 'semibold',
+      className: 'font-bold',
+    });
+
+    expect(result.indexOf('text__root--weight-semibold')).toBeLessThan(
+      result.indexOf('font-bold')
+    );
+  });
+
+  describe('css declarations', () => {
+    const css = readFileSync(
+      join(__dirname, '../../../styles/components/text.css'),
+      'utf8'
+    );
+
+    const getRule = (selector: string) => {
+      const match = css.match(new RegExp(`\\.${selector}\\s*\\{([^}]*)\\}`));
+      expect(match).not.toBeNull();
+      return match![1]!;
+    };
+
+    it.each(WEIGHTS)(
+      'declares font-weight for the %s weight class',
+      (weight) => {
+        // Regression test for #461: the weight classes must set `font-weight`
+        // so the prop works without app-defined `--font-*` family variables.
+        expect(getRule(`text__root--weight-${weight}`)).toContain(
+          `font-weight: var(--font-weight-${weight})`
+        );
+      }
+    );
+
+    it.each(['h1', 'h2', 'h3', 'h4', 'h5', 'h6'])(
+      'declares the semibold font-weight for the %s type class',
+      (type) => {
+        expect(getRule(`text__root--type-${type}`)).toContain(
+          'font-weight: var(--font-weight-semibold)'
+        );
+      }
+    );
+  });
+});

--- a/src/styles/components/text.css
+++ b/src/styles/components/text.css
@@ -1,5 +1,6 @@
 .text__root {
   font-family: var(--font-normal);
+  font-weight: var(--font-weight-normal);
 }
 
 /* Root - type */
@@ -8,6 +9,7 @@
   font-size: var(--text-4xl);
   line-height: var(--text-4xl--line-height);
   font-family: var(--font-semibold);
+  font-weight: var(--font-weight-semibold);
   letter-spacing: var(--tracking-tight);
 }
 
@@ -15,6 +17,7 @@
   font-size: var(--text-3xl);
   line-height: var(--text-3xl--line-height);
   font-family: var(--font-semibold);
+  font-weight: var(--font-weight-semibold);
   letter-spacing: var(--tracking-tight);
 }
 
@@ -22,6 +25,7 @@
   font-size: var(--text-2xl);
   line-height: var(--text-2xl--line-height);
   font-family: var(--font-semibold);
+  font-weight: var(--font-weight-semibold);
   letter-spacing: var(--tracking-tight);
 }
 
@@ -29,6 +33,7 @@
   font-size: var(--text-xl);
   line-height: var(--text-xl--line-height);
   font-family: var(--font-semibold);
+  font-weight: var(--font-weight-semibold);
   letter-spacing: var(--tracking-tight);
 }
 
@@ -36,6 +41,7 @@
   font-size: var(--text-lg);
   line-height: var(--text-lg--line-height);
   font-family: var(--font-semibold);
+  font-weight: var(--font-weight-semibold);
   letter-spacing: var(--tracking-tight);
 }
 
@@ -43,6 +49,7 @@
   font-size: var(--text-base);
   line-height: var(--text-base--line-height);
   font-family: var(--font-semibold);
+  font-weight: var(--font-weight-semibold);
   letter-spacing: var(--tracking-tight);
 }
 
@@ -108,16 +115,20 @@
 
 .text__root--weight-normal {
   font-family: var(--font-normal);
+  font-weight: var(--font-weight-normal);
 }
 
 .text__root--weight-medium {
   font-family: var(--font-medium);
+  font-weight: var(--font-weight-medium);
 }
 
 .text__root--weight-semibold {
   font-family: var(--font-semibold);
+  font-weight: var(--font-weight-semibold);
 }
 
 .text__root--weight-bold {
   font-family: var(--font-bold);
+  font-weight: var(--font-weight-bold);
 }


### PR DESCRIPTION
### Summary

Since v1.0.6, the `Typography` `weight` prop has no visible effect, while Tailwind classNames like `font-semibold` still work (#461).

### Root cause

Commit a36d59c9 (`refactor: migrate component styles to bem css files`, merged via #452 and released in v1.0.6) replaced the Tailwind weight utilities in `text.styles.ts` (`font-normal` / `font-medium` / `font-semibold` / `font-bold`, which compile to `font-weight: 400/500/600/700`) with BEM classes in `src/styles/components/text.css` that only set a font family:

```css
.text__root--weight-semibold {
  font-family: var(--font-semibold);
}
```

The `--font-normal` / `--font-medium` / `--font-semibold` / `--font-bold` variables are not defined anywhere in the library — only apps that opt into custom fonts define them (like the example app's `global.css`). In any app that doesn't, the declaration resolves to nothing, so `weight` (and the implicit semibold on `h1`–`h6`) silently stopped affecting font weight. `className="font-semibold"` kept working because it sets `font-weight` directly.

### Fix

Restore the `font-weight` declarations that the Tailwind utilities previously carried, alongside the existing `font-family` variables, using the Tailwind default theme tokens already relied on elsewhere in this file (`--text-*`, `--tracking-tight`):

- `.text__root--weight-*` → `font-weight: var(--font-weight-normal|medium|semibold|bold)`
- `.text__root--type-h1`–`h6` → `font-weight: var(--font-weight-semibold)` (these lost their semibold look in the same commit)
- `.text__root` base → `font-weight: var(--font-weight-normal)` (parity with the old `font-normal` base class)

Apps with custom fonts are unaffected: each rule pairs the family with its matching weight (e.g. `Inter-SemiBold` + 600), and the declaration order is unchanged, so an explicit `weight` still wins over `type` via the cascade and `className` utilities still override as before.

### Tests

Added `src/components/text/__tests__/text.styles.test.ts`:

- `weight` prop maps to the expected `text__root--weight-*` class for all documented values, and no weight class is emitted when omitted
- `className` overrides stay after the weight class
- regression guard: each weight class and each heading type class declares the expected `font-weight` token

```
Test Suites: 2 passed, 2 total
Tests:       1 todo, 16 passed, 17 total
```

`yarn test`, `yarn typecheck`, and `yarn lint` all pass.

Fixes #461
