### PR TITLE
fix(radio): expose a single role=radio node when nested in RadioGroup.Item

### DIFF
--- a/src/components/radio/radio.tsx
+++ b/src/components/radio/radio.tsx
@@ -90,6 +90,22 @@ const RadioRoot = forwardRef<RadioPrimitives.RootRef, RadioProps>(
         ? children(renderProps)
         : (children ?? <RadioIndicator />);
 
+    /**
+     * Inside a RadioGroupItem the item primitive already exposes the
+     * accessible `role="radio"` node (checked state + press handling), so the
+     * nested trigger is hidden from assistive technology — otherwise every
+     * option exposes two `role="radio"` nodes / focus stops.
+     */
+    const nestedInGroupA11yProps = radioGroupItemContext
+      ? ({
+          'role': 'none',
+          'aria-hidden': true,
+          'accessibilityElementsHidden': true,
+          'importantForAccessibility': 'no-hide-descendants',
+          'focusable': false,
+        } as const)
+      : undefined;
+
     const { isAllAnimationsDisabled } = useRadioRootAnimation({
       animation,
     });
@@ -112,6 +128,7 @@ const RadioRoot = forwardRef<RadioPrimitives.RootRef, RadioProps>(
           isDisabled={isDisabled}
           isInvalid={isInvalid}
           hitSlop={props.hitSlop ?? DEFAULT_HIT_SLOP}
+          {...nestedInGroupA11yProps}
           {...restProps}
         >
           {content}


### PR DESCRIPTION
Closes #476

## 📝 Description

Inside a `RadioGroup.Item`, the item primitive is already the accessible selection control (`role="radio"` + `aria-checked` + press handling), but the nested `Radio`'s trigger also renders `role="radio"` — so every option exposes **two** radio nodes / focus stops to assistive technology (VoiceOver / TalkBack announce each option twice). Full analysis and repro in #476.

## ⛳️ Current behavior (updates)

```tsx
<RadioGroup value="a" onValueChange={() => {}}>
  <RadioGroup.Item value="a">Plain string</RadioGroup.Item>
</RadioGroup>
```

`getAllByRole('radio')` → **2** nodes for the single item (both report `checked` when selected). Same result for the docs-recommended element-children composition, since the default `<Radio />` is rendered inside the Item either way.

## 🚀 New behavior

`Radio` already detects the `RadioGroupItem` context (`useRadioGroupItem`, non-strict). When that context is present, the nested trigger is now hidden from assistive technology (`role="none"`, `aria-hidden`, `accessibilityElementsHidden`, `importantForAccessibility="no-hide-descendants"`, `focusable={false}`) — spread **before** `restProps`, so explicit user-supplied accessibility props still win. `getAllByRole('radio')` → **1** node per item.

AT-tree-only change:

- No visual change — the indicator renders exactly as before.
- No behavior change — pressing the inner radio still selects the item (the press handler is untouched).
- Standalone `Radio` (outside a group) is unaffected and keeps `role="radio"`.

Verified by rendering this component tree pre/post fix under `@react-native/jest-preset` + `@testing-library/react-native` (RN 0.85): the duplicate-node assertion fails on current code and passes with this change; a 58-test downstream a11y contract suite over these controls also stays green. Not adding a test file here because the repo's jest suite is currently a stub with no rendering-test dependency — happy to add `@testing-library/react-native` plus a regression test if you want that dependency.

## 💣 Is this a breaking change (Yes/No):

No. Anyone selecting the nested trigger by accessibility role inside a group would now match the outer Item instead — which is the correct, single target.

## 📝 Additional Information

Verified the duplication exists in `v1.0.6` through `v1.0.8` and on the current `1.0.9` branch.
