### PR TITLE
fix(search-field): pad input only for composed slots

### DIFF
--- a/example/src/app/(home)/components/search-field.tsx
+++ b/example/src/app/(home)/components/search-field.tsx
@@ -59,6 +59,26 @@ const BasicSearchFieldContent = () => {
 
 // ------------------------------------------------------------------------------
 
+const WithoutSearchIconContent = () => {
+  const { t } = useLingui();
+  const [searchValue, setSearchValue] = useState('');
+
+  return (
+    <View className="flex-1 justify-center px-5">
+      <KeyboardAvoidingContainer>
+        <SearchField value={searchValue} onChange={setSearchValue}>
+          <SearchField.Group>
+            <SearchField.Input placeholder={t`Search...`} />
+            <SearchField.ClearButton />
+          </SearchField.Group>
+        </SearchField>
+      </KeyboardAvoidingContainer>
+    </View>
+  );
+};
+
+// ------------------------------------------------------------------------------
+
 const WithDescriptionContent = () => {
   const { t } = useLingui();
   const [searchValue, setSearchValue] = useState('');
@@ -193,6 +213,11 @@ const SEARCH_FIELD_VARIANTS: UsageVariant[] = [
     value: 'basic-search-field',
     label: msg`Basic search field`,
     content: <BasicSearchFieldContent />,
+  },
+  {
+    value: 'without-search-icon',
+    label: msg`Without search icon`,
+    content: <WithoutSearchIconContent />,
   },
   {
     value: 'with-label-and-description',

--- a/src/components/search-field/search-field.md
+++ b/src/components/search-field/search-field.md
@@ -22,9 +22,9 @@ import { SearchField } from 'heroui-native';
 
 - **SearchField**: Root container that accepts `value` and `onChange`, providing them to children via context. Also provides form field state (isDisabled, isInvalid, isRequired) and animation settings.
 - **SearchField.Group**: Flex-row container that positions the search icon, input, and clear button horizontally.
-- **SearchField.SearchIcon**: Magnifying glass icon positioned absolutely on the left side of the input. Supports custom children to replace the default icon.
-- **SearchField.Input**: Wraps the Input component with search-specific defaults. Reads `value` and `onChangeText` from the SearchField context automatically.
-- **SearchField.ClearButton**: Small icon-only button to clear the search input. Automatically hidden when value is empty. Calls `onChange("")` from context on press.
+- **SearchField.SearchIcon**: Magnifying glass icon positioned absolutely on the left side of the input. Supports custom children to replace the default icon. Optional — omitting it drops the Input's leading icon space.
+- **SearchField.Input**: Wraps the Input component with search-specific defaults. Reads `value` and `onChangeText` from the SearchField context automatically. Reserves leading space only when `SearchField.SearchIcon` is composed, and trailing space only when `SearchField.ClearButton` is composed.
+- **SearchField.ClearButton**: Small icon-only button to clear the search input. Automatically hidden when value is empty. Calls `onChange("")` from context on press. Optional — omitting it drops the Input's trailing clear-button space. While composed but hidden (empty value), trailing padding stays so the text does not jump.
 
 ## Usage
 
@@ -41,6 +41,21 @@ The SearchField component uses compound parts to create a search input. Pass `va
   </SearchField.Group>
 </SearchField>
 ```
+
+### Without Search Icon
+
+Omit `SearchField.SearchIcon` to use the Input's normal leading padding. The Input detects composed slots automatically — no extra prop is required.
+
+```tsx
+<SearchField value={searchValue} onChange={setSearchValue}>
+  <SearchField.Group>
+    <SearchField.Input />
+    <SearchField.ClearButton />
+  </SearchField.Group>
+</SearchField>
+```
+
+The same applies to `SearchField.ClearButton`: omitting it drops the trailing space reserved for the clear control.
 
 ### With Label and Description
 

--- a/src/components/search-field/search-field.styles.ts
+++ b/src/components/search-field/search-field.styles.ts
@@ -32,6 +32,10 @@ const inputContainer = tv({
  * Base input styling (bg, border, focus, variants, etc.) comes from the Input component.
  * @see {@link ../input/input.styles.ts} for the base Input styles.
  *
+ * @note Icon and clear-button paddings are variants so they apply only when
+ * those compound parts are composed. Omitting a part falls back to the
+ * Input's own inline padding.
+ *
  * @note Unlike `Text`, `TextInput` maps `textAlign: left/right` to physical
  * edges regardless of layout direction, so the RTL alignment needs an
  * explicit `rtl:text-right` override. It lives here because the uniwind CSS
@@ -39,6 +43,18 @@ const inputContainer = tv({
  */
 const input = tv({
   base: 'search-field__input rtl:text-right',
+  variants: {
+    hasSearchIcon: {
+      true: 'search-field__input--with-search-icon',
+    },
+    hasClearButton: {
+      true: 'search-field__input--with-clear-button',
+    },
+  },
+  defaultVariants: {
+    hasSearchIcon: false,
+    hasClearButton: false,
+  },
 });
 
 const clearButton = tv({

--- a/src/components/search-field/search-field.tsx
+++ b/src/components/search-field/search-field.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useMemo } from 'react';
+import { forwardRef, useLayoutEffect, useMemo, useState } from 'react';
 import {
   type GestureResponderEvent,
   type TextInput as TextInputType,
@@ -24,6 +24,7 @@ import type {
   SearchFieldInputProps,
   SearchFieldProps,
   SearchFieldSearchIconProps,
+  SearchFieldSlotsContextType,
 } from './search-field.types';
 import { SearchIcon } from './search-icon';
 
@@ -32,6 +33,37 @@ const [SearchFieldProvider, useSearchField] =
     name: 'SearchFieldContext',
     strict: false,
   });
+
+const [SearchFieldSlotsProvider, useSearchFieldSlots] =
+  createContext<SearchFieldSlotsContextType>({
+    name: 'SearchFieldSlotsContext',
+    strict: false,
+  });
+
+/**
+ * Registers an optional SearchField slot for the lifetime of the caller.
+ * The effect still runs when the caller later returns `null` (ClearButton
+ * with an empty value), so Input can keep trailing padding and avoid a
+ * text jump when the first character is typed.
+ *
+ * @param setPresent - Slot setter from SearchFieldSlotsContext, or
+ *   `undefined` when rendered outside SearchField
+ */
+function useRegisterSearchFieldSlot(
+  setPresent: ((isPresent: boolean) => void) | undefined
+): void {
+  useLayoutEffect(() => {
+    if (typeof setPresent !== 'function') {
+      return;
+    }
+
+    setPresent(true);
+
+    return () => {
+      setPresent(false);
+    };
+  }, [setPresent]);
+}
 
 // --------------------------------------------------
 
@@ -54,9 +86,22 @@ const SearchFieldRoot = forwardRef<ViewRef, SearchFieldProps>((props, ref) => {
     animation,
   });
 
+  const [hasSearchIcon, setHasSearchIcon] = useState(false);
+  const [hasClearButton, setHasClearButton] = useState(false);
+
   const searchFieldContextValue = useMemo<SearchFieldContextType>(
     () => ({ value, onChange, isDisabled, isInvalid, isRequired }),
     [value, onChange, isDisabled, isInvalid, isRequired]
+  );
+
+  const searchFieldSlotsContextValue = useMemo<SearchFieldSlotsContextType>(
+    () => ({
+      hasSearchIcon,
+      hasClearButton,
+      setHasSearchIcon,
+      setHasClearButton,
+    }),
+    [hasSearchIcon, hasClearButton]
   );
 
   const formFieldContextValue = useMemo(
@@ -73,13 +118,15 @@ const SearchFieldRoot = forwardRef<ViewRef, SearchFieldProps>((props, ref) => {
 
   return (
     <SearchFieldProvider value={searchFieldContextValue}>
-      <AnimationSettingsProvider value={animationSettingsContextValue}>
-        <FormFieldProvider value={formFieldContextValue}>
-          <View ref={ref} className={rootClassName} {...restProps}>
-            {children}
-          </View>
-        </FormFieldProvider>
-      </AnimationSettingsProvider>
+      <SearchFieldSlotsProvider value={searchFieldSlotsContextValue}>
+        <AnimationSettingsProvider value={animationSettingsContextValue}>
+          <FormFieldProvider value={formFieldContextValue}>
+            <View ref={ref} className={rootClassName} {...restProps}>
+              {children}
+            </View>
+          </FormFieldProvider>
+        </AnimationSettingsProvider>
+      </SearchFieldSlotsProvider>
     </SearchFieldProvider>
   );
 });
@@ -105,6 +152,9 @@ const SearchFieldGroup = forwardRef<ViewRef, SearchFieldGroupProps>(
 const SearchFieldSearchIcon = forwardRef<View, SearchFieldSearchIconProps>(
   (props, ref) => {
     const { children, className, iconProps, ...restProps } = props;
+
+    const slots = useSearchFieldSlots();
+    useRegisterSearchFieldSlot(slots?.setHasSearchIcon);
 
     const searchIconClassName = searchFieldClassNames.searchIcon({ className });
 
@@ -140,8 +190,13 @@ const SearchFieldInput = forwardRef<TextInputType, SearchFieldInputProps>(
     } = props;
 
     const searchField = useSearchField();
+    const slots = useSearchFieldSlots();
 
-    const inputClassName = searchFieldClassNames.input({ className });
+    const inputClassName = searchFieldClassNames.input({
+      hasSearchIcon: slots?.hasSearchIcon ?? false,
+      hasClearButton: slots?.hasClearButton ?? false,
+      className,
+    });
 
     const inputContainerClassName = searchFieldClassNames.inputContainer({
       className: containerClassNameProp,
@@ -171,7 +226,14 @@ const SearchFieldClearButton = forwardRef<View, SearchFieldClearButtonProps>(
     const { iconProps, className, children, onPress, ...restProps } = props;
 
     const searchField = useSearchField();
+    const slots = useSearchFieldSlots();
     const themeColorMuted = useThemeColor('muted');
+
+    /**
+     * Register before the empty-value early return so composed ClearButtons
+     * keep trailing input padding while they are visually hidden.
+     */
+    useRegisterSearchFieldSlot(slots?.setHasClearButton);
 
     if (searchField?.value !== undefined && searchField.value.length === 0) {
       return null;
@@ -232,15 +294,18 @@ SearchFieldClearButton.displayName = DISPLAY_NAME.SEARCH_FIELD_CLEAR_BUTTON;
  * and clear button.
  *
  * @component SearchField.SearchIcon - Magnifying glass icon positioned
- * absolutely on the leading edge (left in LTR, right in RTL).
+ * absolutely on the leading edge (left in LTR, right in RTL). Registers
+ * itself so Input reserves leading space only while this part is composed.
  *
  * @component SearchField.Input - Wraps the Input component with search-specific
- * defaults: "Search..." placeholder, leading padding for the search icon, and
- * search a11y role. Reads `value` / `onChangeText` from SearchFieldContext.
+ * defaults: "Search..." placeholder and search a11y role. Reserves leading
+ * space when SearchIcon is composed and trailing space when ClearButton is
+ * composed. Reads `value` / `onChangeText` from SearchFieldContext.
  *
  * @component SearchField.ClearButton - Small button that clears the search
  * input. Automatically hidden when value is empty. Calls `onChange("")` from
- * context on press.
+ * context on press. Registers itself so Input keeps trailing space while
+ * this part is composed, including when it is visually hidden.
  *
  * @see Full documentation: https://heroui.com/docs/native/components/search-field
  */

--- a/src/components/search-field/search-field.types.ts
+++ b/src/components/search-field/search-field.types.ts
@@ -22,6 +22,22 @@ export interface SearchFieldContextType {
 }
 
 /**
+ * Internal layout context that tracks which optional SearchField slots
+ * are composed. Input reads these flags to reserve leading/trailing
+ * space only when the matching part is present.
+ */
+export interface SearchFieldSlotsContextType {
+  /** Whether `SearchField.SearchIcon` is currently composed */
+  hasSearchIcon: boolean;
+  /** Whether `SearchField.ClearButton` is currently composed */
+  hasClearButton: boolean;
+  /** Called by SearchIcon on mount/unmount */
+  setHasSearchIcon: (isPresent: boolean) => void;
+  /** Called by ClearButton on mount/unmount */
+  setHasClearButton: (isPresent: boolean) => void;
+}
+
+/**
  * Props for the SearchField root component
  */
 export interface SearchFieldProps extends ViewProps {

--- a/src/styles/components/search-field.css
+++ b/src/styles/components/search-field.css
@@ -27,13 +27,24 @@
 
 .search-field__input {
   flex-grow: 1;
-  padding-inline-start: calc(var(--spacing) * 9);
-  padding-inline-end: calc(var(--spacing) * 12);
   /*
    * TextInput textAlign is physical (unlike Text), so this is the LTR
    * alignment; the RTL flip comes from `rtl:text-right` in the styles file.
    */
   text-align: left;
+}
+
+/*
+ * Icon/clear paddings are opt-in. SearchField.Input applies these only
+ * when the matching compound part is composed, so omitting SearchIcon or
+ * ClearButton falls back to the Input's own inline padding.
+ */
+.search-field__input--with-search-icon {
+  padding-inline-start: calc(var(--spacing) * 9);
+}
+
+.search-field__input--with-clear-button {
+  padding-inline-end: calc(var(--spacing) * 12);
 }
 
 .search-field__clear-button {


### PR DESCRIPTION
Closes #465 

## 📝 Description

SearchField.Input reserved leading and trailing space for SearchIcon and ClearButton even when those parts were omitted. Padding is now applied only when the matching compound part is composed, so a search field without an icon or clear button uses the Input's normal inline padding.

## ⛳️ Current behavior (updates)

Omitting SearchField.SearchIcon or SearchField.ClearButton still leaves extra leading or trailing padding on the input.

## 🚀 New behavior

- Input reserves leading space only when SearchField.SearchIcon is composed
- Input reserves trailing space only when SearchField.ClearButton is composed
- Trailing padding stays while ClearButton is composed but hidden (empty value), so text does not jump on first keystroke
- Docs and example app include a without-search-icon variant

## 💣 Is this a breaking change (Yes/No):

**No** - Full SearchIcon + Input + ClearButton compositions keep the same padding. Only omitted optional parts lose unused reserved space.

## 📝 Additional Information

Verified via the example app's new without-search-icon variant and the existing basic / with-label-and-description cases. No new dependencies.