### PR TITLE
fix(switch): keep a consumer provided aria-valuetext

### DIFF
--- a/src/__tests__/switch-primitive.test.tsx
+++ b/src/__tests__/switch-primitive.test.tsx
@@ -1,0 +1,37 @@
+import type { ReactElement } from 'react';
+import { Root as SwitchRoot } from '../primitives/switch/switch';
+import type { RootProps } from '../primitives/switch/switch.types';
+
+/**
+ * The Switch primitive Root calls no hooks, so its `forwardRef` render function
+ * can be invoked directly to read the props handed to the underlying Pressable.
+ */
+function getRootProps(props: RootProps): Record<string, unknown> {
+  const { render } = SwitchRoot as unknown as {
+    render: (props: RootProps, ref: null) => ReactElement;
+  };
+
+  return render(props, null).props as Record<string, unknown>;
+}
+
+describe('Switch primitive aria-valuetext', () => {
+  it('derives the value text from the selected state when none is provided', () => {
+    expect(getRootProps({ isSelected: true })['aria-valuetext']).toBe('on');
+    expect(getRootProps({ isSelected: false })['aria-valuetext']).toBe('off');
+  });
+
+  it('forwards a consumer provided value text unchanged', () => {
+    expect(
+      getRootProps({
+        'isSelected': false,
+        'aria-valuetext': 'Silent mode off',
+      })['aria-valuetext']
+    ).toBe('Silent mode off');
+
+    expect(
+      getRootProps({ 'isSelected': true, 'aria-valuetext': 'Silent mode on' })[
+        'aria-valuetext'
+      ]
+    ).toBe('Silent mode on');
+  });
+});

--- a/src/primitives/switch/switch.tsx
+++ b/src/primitives/switch/switch.tsx
@@ -33,7 +33,7 @@ const Root = forwardRef<RootRef, RootProps>(
         aria-disabled={isDisabled}
         role="switch"
         aria-checked={isSelected}
-        aria-valuetext={(ariaValueText ?? isSelected) ? 'on' : 'off'}
+        aria-valuetext={ariaValueText ?? (isSelected ? 'on' : 'off')}
         onPress={onPress}
         accessibilityState={{
           checked: isSelected,


### PR DESCRIPTION
Closes # <!-- no linked issue; defect found while auditing accessibility props across the primitives -->

## 📝 Description

`Switch` accepts `aria-valuetext` (it is part of `SlottablePressableProps`), and the primitive `Root` destructures it so it can be used as an override. A missing pair of parentheses makes that override unreachable.

`src/primitives/switch/switch.tsx:36`

```tsx
aria-valuetext={(ariaValueText ?? isSelected) ? 'on' : 'off'}
```

`??` binds tighter than the conditional operator, so the whole `ariaValueText ?? isSelected` expression is only used as a truthiness test. Any non-empty string a consumer passes is truthy, so it is discarded and replaced with the literal `'on'`, even when the switch is off.

Note that this is worse than not handling the prop at all: because `{...props}` is spread after these defaults, an `aria-valuetext` left in `props` would have overridden the default correctly. The destructure plus the precedence slip is what breaks it.

The two sibling primitives that expose the same attribute forward it untouched, so this is an asymmetry rather than a deliberate choice:

- `src/primitives/sub-menu/sub-menu.tsx:92` -> `aria-valuetext={textValue}`
- `src/primitives/select/select.tsx:605` -> `aria-valuetext={label}`

## ⛳️ Current behavior (updates)

| props | `aria-valuetext` announced |
| --- | --- |
| `isSelected: true` | `'on'` (correct) |
| `isSelected: false` | `'off'` (correct) |
| `isSelected: false`, `aria-valuetext: 'Silent mode off'` | `'on'` (wrong on both counts) |
| `isSelected: true`, `aria-valuetext: 'Silent mode on'` | `'on'` (custom text lost) |

VoiceOver and TalkBack therefore read back `on` for a switch that is off whenever a custom value text is supplied.

## 🚀 New behavior

The fallback is grouped so it only applies when no value text is supplied:

```tsx
aria-valuetext={ariaValueText ?? (isSelected ? 'on' : 'off')}
```

Derived values for the default case are unchanged (`'on'` / `'off'`); a consumer supplied string is now passed through.

## 💣 Is this a breaking change (Yes/No):

No. Behaviour only changes for consumers who pass `aria-valuetext`, where the previous output was incorrect. No design, API or visual change.

## 📝 Additional Information

### How this was proved

The repo has `jest` wired up but no renderer dependency, so the test drives the primitive's `forwardRef` render function directly. `Switch` `Root` calls no hooks, so this is deterministic and needs no new dependency. Added as `src/__tests__/switch-primitive.test.tsx`.

Counterfactual, run at `b9fa5410b5fbb875475127386166f4c029e9e73f` (current `main` tip):

**1. With the fix, green**

```
$ yarn test
PASS src/__tests__/switch-primitive.test.tsx
PASS src/__tests__/index.test.tsx
Tests:       1 todo, 2 passed, 3 total
```

**2. Source fix reverted, test file untouched, red for the right reason**

```
$ git show HEAD~1:src/primitives/switch/switch.tsx > src/primitives/switch/switch.tsx
$ sed -n '36p' src/primitives/switch/switch.tsx
        aria-valuetext={(ariaValueText ?? isSelected) ? 'on' : 'off'}
$ yarn test
FAIL src/__tests__/switch-primitive.test.tsx
  ● Switch primitive aria-valuetext › forwards a consumer provided value text unchanged

    expect(received).toBe(expected) // Object.is equality

    Expected: "Silent mode off"
    Received: "on"
```

**3. Restored, green again**

```
$ git checkout HEAD -- src/primitives/switch/switch.tsx
$ yarn test
PASS src/__tests__/switch-primitive.test.tsx
PASS src/__tests__/index.test.tsx
Tests:       1 todo, 2 passed, 3 total
```

### Checks

```
$ yarn test        # 2 passed, 1 todo
$ yarn typecheck   # ✅ TypeScript check passed successfully!
$ yarn lint        # clean
$ yarn prepare     # library build succeeds
```

`yarn prettier --check` is clean on both touched files. It does flag two files this PR does not touch (`src/components/pressable-feedback/index.ts` and `src/components/pressable-feedback/pressable-feedback.styles.ts`); those are pre-existing on `main` and left alone.
