### PR TITLE
docs: correct documented icon defaults for CloseButton, Alert and SubMenu

### DIFF
--- a/src/components/alert/alert.types.ts
+++ b/src/components/alert/alert.types.ts
@@ -19,7 +19,7 @@ export interface AlertIconProps {
   /**
    * Icon size in pixels
    *
-   * @default 20
+   * @default 18
    */
   size?: number;
   /**

--- a/src/components/close-button/close-button.md
+++ b/src/components/close-button/close-button.md
@@ -105,5 +105,5 @@ For inherited props including `isDisabled`, `className`, `animation`, `feedbackV
 
 | prop    | type     | default                | description       |
 | ------- | -------- | ---------------------- | ----------------- |
-| `size`  | `number` | `20`                   | Size of the icon  |
+| `size`  | `number` | `18`                   | Size of the icon  |
 | `color` | `string` | Uses theme muted color | Color of the icon |

--- a/src/components/close-button/close-button.types.ts
+++ b/src/components/close-button/close-button.types.ts
@@ -6,12 +6,12 @@ import type { ButtonRootProps } from '../button/button.types';
 export interface CloseButtonIconProps {
   /**
    * Size of the icon
-   * @default 16
+   * @default 18
    */
   size?: number;
   /**
    * Color of the icon
-   * @default Uses theme foreground color
+   * @default Uses theme muted color
    */
   color?: string;
 }

--- a/src/components/menu/menu.md
+++ b/src/components/menu/menu.md
@@ -711,7 +711,7 @@ Animated indicator icon that rotates when the submenu opens/closes. Defaults to 
 
 | prop    | type     | default | description                 |
 | ------- | -------- | ------- | --------------------------- |
-| `size`  | `number` | `14`    | Size of the indicator icon  |
+| `size`  | `number` | `16`    | Size of the indicator icon  |
 | `color` | `string` | `muted` | Color of the indicator icon |
 
 ##### SubMenuTriggerIndicatorAnimation

--- a/src/components/sub-menu/sub-menu.types.ts
+++ b/src/components/sub-menu/sub-menu.types.ts
@@ -118,7 +118,7 @@ export interface SubMenuTriggerProps
 export interface SubMenuTriggerIndicatorIconProps {
   /**
    * Size of the icon
-   * @default 14
+   * @default 16
    */
   size?: number;
   /**


### PR DESCRIPTION
Three components document an icon default the implementation does not use. Same shape as #483 — the docs drifted, the code is fine — so this only moves the docs onto the shipped values and changes no behaviour.

| Component | Documented | Actual | Where |
| --- | --- | --- | --- |
| `CloseButton` | `16` (types), `20` (md) | `18` | `close-button.tsx:33` — `size={iconProps?.size ?? 18}` |
| `CloseButton` colour | "theme foreground color" | theme **muted** | `close-button.tsx:34` with `useThemeColor('muted')` at `:16` |
| `Alert` | `20` (types) | `18` | `alert.constants.ts:14` `DEFAULT_ICON_SIZE = 18`, used at `alert.tsx:111` |
| `SubMenu` indicator | `14` (types **and** `menu.md:714`) | `16` | `sub-menu.constants.ts:13` `DEFAULT_INDICATOR_ICON_SIZE = 16`, used at `sub-menu.tsx:356` |

How each one drifted:

- `close-button.types.ts` has said `16` since the component's first commit (`ffc21c7d`), when the code already read `?? 20`. `close-button.md` said `20`, which was right until `43ecb65b feat(close-button): add style file` changed the literal to `18` without touching the doc. `alert.md` was already correct at `18`; only its JSDoc is wrong.
- The `CloseButton` colour line has been wrong since `ffc21c7d` — the component has resolved `useThemeColor('muted')` from the start, and `close-button.md:109` already says muted.

I aligned the docs to the code rather than the other way round: CONTRIBUTING asks for approval before changing visual appearance, and these are the values that actually ship today. If any of the documented numbers is the intended design-system value, say so and I will flip the corresponding constant instead.

### Testing

```
yarn typecheck   # ✅ TypeScript check passed successfully! 🎉
yarn lint        # exit 0, no output
yarn test        # 1 passed (the suite is a single it.todo placeholder)
npx prettier --check <changed files>   # All matched files use Prettier code style!
```

No test added: the repo has no React renderer installed (`react-test-renderer` and `@testing-library/react-native` are both absent), and these defaults are resolved inside components that call `useThemeColor`, so they cannot be exercised without one. A file-scraping doc-consistency test seemed too brittle to propose.

### Not included

`tabs.styles.ts:19` sets `isScrollView: false` in `list`'s `defaultVariants`, but `list` declares only a `variant` variant, so the key resolves to nothing. Left out to keep this PR documentation-only — happy to add it here or send it separately.