### PR TITLE
fix(dialog,select): let outside taps pass through animated wrappers on iOS

### DIFF
--- a/src/components/dialog/dialog.tsx
+++ b/src/components/dialog/dialog.tsx
@@ -315,6 +315,7 @@ const DialogContent = forwardRef<
         <GestureDetector gesture={panGesture}>
           <Animated.View
             ref={dragContainerRef}
+            pointerEvents="box-none"
             entering={entering}
             exiting={exiting}
             collapsable={false}

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -669,6 +669,7 @@ const SelectContentDialog = forwardRef<
           <GestureDetector gesture={panGesture}>
             <Animated.View
               ref={dragContainerRef}
+              pointerEvents="box-none"
               entering={entering}
               exiting={exiting}
               collapsable={false}

--- a/src/components/select/select.tsx
+++ b/src/components/select/select.tsx
@@ -664,7 +664,11 @@ const SelectContentDialog = forwardRef<
       background === undefined ? <SelectContentBackground /> : background;
 
     return (
-      <View className={wrapperClassName} style={styles?.wrapper}>
+      <View
+        className={wrapperClassName}
+        style={styles?.wrapper}
+        pointerEvents="box-none"
+      >
         <PortalGestureRoot>
           <GestureDetector gesture={panGesture}>
             <Animated.View


### PR DESCRIPTION
Refs #490; this PR addresses the iOS portion. Android remains open for a separate fix.

## 📝 Description

A centered, width-constrained Dialog or Select dialog can ignore outside taps beside its panel because internal wrappers intercept empty layout space.

## ⛳️ Current behavior (updates)

The outer animated drag wrappers use default hit testing. Select also has an additional outer layout View. The inner animated wrappers and portal gesture roots already use `box-none`.

## 🚀 New behavior

Add `pointerEvents="box-none"` to both outer Animated.Views and Select's outer dialog layout View: three props in two files. Children remain interactive and the overlay retains control of outside dismissal. Gesture roots, detectors, animation styles, refs, `collapsable={false}` and layout are unchanged.

## 💣 Is this a breaking change (Yes/No):

No. No public API or dismissal-policy changes.

## 📝 Additional Information

Rechecked the final three-prop diff (`b34501d5`) on September 11 using the [standalone reproduction](https://github.com/eliotgevers/heroui-native-window-repro), cold-launched with matching source and generated JavaScript. These runs contain only this hit-testing fix, without the separate geometry patch.

- iPad Pro 13-inch simulator, iOS 26.5: Dialog and Select side taps dismiss at x=206.4/y=688 points, outside the centered 360-point panel. Both remain open with outside dismissal disabled.
- Both components dismiss with swipe enabled and remain open after the same drag with swipe disabled. Dialog's inside button and Select item selection work.
- Both bounded lists scroll. Select can select an item after scrolling. Dialog accepts on-screen keyboard input with KeyboardAvoidingView enabled; its inside button works, and swiping closes the dialog and dismisses the keyboard.
- iPhone 17 Pro Max simulator, iOS 26.5: side-tap dismissal passes for both components.

Environment: Expo 57.0.18, React Native 0.86.3, RNGH 2.32.0 and Reanimated 4.5.1. Typecheck, lint and package build pass. The existing Jest command passes with one TODO test; it provides no regression coverage. No tests or dependencies are added.

No physical-device QA or new Android validation is claimed. The Android nested gesture-root blocker in #490 needs an independent fix; this PR must not close that issue. Separate from FullWindowOverlay accessibility issue #372.

[Implementation discussion](https://github.com/heroui-inc/heroui-native/discussions/491#discussioncomment-18384421).
