### PR TITLE
bugfix: remove default border radius on LinkButton

### DIFF
--- a/src/components/link-button/link-button.styles.ts
+++ b/src/components/link-button/link-button.styles.ts
@@ -2,7 +2,7 @@ import { tv } from '../../helpers/external/utils/cn';
 import { combineStyles } from '../../helpers/internal/utils';
 
 const root = tv({
-  base: 'link-button__root',
+  base: 'link-button__root rounded-none',
 });
 
 const linkButtonClassNames = combineStyles({


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request ❤️!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, repo, or bugfix)
-->

## 📝 Description

<!--- Add a brief description -->
The `Button` component has rounded corners, but the `LinkButton` clearly doesn't need them. These rounded corners cause the text to be clipped.

## ⛳️ Current behavior (updates)

<!--- Please describe the current behavior that you are modifying -->
The LinkButton component has rounded corners, which will clip the text at the edges.

## 🚀 New behavior

<!--- Please describe the behavior or changes this PR adds -->
Remove the default rounded corner configuration

## 💣 Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing HeroUI users. -->
NO

