### PR TITLE
fix(styles): declare font-weight next to the medium and semibold font families

### DIFF
--- a/src/styles/__tests__/component-fonts.test.ts
+++ b/src/styles/__tests__/component-fonts.test.ts
@@ -1,0 +1,46 @@
+import { readdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+const COMPONENTS_DIR = join(__dirname, '../components');
+
+type Rule = {
+  file: string;
+  selector: string;
+  body: string;
+};
+
+const rules: Rule[] = readdirSync(COMPONENTS_DIR)
+  .filter((file) => file.endsWith('.css') && file !== 'index.css')
+  .flatMap((file) => {
+    const css = readFileSync(join(COMPONENTS_DIR, file), 'utf8');
+    return [...css.matchAll(/([^{}]+)\{([^{}]*)\}/g)].map((match) => ({
+      file,
+      selector: (match[1] ?? '').trim().split('\n').pop()!.trim(),
+      body: match[2] ?? '',
+    }));
+  });
+
+describe('Component font declarations', () => {
+  it('collects rules from every component stylesheet', () => {
+    expect(rules.length).toBeGreaterThan(0);
+  });
+
+  it.each(['medium', 'semibold', 'bold'])(
+    'declares the %s font-weight next to the matching font-family',
+    (weight) => {
+      // `--font-*` family variables only exist once an app opts into custom
+      // fonts, so a rule relying on the family alone renders normal (#461).
+      const missing = rules
+        .filter((rule) =>
+          rule.body.includes(`font-family: var(--font-${weight})`)
+        )
+        .filter(
+          (rule) =>
+            !rule.body.includes(`font-weight: var(--font-weight-${weight})`)
+        )
+        .map((rule) => `${rule.file} ${rule.selector}`);
+
+      expect(missing).toEqual([]);
+    }
+  );
+});

--- a/src/styles/components/alert.css
+++ b/src/styles/components/alert.css
@@ -26,6 +26,7 @@
   font-size: var(--text-base);
   line-height: var(--text-base--line-height);
   font-family: var(--font-medium);
+  font-weight: var(--font-weight-medium);
   /* RN Text resolves left/right against layout direction, so this means "start" */
   text-align: left;
 }

--- a/src/styles/components/avatar.css
+++ b/src/styles/components/avatar.css
@@ -76,6 +76,7 @@
 
 .avatar__fallback-text {
   font-family: var(--font-medium);
+  font-weight: var(--font-weight-medium);
 }
 
 /* Fallback text - size */

--- a/src/styles/components/bottom-sheet.css
+++ b/src/styles/components/bottom-sheet.css
@@ -37,6 +37,7 @@
   font-size: var(--text-lg);
   line-height: var(--text-lg--line-height);
   font-family: var(--font-medium);
+  font-weight: var(--font-weight-medium);
   color: var(--color-foreground);
   /* RN Text resolves left/right against layout direction, so this means "start" */
   text-align: left;

--- a/src/styles/components/button.css
+++ b/src/styles/components/button.css
@@ -93,6 +93,7 @@
 
 .button__label {
   font-family: var(--font-medium);
+  font-weight: var(--font-weight-medium);
 }
 
 /* Label - variant */

--- a/src/styles/components/card.css
+++ b/src/styles/components/card.css
@@ -11,6 +11,7 @@
   line-height: var(--text-lg--line-height);
   color: var(--color-foreground);
   font-family: var(--font-medium);
+  font-weight: var(--font-weight-medium);
   /* RN Text resolves left/right against layout direction, so this means "start" */
   text-align: left;
 }

--- a/src/styles/components/chip.css
+++ b/src/styles/components/chip.css
@@ -92,6 +92,7 @@
 
 .chip__label {
   font-family: var(--font-medium);
+  font-weight: var(--font-weight-medium);
 }
 
 /* Label - size */

--- a/src/styles/components/dialog.css
+++ b/src/styles/components/dialog.css
@@ -33,6 +33,7 @@
   font-size: var(--text-lg);
   line-height: var(--text-lg--line-height);
   font-family: var(--font-medium);
+  font-weight: var(--font-weight-medium);
   color: var(--color-foreground);
   /* RN Text resolves left/right against layout direction, so this means "start" */
   text-align: left;

--- a/src/styles/components/input-otp.css
+++ b/src/styles/components/input-otp.css
@@ -60,6 +60,7 @@
   font-size: var(--text-lg);
   line-height: var(--text-lg--line-height);
   font-family: var(--font-semibold);
+  font-weight: var(--font-weight-semibold);
   color: color-mix(in oklab, var(--color-field-placeholder) 50%, transparent);
 }
 
@@ -67,6 +68,7 @@
   font-size: var(--text-lg);
   line-height: var(--text-lg--line-height);
   font-family: var(--font-semibold);
+  font-weight: var(--font-weight-semibold);
   color: var(--color-foreground);
 }
 

--- a/src/styles/components/label.css
+++ b/src/styles/components/label.css
@@ -16,6 +16,7 @@
   line-height: var(--text-base--line-height);
   color: var(--color-foreground);
   font-family: var(--font-medium);
+  font-weight: var(--font-weight-medium);
   /* RN resolves left/right against layout direction, so this means "start" */
   text-align: left;
 }

--- a/src/styles/components/list-group.css
+++ b/src/styles/components/list-group.css
@@ -18,6 +18,7 @@
   line-height: var(--text-base--line-height);
   color: var(--color-foreground);
   font-family: var(--font-medium);
+  font-weight: var(--font-weight-medium);
   /* RN Text resolves left/right against layout direction, so this means "start" */
   text-align: left;
 }

--- a/src/styles/components/menu.css
+++ b/src/styles/components/menu.css
@@ -39,6 +39,7 @@
   font-size: var(--text-sm);
   line-height: var(--text-sm--line-height);
   font-family: var(--font-medium);
+  font-weight: var(--font-weight-medium);
   color: var(--color-muted);
   margin-inline-start: calc(var(--spacing) * 3);
   /* RN Text resolves left/right against layout direction, so this means "start" */
@@ -64,6 +65,7 @@
   font-size: var(--text-base);
   line-height: var(--text-base--line-height);
   font-family: var(--font-medium);
+  font-weight: var(--font-weight-medium);
   /* RN Text resolves left/right against layout direction, so this means "start" */
   text-align: left;
 }

--- a/src/styles/components/popover.css
+++ b/src/styles/components/popover.css
@@ -28,6 +28,7 @@
   font-size: var(--text-lg);
   line-height: var(--text-lg--line-height);
   font-family: var(--font-medium);
+  font-weight: var(--font-weight-medium);
   color: var(--color-foreground);
   /* RN Text resolves left/right against layout direction, so this means "start" */
   text-align: left;

--- a/src/styles/components/select.css
+++ b/src/styles/components/select.css
@@ -89,6 +89,7 @@
   line-height: var(--text-sm--line-height);
   color: var(--color-muted);
   font-family: var(--font-medium);
+  font-weight: var(--font-weight-medium);
   padding-inline: calc(var(--spacing) * 2);
   padding-block: calc(var(--spacing) * 1.5);
   /* RN Text resolves left/right against layout direction, so this means "start" */
@@ -109,6 +110,7 @@
   line-height: var(--text-base--line-height);
   color: var(--color-foreground);
   font-family: var(--font-medium);
+  font-weight: var(--font-weight-medium);
   /* RN Text resolves left/right against layout direction, so this means "start" */
   text-align: left;
 }

--- a/src/styles/components/slider.css
+++ b/src/styles/components/slider.css
@@ -20,6 +20,7 @@
   line-height: var(--text-sm--line-height);
   color: var(--color-muted);
   font-family: var(--font-medium);
+  font-weight: var(--font-weight-medium);
 }
 
 .slider__track {

--- a/src/styles/components/tabs.css
+++ b/src/styles/components/tabs.css
@@ -65,6 +65,7 @@
   font-size: var(--text-base);
   line-height: var(--text-base--line-height);
   font-family: var(--font-medium);
+  font-weight: var(--font-weight-medium);
 }
 
 .tabs__label--is-selected {

--- a/src/styles/components/tag-group.css
+++ b/src/styles/components/tag-group.css
@@ -76,6 +76,7 @@
 
 .tag-group__tag-label {
   font-family: var(--font-medium);
+  font-weight: var(--font-weight-medium);
   color: var(--color-field-foreground);
 }
 

--- a/src/styles/components/toast.css
+++ b/src/styles/components/toast.css
@@ -17,6 +17,7 @@
   font-size: var(--text-base);
   line-height: var(--text-base--line-height);
   font-family: var(--font-medium);
+  font-weight: var(--font-weight-medium);
   /* RN Text resolves left/right against layout direction, so this means "start" */
   text-align: left;
 }


### PR DESCRIPTION
No separate issue: same root cause as #461, which was fixed for `Text` only in #464.

## 📝 Description

`#461` reported that the `Text` `weight` prop had no effect. The fix in #464 added the missing `font-weight` declarations to `text.css`. The same defect is still present in the other 17 component stylesheets.

Those rules ask for a heavier face through the font family alone:

```css
.button__label {
  font-family: var(--font-medium);
}
```

`--font-medium` and `--font-semibold` are only defined once an app opts into custom fonts (docs/theming.md, "Custom Fonts"). The library never defines them. On a default setup the declaration resolves to nothing, no weight is set anywhere in the rule, and the text renders at the normal weight of the system font.

This PR adds the matching `font-weight` to each of those 20 rules, mirroring what #464 already did for `text.css`.

## ⛳️ Current behavior (updates)

Without app-defined `--font-*` variables, every element below renders at the normal weight instead of the intended medium/semibold:

| Stylesheet | Rules |
| --- | --- |
| alert.css | `.alert__title` |
| avatar.css | `.avatar__fallback-text` |
| bottom-sheet.css | `.bottom-sheet__label` |
| button.css | `.button__label` |
| card.css | `.card__label` |
| chip.css | `.chip__label` |
| dialog.css | `.dialog__label` |
| input-otp.css | `.input-otp__slot-placeholder`, `.input-otp__slot-value` |
| label.css | `.label__text` |
| list-group.css | `.list-group__item-title` |
| menu.css | `.menu__label`, `.menu__item-title` |
| popover.css | `.popover__label` |
| select.css | `.select__list-label`, `.select__item-label` |
| slider.css | `.slider__output-text` |
| tabs.css | `.tabs__label` |
| tag-group.css | `.tag-group__tag-label` |
| toast.css | `.toast__label` |

## 🚀 New behavior

Each of those rules now declares the matching weight next to the family:

```css
.button__label {
  font-family: var(--font-medium);
  font-weight: var(--font-weight-medium);
}
```

Apps that do define `--font-*` are unaffected: the custom family still wins, and the weight matches the face that family names.

The two rules that use `var(--font-normal)` (`.input__input`, `.select__value`) are left untouched, since normal is already the fallback weight.

A test walks every file in `src/styles/components` and fails if a rule declares `font-family: var(--font-medium|semibold|bold)` without the matching `font-weight`, so the pattern cannot regress again. It reports the offending selectors by name.

## 💣 Is this a breaking change (Yes/No):

No.

## 📝 Additional Information

`yarn lint`, `yarn typecheck`, `yarn test` and `yarn prepare` all pass.
