### PR TITLE
fix(select): preserve content-fit label sizing

### DIFF
--- a/src/styles/components/select.css
+++ b/src/styles/components/select.css
@@ -25,7 +25,7 @@
 }
 
 .select__value {
-  flex: 1;
+  flex-shrink: 1;
   font-size: var(--text-base);
   line-height: var(--text-base--line-height);
   font-family: var(--font-normal);
@@ -98,13 +98,14 @@
 .select__item {
   flex-direction: row;
   align-items: center;
+  justify-content: space-between;
   gap: calc(var(--spacing) * 2);
   padding-inline: calc(var(--spacing) * 2);
   padding-block: calc(var(--spacing) * 3);
 }
 
 .select__item-label {
-  flex: 1;
+  flex-shrink: 1;
   font-size: var(--text-base);
   line-height: var(--text-base--line-height);
   color: var(--color-foreground);


### PR DESCRIPTION
Closes #467

## 📝 Description

Preserves the intrinsic width of the default Select value and item-label text when the trigger or popover sizes itself to content.

The default `flex: 1` styles make these text nodes flex-grow. In React Native shrink-to-content measurement, they can then contribute no useful intrinsic width: compact triggers show only their indicator and `width="content-fit"` popovers can collapse around the selected check mark.

## ⛳️ Current behavior (updates)

- A compact Select trigger can collapse from the expected text width to about 60 points.
- A `content-fit` popover can collapse to about 44 points, omitting labels or wrapping them one letter per line.

| Stock compact trigger | Stock content-fit menu |
| --- | --- |
| ![Selected text omitted](https://raw.githubusercontent.com/eliotgevers/heroui-native-select-content-fit-repro/main/evidence/stock-trigger.png) | ![Popover collapsed around the check](https://raw.githubusercontent.com/eliotgevers/heroui-native-select-content-fit-repro/main/evidence/stock-menu.png) |

## 🚀 New behavior

- `.select__value` and `.select__item-label` use `flex-shrink: 1`, so their text contributes intrinsic width while still shrinking when constrained.
- `.select__item` uses `justify-content: space-between` to keep the label/indicator relationship correct without flex-grow on the label.

![Compact trigger and long content-fit labels visible](https://raw.githubusercontent.com/eliotgevers/heroui-native-select-content-fit-repro/main/evidence/candidate-patch.png)

The candidate was tested in a default Expo 57 / React Native 0.86.2 Fabric app with HeroUI Native's documented Uniwind setup. It passed compact trigger, long-label `content-fit`, `width="trigger"`, numeric width, `width="full"`, Dialog presentation, accessibility-label inspection, and Android production export checks.

Repository with deterministic stock reproduction and exact steps: https://github.com/eliotgevers/heroui-native-select-content-fit-repro

Repository verification also passed:

- `yarn typecheck`
- `yarn lint`
- `yarn test --runInBand`

## 💣 Is this a breaking change (Yes/No):

No. There are no public API changes; this corrects the default layout behavior for existing sizing modes.
