### PR TITLE
docs(glass-view): correct documented intensity default

### DIFF
--- a/src/components/glass-view/glass-view.md
+++ b/src/components/glass-view/glass-view.md
@@ -74,7 +74,7 @@ Components with an injectable background render it automatically; replace it via
 
 | prop            | type           | default                                   | description                                                                                          |
 | --------------- | -------------- | ----------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `intensity`     | `number`       | `30`                                      | Blur intensity (0-100). iOS only, forwarded to expo-blur.                                            |
+| `intensity`     | `number`       | `25`                                      | Blur intensity (0-100). iOS only, forwarded to expo-blur.                                            |
 | `tint`          | `ExpoBlurTint` | derived from the active light/dark scheme | Blur tint. iOS only, forwarded to expo-blur.                                                         |
 | `fallbackColor` | `ThemeColor`   | `'overlay'`                               | Theme token flattened over `--background` and painted opaque on Android / web (ignored on iOS blur). |
 | `forceFallbackColor` | `boolean` | `false`                                   | Skips the iOS blur and paints the opaque `fallbackColor` on every platform.                          |

--- a/src/components/glass-view/glass-view.types.ts
+++ b/src/components/glass-view/glass-view.types.ts
@@ -9,7 +9,7 @@ export type GlassViewProps = ViewProps & {
   /**
    * Blur intensity (0-100) forwarded to expo-blur's `intensity`.
    * iOS only — the Android fallback layer ignores it.
-   * @default 30
+   * @default 25
    */
   intensity?: number;
   /**


### PR DESCRIPTION
## 📝 Description

`GlassView` documents a default blur `intensity` of `30` in two places, while the actual default is `DEFAULT_INTENSITY = 25`.

```ts
// src/components/glass-view/glass-view.constants.ts
export const DEFAULT_INTENSITY = 25;

// src/components/glass-view/glass-view.tsx
intensity = DEFAULT_INTENSITY,
```

The documented value was correct when the prop was first written up: `2e736f9` raised `DEFAULT_INTENSITY` from `20` to `30` and updated the props table in the same commit. `aa58e54` later lowered it to `25` without touching either mention, so both have been stale since.

Found by cross-checking three sources of truth — the markdown props tables, the `@default` JSDoc tags, and the actual destructuring defaults in the components — across the library. This was the only real disagreement; everything else that looked like a mismatch resolved to a named constant with the right value, or to a same-named prop on a different sub-component.

## ⛳️ Current behavior (updates)

Both the props table in `glass-view.md` and the `@default` tag on `GlassViewProps.intensity` say `30`. The `@default` tag is the one that surfaces in editor hovers and in generated API docs.

## 🚀 New behavior

Both say `25`, matching `DEFAULT_INTENSITY`.

## 💣 Is this a breaking change (Yes/No):

No. Documentation only.

I deliberately did not change `DEFAULT_INTENSITY` to match the docs instead: `25` is the value the glass theme was tuned against in `aa58e54`, and raising it would be a visual change, which the contributing guide asks contributors not to make unilaterally. If `30` was in fact the intended value, this should be flipped into a one-line constants change instead — happy to do that.

## 📝 Additional Information

- `yarn lint` ✅
- `yarn typecheck` ✅
- `yarn test` ✅
