### PR TITLE
fix(select): restore dialog presentation on RNGH 3

### DIFF
--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -11,6 +11,7 @@ import {
   FullWindowOverlay,
   HeroText,
   PopupOverlayBlurView,
+  PortalGestureRoot,
   ThemeBackground,
 } from '../../helpers/internal/components';
 import {
@@ -310,25 +311,28 @@ const DialogContent = forwardRef<
       background === undefined ? <DialogContentBackground /> : background;
 
     return (
-      <GestureDetector gesture={panGesture}>
-        <Animated.View
-          ref={dragContainerRef}
-          entering={entering}
-          exiting={exiting}
-        >
-          <Animated.View style={rDragContainerStyle} pointerEvents="box-none">
-            <DialogPrimitives.Content
-              ref={ref}
-              className={contentClassName}
-              style={[dialogStyleSheet.contentContainer, style]}
-              {...props}
-            >
-              {backgroundElement}
-              {children}
-            </DialogPrimitives.Content>
+      <PortalGestureRoot>
+        <GestureDetector gesture={panGesture}>
+          <Animated.View
+            ref={dragContainerRef}
+            entering={entering}
+            exiting={exiting}
+            collapsable={false}
+          >
+            <Animated.View style={rDragContainerStyle} pointerEvents="box-none">
+              <DialogPrimitives.Content
+                ref={ref}
+                className={contentClassName}
+                style={[dialogStyleSheet.contentContainer, style]}
+                {...props}
+              >
+                {backgroundElement}
+                {children}
+              </DialogPrimitives.Content>
+            </Animated.View>
           </Animated.View>
-        </Animated.View>
-      </GestureDetector>
+        </GestureDetector>
+      </PortalGestureRoot>
     );
   }
 );

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -13,6 +13,7 @@ import {
   ChevronDownIcon,
   FullWindowOverlay,
   HeroText,
+  PortalGestureRoot,
   ThemeBackground,
   useHasDefaultThemeBackground,
 } from '../../helpers/internal/components';
@@ -664,29 +665,35 @@ const SelectContentDialog = forwardRef<
 
     return (
       <View className={wrapperClassName} style={styles?.wrapper}>
-        <GestureDetector gesture={panGesture}>
-          <Animated.View
-            ref={dragContainerRef}
-            entering={entering}
-            exiting={exiting}
-          >
-            <Animated.View style={rDragContainerStyle} pointerEvents="box-none">
-              <SelectPrimitives.DialogContent
-                ref={ref}
-                className={contentClassName}
-                style={[
-                  selectStyleSheet.contentContainer,
-                  styles?.content,
-                  style,
-                ]}
-                {...props}
+        <PortalGestureRoot>
+          <GestureDetector gesture={panGesture}>
+            <Animated.View
+              ref={dragContainerRef}
+              entering={entering}
+              exiting={exiting}
+              collapsable={false}
+            >
+              <Animated.View
+                style={rDragContainerStyle}
+                pointerEvents="box-none"
               >
-                {backgroundElement}
-                {children}
-              </SelectPrimitives.DialogContent>
+                <SelectPrimitives.DialogContent
+                  ref={ref}
+                  className={contentClassName}
+                  style={[
+                    selectStyleSheet.contentContainer,
+                    styles?.content,
+                    style,
+                  ]}
+                  {...props}
+                >
+                  {backgroundElement}
+                  {children}
+                </SelectPrimitives.DialogContent>
+              </Animated.View>
             </Animated.View>
-          </Animated.View>
-        </GestureDetector>
+          </GestureDetector>
+        </PortalGestureRoot>
       </View>
     );
   }

--- a/src/helpers/internal/components/index.ts
+++ b/src/helpers/internal/components/index.ts
@@ -9,4 +9,5 @@ export * from './full-window-overlay';
 export * from './hero-text';
 export * from './hero-text-input';
 export * from './popup-overlay-blur-view';
+export * from './portal-gesture-root';
 export * from './theme-background';

--- a/src/helpers/internal/components/portal-gesture-root.tsx
+++ b/src/helpers/internal/components/portal-gesture-root.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from 'react';
+import { StyleSheet } from 'react-native';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+
+const styles = StyleSheet.create({
+  /**
+   * Stretch to the portal/wrapper width, but wrap the dialog height.
+   * `flex: 1` plus `justifyContent: 'center'` would fill the overlay and
+   * ignore parent alignment (`justify-center` vs `justify-start`), which
+   * breaks keyboard-safe layouts like `TextInputDialogContent`.
+   * Passing any `style` also opts out of GH's default `{ flex: 1 }`.
+   */
+  root: {
+    alignSelf: 'stretch',
+  },
+});
+
+/**
+ * Nested gesture root for content rendered through a portal.
+ *
+ * RNGH 3's `GestureDetector` is a native host view and throws on Android when
+ * it cannot find a `GestureHandlerRootView` in its native ancestor chain.
+ * Portal children are React descendants of the app root, but that is not
+ * enough on Android under 3.x. A nested root is a layout-only `View` on
+ * RNGH 2 (nested roots are ignored for gesture routing).
+ *
+ * @see https://github.com/heroui-inc/heroui-native/issues/444
+ */
+export function PortalGestureRoot({ children }: { children: ReactNode }) {
+  return (
+    <GestureHandlerRootView style={styles.root} pointerEvents="box-none">
+      {children}
+    </GestureHandlerRootView>
+  );
+}


### PR DESCRIPTION
Closes #444 

## 📝 Description

Fixes Dialog and Select dialog presentation on Android when using react-native-gesture-handler 3. Portal-rendered `GestureDetector` hosts need a native `GestureHandlerRootView` ancestor, which the app root does not provide through a portal.

## ⛳️ Current behavior (updates)

Opening a Select (or Dialog) with swipe-to-dismiss on Android under RNGH 3 throws because the portal content has no gesture root in its native ancestor chain.

## 🚀 New behavior

- Adds an internal `PortalGestureRoot` that nests a layout-only `GestureHandlerRootView` around portal dialog content
- Wraps Dialog and Select dialog drag containers so swipe-to-dismiss works on RNGH 3 Android
- Marks the drag container `collapsable={false}` so the native view is not optimized away

## 💣 Is this a breaking change (Yes/No):

**No** - This is an internal helper used only by Dialog and Select. Public APIs and consumer code are unchanged.

## 📝 Additional Information

Addresses https://github.com/heroui-inc/heroui-native/issues/444. Nested roots are ignored for gesture routing on RNGH 2, so existing RNGH 2 apps keep the same behavior. The root stretches to the portal width but wraps content height so keyboard-safe layouts (e.g. `TextInputDialogContent`) stay aligned.