### PR TITLE
fix(menu,popover,select): refresh open anchors when the app window changes

### DIFF
--- a/src/helpers/internal/hooks/use-relative-position.ts
+++ b/src/helpers/internal/hooks/use-relative-position.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-  Dimensions,
+  useWindowDimensions,
   type LayoutRectangle,
   type ScaledSize,
 } from 'react-native';
@@ -27,7 +27,7 @@ export function useRelativePosition({
   placement,
   disablePositioningStyle,
 }: UseRelativePositionArgs) {
-  const dimensions = Dimensions.get('screen');
+  const dimensions = useWindowDimensions();
   const isRTL = useIsRTL();
 
   return React.useMemo(() => {

--- a/src/primitives/menu/menu.tsx
+++ b/src/primitives/menu/menu.tsx
@@ -5,6 +5,7 @@ import React, {
   useContext,
   useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useState,
 } from 'react';
@@ -13,6 +14,7 @@ import {
   Pressable,
   Text,
   View,
+  useWindowDimensions,
   type GestureResponderEvent,
   type LayoutChangeEvent,
   type LayoutRectangle,
@@ -141,7 +143,10 @@ const Trigger = forwardRef<TriggerRef, TriggerProps>(
       setContentLayout,
       isDefaultOpen,
       triggerPosition,
+      presentation,
     } = useRootContext();
+
+    const { width: windowWidth, height: windowHeight } = useWindowDimensions();
 
     const isDisabledValue = isDisabled ?? isDisabledRoot ?? undefined;
 
@@ -164,6 +169,21 @@ const Trigger = forwardRef<TriggerRef, TriggerProps>(
       },
       deps: [isOpen],
     });
+
+    // A centered ancestor can move without changing the trigger's local layout.
+    useLayoutEffect(() => {
+      if (!isOpen || presentation !== 'popover') return;
+      augmentedRef.current?.measure((_x, _y, width, height, pageX, pageY) => {
+        setTriggerPosition({ width, height, pageX, pageY });
+      });
+    }, [
+      isOpen,
+      presentation,
+      windowWidth,
+      windowHeight,
+      augmentedRef,
+      setTriggerPosition,
+    ]);
 
     // Open menu on mount if isDefaultOpen is true
     useEffect(() => {

--- a/src/primitives/popover/popover.tsx
+++ b/src/primitives/popover/popover.tsx
@@ -3,12 +3,14 @@ import React, {
   useContext,
   useEffect,
   useId,
+  useLayoutEffect,
   useState,
 } from 'react';
 import {
   BackHandler,
   Pressable,
   View,
+  useWindowDimensions,
   type GestureResponderEvent,
   type LayoutChangeEvent,
   type LayoutRectangle,
@@ -108,9 +110,11 @@ const Trigger = forwardRef<TriggerRef, TriggerProps>(
       setContentLayout,
       isDefaultOpen,
       triggerPosition,
+      presentation,
     } = useRootContext();
 
     const isDisabledValue = isDisabled ?? isDisabledRoot ?? undefined;
+    const { width: windowWidth, height: windowHeight } = useWindowDimensions();
 
     const augmentedRef = useAugmentedRef({
       ref,
@@ -131,6 +135,21 @@ const Trigger = forwardRef<TriggerRef, TriggerProps>(
       },
       deps: [isOpen],
     });
+
+    // A centered ancestor can move without changing the trigger's local layout.
+    useLayoutEffect(() => {
+      if (!isOpen || presentation !== 'popover') return;
+      augmentedRef.current?.measure((_x, _y, width, height, pageX, pageY) => {
+        setTriggerPosition({ width, height, pageX, pageY });
+      });
+    }, [
+      isOpen,
+      presentation,
+      windowWidth,
+      windowHeight,
+      augmentedRef,
+      setTriggerPosition,
+    ]);
 
     // Open popover on mount if isDefaultOpen is true
     useEffect(() => {

--- a/src/primitives/select/select.tsx
+++ b/src/primitives/select/select.tsx
@@ -4,6 +4,7 @@ import React, {
   useContext,
   useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useState,
 } from 'react';
@@ -12,6 +13,7 @@ import {
   Pressable,
   StyleSheet,
   Text,
+  useWindowDimensions,
   View,
   type GestureResponderEvent,
   type LayoutChangeEvent,
@@ -151,9 +153,11 @@ const Trigger = forwardRef<TriggerRef, TriggerProps>(
       setContentLayout,
       isDefaultOpen,
       triggerPosition,
+      presentation,
     } = useRootContext();
 
     const isDisabledValue = isDisabled || isDisabledRoot;
+    const { width: windowWidth, height: windowHeight } = useWindowDimensions();
 
     const augmentedRef = useAugmentedRef({
       ref,
@@ -174,6 +178,21 @@ const Trigger = forwardRef<TriggerRef, TriggerProps>(
       },
       deps: [isOpen],
     });
+
+    // A centered ancestor can move without changing the trigger's local layout.
+    useLayoutEffect(() => {
+      if (!isOpen || presentation !== 'popover') return;
+      augmentedRef.current?.measure((_x, _y, width, height, pageX, pageY) => {
+        setTriggerPosition({ width, height, pageX, pageY });
+      });
+    }, [
+      isOpen,
+      presentation,
+      windowWidth,
+      windowHeight,
+      augmentedRef,
+      setTriggerPosition,
+    ]);
 
     // Open popover on mount if isDefaultOpen is true or isOpen is true initially
     useEffect(() => {


### PR DESCRIPTION
Fixes #489.

## 📝 Description

An open dropdown can detach from its button after iPad rotation, or disappear when the app window shrinks. Use the current application-window bounds for collision handling and refresh the native trigger position when that window changes.

## ⛳️ Current behavior (updates)

The shared hook uses physical-screen dimensions. Cached trigger coordinates can remain unchanged when a centered ancestor moves. Updating dimensions alone keeps a panel within the smaller window but does not align it with its trigger.

## 🚀 New behavior

The shared hook uses useWindowDimensions. Select, Popover and Menu remeasure their existing trigger refs in a layout effect while open with popover presentation when width or height changes. Dialog and bottom-sheet presentations skip this measurement.

Native measurement justifies the effect. The change adds no polling, device detection, public API or dependencies. Menu is included because the narrower Select/Popover candidate reproduced the same stale-anchor failure there.

## 💣 Is this a breaking change (Yes/No):

No public API change is intended. Collision placement deliberately changes for app windows smaller than the screen. Arbitrary ancestor motion, custom portal/native-modal coordinate origins and legacy-renderer timing are outside the verified scope.

## Native comparison

All three captures show a 519 × 602-point app window on the same 1032 × 1376-point iPad screen. They demonstrate why updating collision bounds alone is insufficient: the cached trigger position must also be refreshed. The repaired capture uses the Select/Popover geometry implementation included in this PR; Menu was verified separately.

![Stock: the open panel is not visible inside the resized app window.](https://raw.githubusercontent.com/eliotgevers/heroui-native-window-repro/c8007ac579accc57fb8839641df46b5cf262acf0/evidence/stock-popover-after-window-resize.png)

![Window bounds only: the panel is visible, but detached to the lower right of its trigger.](https://raw.githubusercontent.com/eliotgevers/heroui-native-window-repro/c8007ac579accc57fb8839641df46b5cf262acf0/evidence/bounds-popover-small-window.png)

![Window bounds plus trigger remeasurement: the panel stays aligned below its trigger.](https://raw.githubusercontent.com/eliotgevers/heroui-native-window-repro/c8007ac579accc57fb8839641df46b5cf262acf0/evidence/geometry-popover-small-window.png)

## 📝 Additional Information

Verified in a standalone supported Expo/RN environment: stock versus bounds-only versus full geometry patch; iPad portrait/landscape; actual 1032 × 1376 to 519 × 602 app-window resize; Menu controlled/uncontrolled/default-open mounting. Upstream typecheck, lint and package build pass. The existing Jest suite contains only a TODO, not regression coverage.

This PR changes source files only; generated package JavaScript is excluded.

Reproduction: https://github.com/eliotgevers/heroui-native-window-repro

Implementation discussion: https://github.com/heroui-inc/heroui-native/discussions/491

