### PR TITLE
fix(search-field): support inputs without search icon

### DIFF
--- a/example/src/app/(home)/components/search-field.tsx
+++ b/example/src/app/(home)/components/search-field.tsx
@@ -68,7 +68,10 @@ const WithoutSearchIconContent = () => {
       <KeyboardAvoidingContainer>
         <SearchField value={searchValue} onChange={setSearchValue}>
           <SearchField.Group>
-            <SearchField.Input placeholder={t`Search...`} />
+            <SearchField.Input
+              hasSearchIcon={false}
+              placeholder={t`Search...`}
+            />
             <SearchField.ClearButton />
           </SearchField.Group>
         </SearchField>

--- a/example/src/app/(home)/components/search-field.tsx
+++ b/example/src/app/(home)/components/search-field.tsx
@@ -59,6 +59,26 @@ const BasicSearchFieldContent = () => {
 
 // ------------------------------------------------------------------------------
 
+const WithoutSearchIconContent = () => {
+  const { t } = useLingui();
+  const [searchValue, setSearchValue] = useState('');
+
+  return (
+    <View className="flex-1 justify-center px-5">
+      <KeyboardAvoidingContainer>
+        <SearchField value={searchValue} onChange={setSearchValue}>
+          <SearchField.Group>
+            <SearchField.Input placeholder={t`Search...`} />
+            <SearchField.ClearButton />
+          </SearchField.Group>
+        </SearchField>
+      </KeyboardAvoidingContainer>
+    </View>
+  );
+};
+
+// ------------------------------------------------------------------------------
+
 const WithDescriptionContent = () => {
   const { t } = useLingui();
   const [searchValue, setSearchValue] = useState('');
@@ -193,6 +213,11 @@ const SEARCH_FIELD_VARIANTS: UsageVariant[] = [
     value: 'basic-search-field',
     label: msg`Basic search field`,
     content: <BasicSearchFieldContent />,
+  },
+  {
+    value: 'without-search-icon',
+    label: msg`Without search icon`,
+    content: <WithoutSearchIconContent />,
   },
   {
     value: 'with-label-and-description',

--- a/src/components/search-field/search-field.md
+++ b/src/components/search-field/search-field.md
@@ -58,6 +58,19 @@ Add a Label and Description outside the Group to provide context for the search 
 </SearchField>
 ```
 
+### Without Search Icon
+
+Omit `SearchField.SearchIcon` and set `hasSearchIcon={false}` on the Input to use the Input's normal leading padding.
+
+```tsx
+<SearchField value={searchValue} onChange={setSearchValue}>
+  <SearchField.Group>
+    <SearchField.Input hasSearchIcon={false} />
+    <SearchField.ClearButton />
+  </SearchField.Group>
+</SearchField>
+```
+
 ### With Validation
 
 Use `isInvalid` and `isRequired` on the root to control validation state. Pair with FieldError to display error messages.
@@ -189,6 +202,10 @@ Animation configuration for the SearchField root component. Can be:
 ### SearchField.Input
 
 Extends [Input](../input/input.md) props with search-specific defaults (`placeholder="Search..."`, `returnKeyType="search"`, `accessibilityRole="search"`). Omits `value` and `onChangeText` because they are provided by the SearchField context.
+
+| prop            | type      | default | description                                                         |
+| --------------- | --------- | ------- | ------------------------------------------------------------------- |
+| `hasSearchIcon` | `boolean` | `true`  | Whether the Input reserves leading space for SearchField.SearchIcon |
 
 ### SearchField.ClearButton
 

--- a/src/components/search-field/search-field.styles.ts
+++ b/src/components/search-field/search-field.styles.ts
@@ -39,6 +39,15 @@ const inputContainer = tv({
  */
 const input = tv({
   base: 'search-field__input rtl:text-right',
+  variants: {
+    hasSearchIcon: {
+      true: 'search-field__input--with-search-icon',
+      false: '',
+    },
+  },
+  defaultVariants: {
+    hasSearchIcon: true,
+  },
 });
 
 const clearButton = tv({

--- a/src/components/search-field/search-field.tsx
+++ b/src/components/search-field/search-field.tsx
@@ -132,6 +132,7 @@ const SearchFieldInput = forwardRef<TextInputType, SearchFieldInputProps>(
     const {
       className,
       containerClassName: containerClassNameProp,
+      hasSearchIcon = true,
       placeholder = 'Search...',
       returnKeyType = 'search',
       accessibilityRole = 'search',
@@ -141,7 +142,10 @@ const SearchFieldInput = forwardRef<TextInputType, SearchFieldInputProps>(
 
     const searchField = useSearchField();
 
-    const inputClassName = searchFieldClassNames.input({ className });
+    const inputClassName = searchFieldClassNames.input({
+      hasSearchIcon,
+      className,
+    });
 
     const inputContainerClassName = searchFieldClassNames.inputContainer({
       className: containerClassNameProp,
@@ -235,8 +239,9 @@ SearchFieldClearButton.displayName = DISPLAY_NAME.SEARCH_FIELD_CLEAR_BUTTON;
  * absolutely on the leading edge (left in LTR, right in RTL).
  *
  * @component SearchField.Input - Wraps the Input component with search-specific
- * defaults: "Search..." placeholder, leading padding for the search icon, and
- * search a11y role. Reads `value` / `onChangeText` from SearchFieldContext.
+ * defaults: "Search..." placeholder, optional leading padding for the search
+ * icon, and search a11y role. Reads `value` / `onChangeText` from
+ * SearchFieldContext.
  *
  * @component SearchField.ClearButton - Small button that clears the search
  * input. Automatically hidden when value is empty. Calls `onChange("")` from

--- a/src/components/search-field/search-field.types.ts
+++ b/src/components/search-field/search-field.types.ts
@@ -130,7 +130,13 @@ export interface SearchFieldSearchIconProps extends ViewProps {
  * root through SearchFieldValueContext.
  */
 export interface SearchFieldInputProps
-  extends Omit<InputProps, 'value' | 'onChangeText'> {}
+  extends Omit<InputProps, 'value' | 'onChangeText'> {
+  /**
+   * Whether the input should reserve leading space for SearchField.SearchIcon
+   * @default true
+   */
+  hasSearchIcon?: boolean;
+}
 
 /**
  * Props for customizing the clear button icon

--- a/src/styles/components/search-field.css
+++ b/src/styles/components/search-field.css
@@ -27,13 +27,16 @@
 
 .search-field__input {
   flex-grow: 1;
-  padding-inline-start: calc(var(--spacing) * 9);
   padding-inline-end: calc(var(--spacing) * 12);
   /*
    * TextInput textAlign is physical (unlike Text), so this is the LTR
    * alignment; the RTL flip comes from `rtl:text-right` in the styles file.
    */
   text-align: left;
+}
+
+.search-field__input--with-search-icon {
+  padding-inline-start: calc(var(--spacing) * 9);
 }
 
 .search-field__clear-button {


### PR DESCRIPTION
Closes #465

## 📝 Description

Allows `SearchField.Input` to use normal leading padding when a composed SearchField intentionally omits `SearchField.SearchIcon`.

This adds a backward-compatible `hasSearchIcon` prop, defaulting to `true`, and documents the iconless composition.

I opened this as a draft because the contribution guide asks for maintainer alignment on API and implementation changes. I am happy to adjust the prop name, move the option to another compound part, or follow a different pattern that fits HeroUI Native better.

## ⛳️ Current behavior (updates)

`SearchField.Input` always receives the leading spacing reserved for `SearchField.SearchIcon`. Omitting the icon leaves an empty gap, so consumers have to override SearchField's internal padding.

## 🚀 New behavior

Consumers can explicitly indicate that the icon is absent:

```tsx
<SearchField value={value} onChange={setValue}>
  <SearchField.Group>
    <SearchField.Input hasSearchIcon={false} />
    <SearchField.ClearButton />
  </SearchField.Group>
</SearchField>
```

The Input then keeps its normal leading padding. Existing SearchFields retain their current icon spacing because `hasSearchIcon` defaults to `true`. Clear-button spacing is unchanged.

The implementation uses one focused style variant rather than inspecting, registering, or cloning compound children.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

- Added an iconless variant to the SearchField example screen.
- Added usage and API documentation.
- `yarn typecheck` passes.
- `yarn lint` passes.
- `yarn test --runInBand` passes; the current suite contains one existing todo test.
