### PR TITLE
fix(select): apply the documented default trigger variant

### DIFF
--- a/src/__tests__/select.styles.test.ts
+++ b/src/__tests__/select.styles.test.ts
@@ -1,0 +1,19 @@
+import { selectClassNames } from '../components/select/select.styles';
+
+describe('selectClassNames.trigger', () => {
+  it('applies the default variant when no variant is passed', () => {
+    expect(selectClassNames.trigger()).toBe('select__trigger--variant-default');
+  });
+
+  it('keeps the default variant when other props are passed', () => {
+    expect(selectClassNames.trigger({ isDisabled: true })).toBe(
+      'select__trigger--variant-default select__trigger--is-disabled'
+    );
+  });
+
+  it('omits the default variant styles when unstyled is requested', () => {
+    expect(
+      selectClassNames.trigger({ variant: 'unstyled', isDisabled: true })
+    ).toBe('select__trigger--is-disabled');
+  });
+});

--- a/src/components/select/select.styles.ts
+++ b/src/components/select/select.styles.ts
@@ -14,6 +14,9 @@ const trigger = tv({
       false: '',
     },
   },
+  defaultVariants: {
+    variant: 'default',
+  },
 });
 
 /**


### PR DESCRIPTION
Closes #

## Description

`selectClassNames.trigger()` never applied the trigger's `default` variant styles, because the `trigger` `tv()` in `select.styles.ts` declares a `variant` group but no `defaultVariants`.

`docs/styling.md` documents the exported `*ClassNames` helpers as public API and states that they "accept the same variant props as the components themselves", so a consumer building a custom trigger with `selectClassNames.trigger()` got no padding, radius, background or field shadow at all.

`Select.Trigger` itself is unaffected: `select.tsx` destructures `variant = 'default'` and always passes it explicitly, which is what has been hiding the gap.

Minimal reproduction:

```tsx
import { selectClassNames } from 'heroui-native';

selectClassNames.trigger();
// -> undefined                        (expected 'select__trigger--variant-default')

selectClassNames.trigger({ isDisabled: true });
// -> 'select__trigger--is-disabled'   (expected 'select__trigger--variant-default select__trigger--is-disabled')
```

## Current behavior (updates)

The default variant is only applied when the caller passes `variant: 'default'` explicitly, even though `'default'` is documented as the default in `select.md` and in the `@default` JSDoc on `SelectTriggerProps['variant']`.

`Select.Trigger` is the only `tv()` block in the library with a non-boolean variant group and no `defaultVariants` entry for it. Its siblings (`accordion.trigger`, `chip.root`, `button.root`, `checkbox.root`, `tabs.list`, `alert.title`, `inputOTP.slot` and the rest) all declare one.

## New behavior

`defaultVariants: { variant: 'default' }` is added to the trigger style, so the helper resolves the documented default. Rendering is unchanged, since the component already passed the variant explicitly.

Added `src/__tests__/select.styles.test.ts`, which asserts that `selectClassNames.trigger()` resolves to `'select__trigger--variant-default'`, that the default survives alongside `isDisabled: true`, and that `variant: 'unstyled'` still opts out.

## Is this a breaking change (Yes/No):

No.

## Additional Information

`yarn jest`, `yarn typecheck` and `yarn lint` all pass. Test suites went from 1 (1 todo) to 2 (3 passing, 1 todo).
