### PR TITLE
fix(toast): correct auto-dismiss timer lifecycle

### DIFF
--- a/src/providers/toast/provider.tsx
+++ b/src/providers/toast/provider.tsx
@@ -154,6 +154,22 @@ export function ToastProvider({
 
   const idCounter = useRef(0);
   const timeoutRefs = useRef<Map<string, NodeJS.Timeout>>(new Map());
+
+  /**
+   * Clear every pending auto-dismiss timer when the provider unmounts, so a
+   * timer cannot outlive the tree it dispatches into.
+   */
+  useEffect(() => {
+    const timeouts = timeoutRefs.current;
+
+    return () => {
+      timeouts.forEach((timeout) => {
+        clearTimeout(timeout);
+      });
+      timeouts.clear();
+    };
+  }, []);
+
   const hideRef = useRef<((ids?: string | string[] | 'all') => void) | null>(
     null
   );
@@ -330,28 +346,30 @@ export function ToastProvider({
         normalizedOptions.onShow();
       }
 
-      // Set up auto-dismiss timeout synchronously
+      /**
+       * Set up auto-dismiss timeout synchronously.
+       *
+       * `duration: 0` is scheduled like any other duration rather than
+       * dismissed inline: `hide` closes over the `toasts` of the current
+       * render, which does not contain this toast yet, so an inline call
+       * would find nothing to remove and leave the toast on screen forever.
+       * Deferring lets the `SHOW` dispatch commit and `hideRef` re-point to a
+       * `hide` that can see the new toast.
+       */
       if (
         duration !== 'persistent' &&
         typeof duration === 'number' &&
         !isNaN(duration) &&
-        duration > 0 &&
+        duration >= 0 &&
         duration !== Infinity
       ) {
-        // Handle immediate dismissal
-        if (duration === 0) {
+        const timeout = setTimeout(() => {
           if (hideRef.current) {
             hideRef.current(id);
           }
-        } else {
-          const timeout = setTimeout(() => {
-            if (hideRef.current) {
-              hideRef.current(id);
-            }
-            timeoutRefs.current.delete(id);
-          }, duration);
-          timeoutRefs.current.set(id, timeout);
-        }
+          timeoutRefs.current.delete(id);
+        }, duration);
+        timeoutRefs.current.set(id, timeout);
       }
 
       return id;


### PR DESCRIPTION
## 📝 Description

Fixes two defects in the auto-dismiss timers owned by `ToastProvider`. Found while reading the toast provider; not tied to an existing issue.

### 1. `duration: 0` never dismisses

`duration` is documented as `number | 'persistent'` — *"Duration in milliseconds before auto-hide. Set to `'persistent'` to prevent auto-hide"* — so `0` is a valid number and only `'persistent'` should opt out. The guard around the timer setup required `duration > 0`:

```ts
if (
  duration !== 'persistent' &&
  typeof duration === 'number' &&
  !isNaN(duration) &&
  duration > 0 &&            // 0 skips the whole block
  duration !== Infinity
) {
  if (duration === 0) {      // unreachable
    hideRef.current?.(id);
  } else {
    /* setTimeout path */
  }
}
```

So `toast.show({ label: 'x', duration: 0 })` registers no timer at all and the toast behaves as `persistent`.

The `if (duration === 0)` branch was unreachable, and would not have worked had it been reached. `hide` closes over the `toasts` of the current render, which does not yet contain the toast that the surrounding `show` call just dispatched. `hide` looks the id up in that stale array:

```ts
const toast = toasts.find((t) => String(t.id) === String(id));
if (toast) { removedCount++; /* … */ }
// …
if (removedCount > 0) { dispatch({ type: 'HIDE', /* … */ }); }
```

`removedCount` stays `0`, no `HIDE` is dispatched, and the toast stays on screen.

### 2. Pending timers outlive the provider

`timeoutRefs` is only drained by an explicit `hide`. Unmounting `ToastProvider` while toasts are still visible leaves every scheduled timer running; each one later calls `hideRef.current(id)` and dispatches into a torn-down tree.

## ⛳️ Current behavior (updates)

- `duration: 0` silently behaves like `'persistent'`.
- Unmounting the provider with visible toasts leaks one pending timer per toast.

## 🚀 New behavior

- Zero-duration toasts go through the same `setTimeout` path as every other duration, and the dead branch is gone. Deferring by a tick lets the `SHOW` dispatch commit and `hideRef` re-point to a `hide` that can see the new toast.
- A cleanup effect clears every pending timer when the provider unmounts.

`'persistent'`, `NaN`, `Infinity` and negative durations keep their current no-auto-dismiss behaviour — only `0` changes, and it changes to match the documented contract.

## 💣 Is this a breaking change (Yes/No):

No. The only behavioural change is `duration: 0`, which moves from an undocumented persistent state to the documented auto-hide.

## 📝 Additional Information

Verified locally against every CI job on this branch:

- `yarn lint` ✅
- `yarn typecheck` ✅
- `yarn test` ✅
- `yarn prepare` ✅
- `yarn example expo export --platform web` ✅

No component-level test is included — the repo currently has no React renderer or testing-library dependency, so there is no harness to mount a provider in. Happy to add one if you would like that dependency introduced.
